### PR TITLE
update changelog for 2.1.1 and added quickstart guide to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .DS_Store
 .src/
 .npmrc
+vsc-extension-quickstart.md
 
 # Local planning
 internal_docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.2 - March 2026
+## 2.1.1 - April 2026
 ### Fixed
 - Fixed erroneous error banner displaying in the Upstream Webview when all upstream data loaded successfully.
 - Upstream Resolution Preview no longer throws an error when policy simulation endpoint returns 404


### PR DESCRIPTION
This pull request makes a minor update to the `CHANGELOG.md` file, correcting the version number from 2.1.2 to 2.1.1 and updating the release month from March to April 2026.## 📄 Summary

Briefly describe the purpose of this pull request. What problem does it solve or feature does it add?

## 🔍 Related Issues

Link to any related GitHub issues (e.g., `Fixes #12`, `Closes #34`):

## 🧪 Type of Change

Please check the relevant type tag for this PR title:

- [ ] `[FIX]` Bug fix
- [ ] `[NEW]` New thing
- [ ] `[REFACTOR]` Internal changes such as code restructuring or optimization that does not alter functionality
- [ ] `[DOC]` Documentation-only changes
- [ ] `[CHORE]` Maintenance, cleanup, or CI configuration

## 🧪 How Has This Been Tested?

Describe how you tested your changes. Include CI runs, local tests, manual verification, or screenshots if applicable.

## 📸 Screenshots (if applicable)

If UI or logs are affected, include before/after screenshots or output.

## ✅ Checklist

- [ ] I’ve read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] I’ve added or updated documentation as needed.
- [ ] I’ve verified the change is tested and works as intended.
- [ ] CI/CD checks pass and do not break existing functionality.
- [ ] My code follows the style guidelines of this project.
