### PR TITLE
fix: pin VS Code test runtime

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
+	version: '1.109.5',
 	files: 'test/**/*.test.js',
 });


### PR DESCRIPTION
## Summary

Pin the VS Code extension test runtime to 1.109.5 so the existing suite launches reliably on macOS.

The current test launcher expects `Contents/MacOS/Electron`, while newer VS Code downloads use `Contents/MacOS/Code`. Pinning a known-good runtime restores test execution without changing product behavior.

## Validation

- `npm run build`
- `npm run lint` (2 existing warnings)
- `npm test` — 352 passing, 7 pending
