### PR TITLE
security: harden generated install commands

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
+	version: '1.109.5',
 	files: 'test/**/*.test.js',
 });

--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,10 @@ const {
   FILTER_MODES,
   SORT_MODES,
 } = require("./views/dependencyHealthProvider");
-const { InstallCommandBuilder } = require("./util/installCommandBuilder");
+const {
+  InstallCommandBuilder,
+  InstallCommandValidationError,
+} = require("./util/installCommandBuilder");
 const { VulnerabilityProvider } = require("./views/vulnerabilityProvider");
 const { ComplianceReportProvider } = require("./views/complianceReportProvider");
 const { QuarantineExplainProvider } = require("./views/quarantineExplainProvider");
@@ -146,6 +149,32 @@ function getInstallOptions(item) {
   }
 
   return installOpts;
+}
+
+function buildInstallCommand(format, name, version, workspace, repo, item) {
+  try {
+    return InstallCommandBuilder.build(
+      format,
+      name,
+      version,
+      workspace,
+      repo,
+      getInstallOptions(item)
+    );
+  } catch (error) {
+    if (error instanceof InstallCommandValidationError) {
+      vscode.window.showErrorMessage(`Could not safely generate install command: ${error.message}`);
+      return null;
+    }
+    throw error;
+  }
+}
+
+function commentCommandNote(note) {
+  return String(note)
+    .split(/\r?\n/)
+    .map(line => `# ${line}`)
+    .join("\n");
 }
 
 async function pickInstallCommandVariant(result) {
@@ -1450,14 +1479,15 @@ async function activate(context) {
         if (!action) return;
 
         if (action.id === "install") {
-          const installResult = InstallCommandBuilder.build(
+          const installResult = buildInstallCommand(
             format,
             name,
             pkg.version,
             workspace,
             pkgRepo,
-            getInstallOptions(pkg)
+            pkg
           );
+          if (!installResult) return;
           const chosenCommand = await pickInstallCommandVariant(installResult);
           if (!chosenCommand) return;
           await vscode.env.clipboard.writeText(InstallCommandBuilder.toClipboardCommand(chosenCommand));
@@ -1745,9 +1775,10 @@ async function activate(context) {
         vscode.window.showWarningMessage("Could not determine package details for install command.");
         return;
       }
-      const result = InstallCommandBuilder.build(
-        info.format, info.name, info.version || "latest", info.workspace, info.repo, getInstallOptions(item)
+      const result = buildInstallCommand(
+        info.format, info.name, info.version || "latest", info.workspace, info.repo, item
       );
+      if (!result) return;
       const chosenCommand = await pickInstallCommandVariant(result);
       if (!chosenCommand) return;
       await vscode.env.clipboard.writeText(InstallCommandBuilder.toClipboardCommand(chosenCommand));
@@ -1881,9 +1912,10 @@ async function activate(context) {
         vscode.window.showWarningMessage("Could not determine package details for install command.");
         return;
       }
-      const result = InstallCommandBuilder.build(
-        info.format, info.name, info.version || "latest", info.workspace, info.repo, getInstallOptions(item)
+      const result = buildInstallCommand(
+        info.format, info.name, info.version || "latest", info.workspace, info.repo, item
       );
+      if (!result) return;
       let content = result.command;
       if (result.alternatives && result.alternatives.length > 0) {
         for (const alt of result.alternatives) {
@@ -1891,7 +1923,7 @@ async function activate(context) {
         }
       }
       if (result.note) {
-        content += "\n\n# Note: " + result.note;
+        content += "\n\n# Note\n" + commentCommandNote(result.note);
       }
       const doc = await vscode.workspace.openTextDocument({
         language: info.format === "maven" ? "xml" : "shellscript",

--- a/test/installCommandBuilder.test.js
+++ b/test/installCommandBuilder.test.js
@@ -483,6 +483,7 @@ suite("InstallCommandBuilder Test Suite", () => {
       "https://user:password@dl.cloudsmith.io/file",
       "https://dl.cloudsmith.io/file#fragment",
       "https://dl.cloudsmith.io/file with spaces",
+      "https://dl.cloudsmith.io/file'name",
       "https:\\dl.cloudsmith.io\\file",
       "not a URL",
     ];

--- a/test/installCommandBuilder.test.js
+++ b/test/installCommandBuilder.test.js
@@ -1,16 +1,27 @@
 const assert = require("assert");
-const { InstallCommandBuilder } = require("../util/installCommandBuilder");
+const {
+  InstallCommandBuilder,
+  InstallCommandValidationError,
+} = require("../util/installCommandBuilder");
 
 suite("InstallCommandBuilder Test Suite", () => {
 
   const ws = "my-org";
   const repo = "my-repo";
+  const sha256 = "a".repeat(64);
+
+  function assertValidationError(build, field) {
+    assert.throws(build, error =>
+      error instanceof InstallCommandValidationError
+      && (!field || error.field === field)
+    );
+  }
 
   test("python generates pip install with index-url", () => {
     const result = InstallCommandBuilder.build("python", "flask", "3.0.0", ws, repo);
     assert.strictEqual(
       result.command,
-      "# Verify package details before running\npip install 'flask'=='3.0.0' --index-url https://dl.cloudsmith.io/basic/my-org/my-repo/python/simple/"
+      "# Verify package details before running\npip install 'flask==3.0.0' --index-url https://dl.cloudsmith.io/basic/my-org/my-repo/python/simple/"
     );
     assert.ok(result.note);
     assert.ok(result.note.includes("basic"));
@@ -20,7 +31,7 @@ suite("InstallCommandBuilder Test Suite", () => {
     const result = InstallCommandBuilder.build("npm", "lodash", "4.17.21", ws, repo);
     assert.strictEqual(
       result.command,
-      "# Verify package details before running\nnpm install 'lodash'@'4.17.21' --registry=https://npm.cloudsmith.io/my-org/my-repo/"
+      "# Verify package details before running\nnpm install 'lodash@4.17.21' --registry=https://npm.cloudsmith.io/my-org/my-repo/"
     );
     assert.ok(result.note);
   });
@@ -72,12 +83,12 @@ suite("InstallCommandBuilder Test Suite", () => {
       tags: {
         version: ["1.25"],
       },
-      checksumSha256: "abc123def456",
+      checksumSha256: sha256,
     });
     assert.ok(result.command.includes("nginx:1.25"), "Primary is tag-based");
     assert.ok(result.alternatives, "Should have alternatives");
     assert.strictEqual(result.alternatives.length, 1);
-    assert.ok(result.alternatives[0].command.includes("nginx@sha256:abc123def456"));
+    assert.ok(result.alternatives[0].command.includes(`nginx@sha256:${sha256}`));
     assert.ok(result.alternatives[0].label.includes("digest"));
   });
 
@@ -92,18 +103,20 @@ suite("InstallCommandBuilder Test Suite", () => {
     assert.ok(!result.command.includes("'stable'"));
   });
 
-  test("docker falls back to version when tags.version is missing", () => {
-    const result = InstallCommandBuilder.build("docker", "flask-app", "sha256:7d954406d981866d429fcfd1d832391a38546fdea1aa8a3ae1d4db08a9a250f2", ws, repo);
-    assert.ok(result.command.includes("docker pull docker.cloudsmith.io/my-org/my-repo/flask-app:sha256:7d954406d981866d429fcfd1d832391a38546fdea1aa8a3ae1d4db08a9a250f2"));
+  test("docker rejects a digest used as a tag", () => {
+    assertValidationError(
+      () => InstallCommandBuilder.build("docker", "flask-app", `sha256:${sha256}`, ws, repo),
+      "Docker tag"
+    );
   });
 
   test("docker uses versionDigest when checksumSha256 is unavailable", () => {
     const result = InstallCommandBuilder.build("docker", "nginx", "1.25", ws, repo, {
-      versionDigest: "sha256:def456abc123",
+      versionDigest: `sha256:${sha256}`,
     });
     assert.ok(result.alternatives, "Should have digest alternative");
     assert.strictEqual(result.alternatives.length, 1);
-    assert.ok(result.alternatives[0].command.includes("nginx@sha256:def456abc123"));
+    assert.ok(result.alternatives[0].command.includes(`nginx@sha256:${sha256}`));
   });
 
   test("docker has no digest alternative when checksumSha256 is missing", () => {
@@ -163,7 +176,7 @@ suite("InstallCommandBuilder Test Suite", () => {
 
   test("cargo generates cargo add with registry note", () => {
     const result = InstallCommandBuilder.build("cargo", "serde", "1.0.0", ws, repo);
-    assert.strictEqual(result.command, "# Verify package details before running\ncargo add 'serde'@'1.0.0'");
+    assert.strictEqual(result.command, "# Verify package details before running\ncargo add 'serde@1.0.0'");
     assert.ok(result.note);
     assert.ok(result.note.includes(".cargo/config.toml"));
     assert.ok(result.note.includes(`cargo.cloudsmith.io/${ws}/${repo}`));
@@ -173,7 +186,7 @@ suite("InstallCommandBuilder Test Suite", () => {
     const result = InstallCommandBuilder.build("go", "github.com/gin-gonic/gin", "1.9.1", ws, repo);
     assert.strictEqual(
       result.command,
-      "# Verify package details before running\nGONOSUMCHECK='github.com/gin-gonic/gin' go get 'github.com/gin-gonic/gin'@v'1.9.1'"
+      "# Verify package details before running\nGONOSUMCHECK='github.com/gin-gonic/gin' go get 'github.com/gin-gonic/gin@v1.9.1'"
     );
     assert.ok(result.note);
     assert.ok(result.note.includes("GOPROXY"));
@@ -191,21 +204,21 @@ suite("InstallCommandBuilder Test Suite", () => {
     const result = InstallCommandBuilder.build("conda", "numpy", "1.24.0", ws, repo);
     assert.strictEqual(
       result.command,
-      "# Verify package details before running\nconda install -c https://conda.cloudsmith.io/my-org/my-repo/ 'numpy'='1.24.0'"
+      "# Verify package details before running\nconda install -c https://conda.cloudsmith.io/my-org/my-repo/ 'numpy=1.24.0'"
     );
     assert.strictEqual(result.note, null);
   });
 
   test("composer generates composer require with repo note", () => {
     const result = InstallCommandBuilder.build("composer", "vendor/package", "2.0.0", ws, repo);
-    assert.strictEqual(result.command, "# Verify package details before running\ncomposer require 'vendor/package':'2.0.0'");
+    assert.strictEqual(result.command, "# Verify package details before running\ncomposer require 'vendor/package:2.0.0'");
     assert.ok(result.note);
     assert.ok(result.note.includes("composer.json"));
   });
 
   test("dart generates dart pub add with hosted note", () => {
     const result = InstallCommandBuilder.build("dart", "my_pkg", "1.0.0", ws, repo);
-    assert.strictEqual(result.command, "# Verify package details before running\ndart pub add 'my_pkg':'1.0.0'");
+    assert.strictEqual(result.command, "# Verify package details before running\ndart pub add 'my_pkg:1.0.0'");
     assert.ok(result.note);
     assert.ok(result.note.includes("pubspec.yaml"));
   });
@@ -213,25 +226,25 @@ suite("InstallCommandBuilder Test Suite", () => {
   test("rpm generates dnf install with yum alternative", () => {
     const result = InstallCommandBuilder.build("rpm", "httpd", "2.4.57", ws, repo);
     assert.ok(result.command.includes("dnf install"));
-    assert.ok(result.command.includes("'httpd'-'2.4.57'"));
+    assert.ok(result.command.includes("'httpd-2.4.57'"));
     assert.ok(result.note);
     assert.ok(result.note.includes("yum.repos.d"));
     assert.ok(result.alternatives);
     assert.strictEqual(result.alternatives.length, 1);
     assert.ok(result.alternatives[0].command.includes("yum install"));
-    assert.ok(result.alternatives[0].command.includes("'httpd'-'2.4.57'"));
+    assert.ok(result.alternatives[0].command.includes("'httpd-2.4.57'"));
   });
 
   test("raw generates curl download with wget alternative", () => {
     const result = InstallCommandBuilder.build("raw", "myfile", "1.0.0", ws, repo, {
-      cdnUrl: "https://cdn.example.com/myfile-1.0.0.tar.gz",
+      cdnUrl: "https://dl.cloudsmith.io/basic/my-org/my-repo/raw/files/myfile-1.0.0.tar.gz",
     });
     assert.ok(result.command.includes("curl -L -O"));
-    assert.ok(result.command.includes("https://cdn.example.com/myfile-1.0.0.tar.gz"));
+    assert.ok(result.command.includes("https://dl.cloudsmith.io/basic/my-org/my-repo/raw/files/myfile-1.0.0.tar.gz"));
     assert.ok(result.alternatives);
     assert.strictEqual(result.alternatives.length, 1);
     assert.ok(result.alternatives[0].command.includes("wget"));
-    assert.ok(result.alternatives[0].command.includes("https://cdn.example.com/myfile-1.0.0.tar.gz"));
+    assert.ok(result.alternatives[0].command.includes("https://dl.cloudsmith.io/basic/my-org/my-repo/raw/files/myfile-1.0.0.tar.gz"));
   });
 
   test("raw constructs URL when cdnUrl is missing", () => {
@@ -248,10 +261,10 @@ suite("InstallCommandBuilder Test Suite", () => {
 
   test("generic routes to raw handler", () => {
     const result = InstallCommandBuilder.build("generic", "myfile", "1.0.0", ws, repo, {
-      cdnUrl: "https://cdn.example.com/file.bin",
+      cdnUrl: "https://dl.cloudsmith.io/basic/my-org/my-repo/generic/files/file.bin",
     });
     assert.ok(result.command.includes("curl -L -O"));
-    assert.ok(result.command.includes("https://cdn.example.com/file.bin"));
+    assert.ok(result.command.includes("https://dl.cloudsmith.io/basic/my-org/my-repo/generic/files/file.bin"));
   });
 
   test("unknown format returns comment with link", () => {
@@ -270,9 +283,21 @@ suite("InstallCommandBuilder Test Suite", () => {
     }
   });
 
-  test("shell commands safely escape embedded single quotes", () => {
-    const result = InstallCommandBuilder.build("npm", "evil'pkg", "1.0.0", ws, repo);
-    assert.ok(result.command.includes("'evil'\\''pkg'"));
+  test("shell command formats reject apostrophes that differ across shell dialects", () => {
+    const shellFormats = [
+      "python", "npm", "nuget", "helm", "cargo", "go",
+      "ruby", "conda", "composer", "dart", "rpm",
+    ];
+    for (const format of shellFormats) {
+      assertValidationError(
+        () => InstallCommandBuilder.build(format, "evil'; echo injected; '", "1.0.0", ws, repo),
+        "Package name"
+      );
+      assertValidationError(
+        () => InstallCommandBuilder.build(format, "pkg", "1.0'; echo injected; '", ws, repo),
+        "Package version"
+      );
+    }
   });
 
   test("maven escapes XML-sensitive values", () => {
@@ -280,5 +305,223 @@ suite("InstallCommandBuilder Test Suite", () => {
     assert.ok(result.command.includes("<groupId>group&lt;&amp;&gt;</groupId>"));
     assert.ok(result.command.includes("<artifactId>artifact&quot;name</artifactId>"));
     assert.ok(result.command.includes("<version>1.0&lt;&amp;&gt;&quot;</version>"));
+  });
+
+  test("all shell command formats quote representative shell-active metadata", () => {
+    const shellFormats = [
+      "python", "npm", "nuget", "helm", "cargo", "go",
+      "ruby", "conda", "composer", "dart", "rpm",
+    ];
+    const hostileValues = [
+      "pkg$(touch /tmp/proof)",
+      "pkg`touch /tmp/proof`",
+      "pkg; echo injected",
+      "pkg | echo injected",
+      "pkg && echo injected",
+      "pkg || echo injected",
+      "pkg & echo injected",
+      'pkg"quoted',
+      "pkg with spaces",
+      "pkg$HOME",
+      "pkg\\path",
+      "pkg(foo)<bar>",
+    ];
+
+    const coordinateFor = (format, name, version) => ({
+      python: `${name}==${version}`,
+      npm: `${name}@${version}`,
+      cargo: `${name}@${version}`,
+      go: `${name}@v${version}`,
+      conda: `${name}=${version}`,
+      composer: `${name}:${version}`,
+      dart: `${name}:${version}`,
+      rpm: `${name}-${version}`,
+    }[format] || name);
+
+    for (const format of shellFormats) {
+      for (const hostileValue of hostileValues) {
+        const result = InstallCommandBuilder.build(format, hostileValue, "1.0.0", ws, repo);
+        const clipboardCommand = InstallCommandBuilder.toClipboardCommand(result.command);
+        assert.ok(
+          clipboardCommand.includes(InstallCommandBuilder.shellEscape(
+            coordinateFor(format, hostileValue, "1.0.0")
+          )),
+          `${format} should render hostile package metadata as one quoted shell argument`
+        );
+        assert.strictEqual(clipboardCommand.split("\n").length, 1);
+
+        const versionResult = InstallCommandBuilder.build(format, "pkg", hostileValue, ws, repo);
+        const versionClipboardCommand = InstallCommandBuilder.toClipboardCommand(versionResult.command);
+        const expectedVersionArgument = ["nuget", "helm", "ruby"].includes(format)
+          ? hostileValue
+          : coordinateFor(format, "pkg", hostileValue);
+        assert.ok(
+          versionClipboardCommand.includes(InstallCommandBuilder.shellEscape(expectedVersionArgument)),
+          `${format} should render hostile version metadata as one quoted shell argument`
+        );
+        assert.strictEqual(versionClipboardCommand.split("\n").length, 1);
+      }
+    }
+  });
+
+  test("all generated command formats reject newlines in package metadata", () => {
+    const formats = [
+      "python", "npm", "maven", "nuget", "docker", "helm", "cargo",
+      "go", "ruby", "conda", "composer", "dart", "rpm", "raw", "generic",
+    ];
+    for (const format of formats) {
+      assertValidationError(
+        () => InstallCommandBuilder.build(format, "package\necho injected", "1.0.0", ws, repo),
+        "Package name"
+      );
+    }
+  });
+
+  test("all generated command formats reject shell-active Cloudsmith slugs", () => {
+    const formats = [
+      "python", "npm", "maven", "nuget", "docker", "helm", "cargo",
+      "go", "ruby", "conda", "composer", "dart", "rpm", "raw", "generic",
+    ];
+    const hostileSlugs = [
+      "ws$(touch)", "ws`touch`", "ws;echo", "ws|echo", "ws&&echo", "ws||echo",
+      'ws"quote', "ws'quote", "ws with spaces", "ws$HOME", "../ws", "ws\\repo", "ws\necho",
+    ];
+    for (const format of formats) {
+      for (const hostileSlug of hostileSlugs) {
+        assertValidationError(
+          () => InstallCommandBuilder.build(format, "pkg", "1.0.0", hostileSlug, repo),
+          "Workspace slug"
+        );
+      }
+      assertValidationError(
+        () => InstallCommandBuilder.build(format, "pkg", "1.0.0", ws, "repo;echo injected"),
+        "Repository slug"
+      );
+    }
+  });
+
+  test("maven safely renders shell metacharacters as XML text", () => {
+    const result = InstallCommandBuilder.build(
+      "maven",
+      "group.$(touch):artifact;echo|value",
+      "1.0-$HOME&&false",
+      ws,
+      repo
+    );
+    assert.ok(result.command.includes("<groupId>group.$(touch)</groupId>"));
+    assert.ok(result.command.includes("<artifactId>artifact;echo|value</artifactId>"));
+    assert.ok(result.command.includes("<version>1.0-$HOME&amp;&amp;false</version>"));
+  });
+
+  test("docker rejects malformed image names including the original proof case", () => {
+    const invalidNames = [
+      "image; echo injected",
+      "image$(touch)",
+      "image`touch`",
+      "Image",
+      ".image",
+      "image..name",
+      "team//image",
+      "team/image:tag",
+      "team/image with spaces",
+      "../image",
+    ];
+    for (const name of invalidNames) {
+      assertValidationError(
+        () => InstallCommandBuilder.build("docker", name, "latest", ws, repo),
+        "Docker image name"
+      );
+    }
+  });
+
+  test("docker rejects malformed tags", () => {
+    const invalidTags = [
+      "tag;echo", "tag|echo", "tag&&echo", "tag||echo", "tag$(touch)",
+      "tag`touch`", "tag with spaces", ".tag", "-tag", "tag:other", "a".repeat(129),
+    ];
+    for (const tag of invalidTags) {
+      assertValidationError(
+        () => InstallCommandBuilder.build("docker", "image", "fallback", ws, repo, {
+          tags: { version: [tag] },
+        }),
+        "Docker tag"
+      );
+    }
+  });
+
+  test("docker rejects malformed digests and accepts a canonical sha256 digest", () => {
+    const invalidDigests = [
+      "abc123",
+      "sha512:" + "a".repeat(64),
+      "sha256:" + "g".repeat(64),
+      "sha256:" + "a".repeat(63),
+      "sha256:" + "a".repeat(64) + ";echo",
+      "sha256:$(touch)",
+    ];
+    for (const digest of invalidDigests) {
+      assertValidationError(
+        () => InstallCommandBuilder.build("docker", "image", "latest", ws, repo, {
+          checksumSha256: digest,
+        }),
+        "Docker digest"
+      );
+    }
+
+    const result = InstallCommandBuilder.build("docker", "team/image", "stable", ws, repo, {
+      checksumSha256: `sha256:${sha256.toUpperCase()}`,
+    });
+    assert.ok(result.alternatives[0].command.endsWith(`@sha256:${sha256}`));
+  });
+
+  test("raw rejects malformed, untrusted, and credential-bearing URLs", () => {
+    const invalidUrls = [
+      "https://example.invalid/$(touch /tmp/cloudsmith-audit-proof)",
+      "http://dl.cloudsmith.io/basic/ws/repo/raw/files/file",
+      "ftp://dl.cloudsmith.io/basic/ws/repo/raw/files/file",
+      "https://dl.cloudsmith.io.evil.invalid/file",
+      "https://evil.dl.cloudsmith.io/file",
+      "https://user:password@dl.cloudsmith.io/file",
+      "https://dl.cloudsmith.io/file#fragment",
+      "https://dl.cloudsmith.io/file with spaces",
+      "https:\\dl.cloudsmith.io\\file",
+      "not a URL",
+    ];
+    for (const cdnUrl of invalidUrls) {
+      assertValidationError(
+        () => InstallCommandBuilder.build("raw", "file", "1.0.0", ws, repo, { cdnUrl }),
+        "Raw download URL"
+      );
+    }
+  });
+
+  test("raw renders shell-active URL query data as one quoted argument", () => {
+    const cdnUrl = "https://dl.cloudsmith.io/basic/ws/repo/raw/files/file"
+      + "?one=$(touch)&two=`id`;three=$HOME|false&&true||false";
+    const result = InstallCommandBuilder.build("raw", "file", "1.0.0", ws, repo, { cdnUrl });
+    assert.strictEqual(
+      InstallCommandBuilder.toClipboardCommand(result.command),
+      `curl -L -O ${InstallCommandBuilder.shellEscape(cdnUrl)}`
+    );
+  });
+
+  test("raw encodes package path components and rejects filename traversal", () => {
+    const result = InstallCommandBuilder.build("raw", "../file $(id)", "../1.0", ws, repo);
+    assert.ok(result.command.includes("..%2Ffile%20%24%28id%29"));
+    assert.ok(result.command.includes("..%2F1.0"));
+    assert.ok(!result.command.includes("/../"));
+
+    for (const filename of ["../payload", "..\\payload", ".", "..", "file\nname"]) {
+      assertValidationError(
+        () => InstallCommandBuilder.build("raw", "file", "1.0.0", ws, repo, { filename }),
+        "Raw package filename"
+      );
+    }
+  });
+
+  test("rejects a format that could escape the unknown-format comment", () => {
+    assertValidationError(
+      () => InstallCommandBuilder.build("unknown\necho injected", "pkg", "1.0", ws, repo),
+      "Package format"
+    );
   });
 });

--- a/test/integration/installCommand.test.js
+++ b/test/integration/installCommand.test.js
@@ -74,6 +74,6 @@ suite('Integration: Install Command Builder', function () {
 
   test('shell command formats quote package coordinates', function () {
     const result = InstallCommandBuilder.build('python', 'demo', '1.2.3', 'ws', 'repo');
-    assert.ok(result.command.includes("'demo'=='1.2.3'"), 'Should quote package name and version');
+    assert.ok(result.command.includes("'demo==1.2.3'"), 'Should quote package name and version');
   });
 });

--- a/util/installCommandBuilder.js
+++ b/util/installCommandBuilder.js
@@ -257,10 +257,11 @@ class InstallCommandBuilder {
       || value !== value.trim()
       || ASCII_CONTROL_PATTERN.test(value)
       || /[\\\s]/.test(value)
+      || value.includes("'")
     ) {
       throw new InstallCommandValidationError(
         "Raw download URL",
-        "must be a well-formed HTTPS Cloudsmith download URL without whitespace or backslashes."
+        "must be a well-formed HTTPS Cloudsmith download URL without whitespace, backslashes, or apostrophes."
       );
     }
 

--- a/util/installCommandBuilder.js
+++ b/util/installCommandBuilder.js
@@ -4,19 +4,48 @@
 const { WEB_APP_BASE_URL, buildRepositoryUrl } = require("./webAppUrls");
 
 const VERIFICATION_BANNER = "# Verify package details before running";
+const CLOUDSMITH_DOWNLOAD_HOST = "dl.cloudsmith.io";
+const DOCKER_REGISTRY = "docker.cloudsmith.io";
+const MAX_IDENTIFIER_LENGTH = 255;
+const MAX_DOCKER_NAME_LENGTH = 255;
+const ASCII_CONTROL_PATTERN = /[\u0000-\u001f\u007f]/;
+const CLOUDSMITH_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]+$/;
+const COMMAND_FORMAT_PATTERN = /^[a-z0-9][a-z0-9._+-]{0,63}$/;
+const DOCKER_NAME_COMPONENT_PATTERN = /^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$/;
+const DOCKER_TAG_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/;
+const SHA256_DIGEST_PATTERN = /^(?:sha256:)?([a-fA-F0-9]{64})$/;
+const SHELL_ARGUMENT_FORMATS = new Set([
+  "python", "npm", "nuget", "helm", "cargo", "go",
+  "ruby", "conda", "composer", "dart", "rpm",
+]);
+
+class InstallCommandValidationError extends Error {
+  constructor(field, reason) {
+    super(`${field} ${reason}`);
+    this.name = "InstallCommandValidationError";
+    this.field = field;
+  }
+}
 
 class InstallCommandBuilder {
   /**
-   * Escape a string for safe single-quoted shell usage.
+   * Render one argument using syntax shared by POSIX-compatible shells and PowerShell.
+   * Embedded apostrophes are rejected because those shells escape them differently.
    */
   static shellEscape(str) {
     const value = String(str);
-    return `'${value.replace(/'/g, `'\\''`)}'`;
+    if (value.includes("'")) {
+      throw new InstallCommandValidationError(
+        "Shell argument",
+        "must not contain an apostrophe."
+      );
+    }
+    return `'${value}'`;
   }
 
   /**
-   * Remove the display-only verification banner before copying to the clipboard.
-   * Unknown-format fallback comments are preserved.
+   * Remove the display-only verification banner from an already validated command.
+   * Unknown-format fallback comments are preserved and remain non-executable.
    *
    * @param   {string} command
    * @returns {string}
@@ -82,40 +111,201 @@ class InstallCommandBuilder {
       return null;
     }
 
-    const normalized = InstallCommandBuilder._sanitizeDockerComponent(value);
-    return normalized || null;
-  }
-
-  static _sanitizeDockerComponent(value) {
-    return String(value).trim().replace(/^['"]+|['"]+$/g, "");
+    return DOCKER_TAG_PATTERN.test(value) ? value : null;
   }
 
   static _normalizeDockerDigest(value) {
-    if (typeof value !== "string") {
+    if (value == null || value === "") {
       return null;
     }
 
-    const normalized = InstallCommandBuilder._sanitizeDockerComponent(value).replace(/^sha256:/i, "");
-    return normalized || null;
+    if (typeof value !== "string") {
+      throw new InstallCommandValidationError("Docker digest", "must be a string.");
+    }
+
+    const match = value.match(SHA256_DIGEST_PATTERN);
+    if (!match) {
+      throw new InstallCommandValidationError(
+        "Docker digest",
+        "must be a sha256 digest containing exactly 64 hexadecimal characters."
+      );
+    }
+
+    return match[1].toLowerCase();
   }
 
   static _resolveDockerTag(version, opts) {
-    const explicitTag = InstallCommandBuilder.extractDockerTag(opts);
-    if (explicitTag) {
-      return explicitTag;
+    const candidates = [
+      opts.tags && opts.tags.version,
+      opts.tags_raw && opts.tags_raw.version,
+      opts.cloudsmithMatch && opts.cloudsmithMatch.tags && opts.cloudsmithMatch.tags.version,
+    ];
+
+    for (const candidate of candidates) {
+      const values = Array.isArray(candidate) ? candidate : [candidate];
+      for (const value of values) {
+        if (value == null || value === "") {
+          continue;
+        }
+        if (typeof value !== "string" || !DOCKER_TAG_PATTERN.test(value)) {
+          throw new InstallCommandValidationError(
+            "Docker tag",
+            "must start with an alphanumeric character or underscore, contain only alphanumerics, underscores, periods, or dashes, and be at most 128 characters."
+          );
+        }
+        return value;
+      }
     }
 
-    const normalizedVersion = InstallCommandBuilder._normalizeDockerTag(version);
-    if (normalizedVersion) {
-      return normalizedVersion;
+    if (version === "") {
+      return "latest";
     }
 
-    return "latest";
+    if (!DOCKER_TAG_PATTERN.test(version)) {
+      throw new InstallCommandValidationError(
+        "Docker tag",
+        "must start with an alphanumeric character or underscore, contain only alphanumerics, underscores, periods, or dashes, and be at most 128 characters."
+      );
+    }
+
+    return version;
   }
 
   static _normalizeDockerName(name) {
-    const normalized = InstallCommandBuilder._sanitizeDockerComponent(name);
-    return normalized.endsWith(".sig") ? normalized.slice(0, -4) : normalized;
+    return name.endsWith(".sig") ? name.slice(0, -4) : name;
+  }
+
+  static _validateCommandFormat(format) {
+    if (typeof format !== "string" || !COMMAND_FORMAT_PATTERN.test(format)) {
+      throw new InstallCommandValidationError(
+        "Package format",
+        "must be a lowercase identifier containing only letters, numbers, periods, underscores, plus signs, or dashes."
+      );
+    }
+    return format;
+  }
+
+  static _validateCommandValue(value, field, allowEmpty = false) {
+    if (typeof value !== "string") {
+      throw new InstallCommandValidationError(field, "must be a string.");
+    }
+    if ((!allowEmpty && value.length === 0) || ASCII_CONTROL_PATTERN.test(value)) {
+      throw new InstallCommandValidationError(field, "must be non-empty and contain no control characters or newlines.");
+    }
+    return value;
+  }
+
+  static _validateShellArgument(value, field) {
+    if (value.includes("'")) {
+      throw new InstallCommandValidationError(
+        field,
+        "must not contain an apostrophe because generated commands support both POSIX shells and PowerShell."
+      );
+    }
+    return value;
+  }
+
+  static _validateCloudsmithIdentifier(value, field) {
+    if (
+      typeof value !== "string"
+      || value.length === 0
+      || value.length > MAX_IDENTIFIER_LENGTH
+      || value === "."
+      || value === ".."
+      || !CLOUDSMITH_IDENTIFIER_PATTERN.test(value)
+    ) {
+      throw new InstallCommandValidationError(
+        field,
+        "must be a Cloudsmith slug containing only letters, numbers, periods, underscores, or dashes."
+      );
+    }
+    return value;
+  }
+
+  static _encodeUrlPathSegment(value) {
+    return encodeURIComponent(value).replace(/[!'()*]/g, character =>
+      `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+    );
+  }
+
+  static _validateDockerPathComponent(value, field) {
+    if (!DOCKER_NAME_COMPONENT_PATTERN.test(value)) {
+      throw new InstallCommandValidationError(
+        field,
+        "must be a lowercase Docker repository component using valid periods, underscores, or dashes."
+      );
+    }
+    return value;
+  }
+
+  static _validateDockerImageName(value) {
+    const imageName = InstallCommandBuilder._normalizeDockerName(value);
+    const components = imageName.split("/");
+    if (!imageName || components.some(component => !DOCKER_NAME_COMPONENT_PATTERN.test(component))) {
+      throw new InstallCommandValidationError(
+        "Docker image name",
+        "must be a lowercase slash-delimited Docker repository path."
+      );
+    }
+    return imageName;
+  }
+
+  static _validateRawDownloadUrl(value) {
+    if (
+      typeof value !== "string"
+      || value.length === 0
+      || value !== value.trim()
+      || ASCII_CONTROL_PATTERN.test(value)
+      || /[\\\s]/.test(value)
+    ) {
+      throw new InstallCommandValidationError(
+        "Raw download URL",
+        "must be a well-formed HTTPS Cloudsmith download URL without whitespace or backslashes."
+      );
+    }
+
+    let parsed;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new InstallCommandValidationError("Raw download URL", "must be a well-formed URL.");
+    }
+
+    if (parsed.protocol !== "https:") {
+      throw new InstallCommandValidationError("Raw download URL", "must use HTTPS.");
+    }
+    if (parsed.hostname !== CLOUDSMITH_DOWNLOAD_HOST || parsed.port) {
+      throw new InstallCommandValidationError(
+        "Raw download URL",
+        `must use the approved ${CLOUDSMITH_DOWNLOAD_HOST} host.`
+      );
+    }
+    if (parsed.username || parsed.password) {
+      throw new InstallCommandValidationError("Raw download URL", "must not contain embedded credentials.");
+    }
+    if (parsed.hash) {
+      throw new InstallCommandValidationError("Raw download URL", "must not contain a fragment.");
+    }
+
+    return parsed.toString();
+  }
+
+  static _validateFilename(value) {
+    if (
+      typeof value !== "string"
+      || value.length === 0
+      || value === "."
+      || value === ".."
+      || ASCII_CONTROL_PATTERN.test(value)
+      || value.includes("/")
+      || value.includes("\\")
+    ) {
+      throw new InstallCommandValidationError(
+        "Raw package filename",
+        "must be a non-empty filename without control characters or path separators."
+      );
+    }
+    return value;
   }
 
   /**
@@ -134,71 +324,111 @@ class InstallCommandBuilder {
    */
   static build(format, name, version, workspace, repo, opts) {
     const options = opts || {};
-    const safeName = InstallCommandBuilder.shellEscape(name);
-    const safeVersion = InstallCommandBuilder.shellEscape(version);
+    const validatedFormat = InstallCommandBuilder._validateCommandFormat(format);
+    const validatedName = InstallCommandBuilder._validateCommandValue(name, "Package name");
+    const validatedVersion = InstallCommandBuilder._validateCommandValue(
+      version,
+      "Package version",
+      validatedFormat === "docker"
+    );
+    const validatedWorkspace = InstallCommandBuilder._validateCloudsmithIdentifier(workspace, "Workspace slug");
+    const validatedRepo = InstallCommandBuilder._validateCloudsmithIdentifier(repo, "Repository slug");
+    const encodedWorkspace = InstallCommandBuilder._encodeUrlPathSegment(validatedWorkspace);
+    const encodedRepo = InstallCommandBuilder._encodeUrlPathSegment(validatedRepo);
+    const usesShellArguments = SHELL_ARGUMENT_FORMATS.has(validatedFormat);
+    if (usesShellArguments) {
+      InstallCommandBuilder._validateShellArgument(validatedName, "Package name");
+      InstallCommandBuilder._validateShellArgument(validatedVersion, "Package version");
+    }
+    const safeName = usesShellArguments ? InstallCommandBuilder.shellEscape(validatedName) : "";
+    const safeVersion = usesShellArguments ? InstallCommandBuilder.shellEscape(validatedVersion) : "";
+    const shellArgument = value => usesShellArguments ? InstallCommandBuilder.shellEscape(value) : "";
     const commands = {
       python: {
-        command: `# Verify package details before running\npip install ${safeName}==${safeVersion} --index-url https://dl.cloudsmith.io/basic/${workspace}/${repo}/python/simple/`,
+        command: `# Verify package details before running\npip install ${shellArgument(`${validatedName}==${validatedVersion}`)} --index-url https://dl.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/python/simple/`,
         note: 'For private repositories, replace "basic" with an entitlement token.',
       },
       npm: {
-        command: `# Verify package details before running\nnpm install ${safeName}@${safeVersion} --registry=https://npm.cloudsmith.io/${workspace}/${repo}/`,
-        note: "Run `npm login --registry=https://npm.cloudsmith.io/" + workspace + "/" + repo + "/` first for private repositories.",
+        command: `# Verify package details before running\nnpm install ${shellArgument(`${validatedName}@${validatedVersion}`)} --registry=https://npm.cloudsmith.io/${encodedWorkspace}/${encodedRepo}/`,
+        note: "Run `npm login --registry=https://npm.cloudsmith.io/" + encodedWorkspace + "/" + encodedRepo + "/` first for private repositories.",
       },
       maven: {
-        command: InstallCommandBuilder._buildMaven(name, version, workspace, repo),
+        command: InstallCommandBuilder._buildMaven(
+          validatedName,
+          validatedVersion,
+          validatedRepo,
+          encodedWorkspace,
+          encodedRepo
+        ),
         note: 'For private repositories, replace "basic" with an entitlement token in the repository URL.',
       },
       nuget: {
-        command: `# Verify package details before running\ndotnet add package ${safeName} --version ${safeVersion} --source https://nuget.cloudsmith.io/${workspace}/${repo}/v3/index.json`,
+        command: `# Verify package details before running\ndotnet add package ${safeName} --version ${safeVersion} --source https://nuget.cloudsmith.io/${encodedWorkspace}/${encodedRepo}/v3/index.json`,
         note: "For private repositories, configure NuGet source credentials.",
       },
       helm: {
-        command: `# Verify package details before running\nhelm install ${safeName} --repo https://dl.cloudsmith.io/basic/${workspace}/${repo}/helm/charts/ --version ${safeVersion}`,
+        command: `# Verify package details before running\nhelm install ${safeName} --repo https://dl.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/helm/charts/ --version ${safeVersion}`,
         note: 'For private repositories, replace "basic" with an entitlement token.',
       },
       cargo: {
-        command: `# Verify package details before running\ncargo add ${safeName}@${safeVersion}`,
-        note: `Add registry to .cargo/config.toml:\n[registries.cloudsmith]\nindex = "sparse+https://cargo.cloudsmith.io/${workspace}/${repo}/"`,
+        command: `# Verify package details before running\ncargo add ${shellArgument(`${validatedName}@${validatedVersion}`)}`,
+        note: `Add registry to .cargo/config.toml:\n[registries.cloudsmith]\nindex = "sparse+https://cargo.cloudsmith.io/${encodedWorkspace}/${encodedRepo}/"`,
       },
       go: {
-        command: `# Verify package details before running\nGONOSUMCHECK=${safeName} go get ${safeName}@v${safeVersion}`,
-        note: `Set GOPROXY=https://go.cloudsmith.io/basic/${workspace}/${repo}/,direct`,
+        command: `# Verify package details before running\nGONOSUMCHECK=${safeName} go get ${shellArgument(`${validatedName}@v${validatedVersion}`)}`,
+        note: `Set GOPROXY=https://go.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/,direct`,
       },
       ruby: {
-        command: `# Verify package details before running\ngem install ${safeName} -v ${safeVersion} --source https://dl.cloudsmith.io/basic/${workspace}/${repo}/ruby/`,
+        command: `# Verify package details before running\ngem install ${safeName} -v ${safeVersion} --source https://dl.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/ruby/`,
         note: 'For private repositories, replace "basic" with an entitlement token.',
       },
       conda: {
-        command: `# Verify package details before running\nconda install -c https://conda.cloudsmith.io/${workspace}/${repo}/ ${safeName}=${safeVersion}`,
+        command: `# Verify package details before running\nconda install -c https://conda.cloudsmith.io/${encodedWorkspace}/${encodedRepo}/ ${shellArgument(`${validatedName}=${validatedVersion}`)}`,
         note: null,
       },
       composer: {
-        command: `# Verify package details before running\ncomposer require ${safeName}:${safeVersion}`,
-        note: `Add repository to composer.json:\n{"type": "composer", "url": "https://composer.cloudsmith.io/${workspace}/${repo}/"}`,
+        command: `# Verify package details before running\ncomposer require ${shellArgument(`${validatedName}:${validatedVersion}`)}`,
+        note: `Add repository to composer.json:\n{"type": "composer", "url": "https://composer.cloudsmith.io/${encodedWorkspace}/${encodedRepo}/"}`,
       },
       dart: {
-        command: `# Verify package details before running\ndart pub add ${safeName}:${safeVersion}`,
-        note: `Add hosted URL to pubspec.yaml:\n  ${name}:\n    hosted: https://dart.cloudsmith.io/basic/${workspace}/${repo}/pub/\n    version: ${version}`,
+        command: `# Verify package details before running\ndart pub add ${shellArgument(`${validatedName}:${validatedVersion}`)}`,
+        note: `Add hosted URL to pubspec.yaml:\n  ${validatedName}:\n    hosted: https://dart.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/pub/\n    version: ${validatedVersion}`,
       },
     };
 
     // Formats with dedicated handlers
-    if (format === "docker") {
-      return InstallCommandBuilder._buildDocker(name, version, workspace, repo, options);
+    if (validatedFormat === "docker") {
+      return InstallCommandBuilder._buildDocker(
+        validatedName,
+        validatedVersion,
+        validatedWorkspace,
+        validatedRepo,
+        options
+      );
     }
-    if (format === "rpm") {
-      return InstallCommandBuilder._buildRpm(name, version, workspace, repo);
+    if (validatedFormat === "rpm") {
+      return InstallCommandBuilder._buildRpm(
+        validatedName,
+        validatedVersion,
+        encodedWorkspace,
+        encodedRepo
+      );
     }
-    if (format === "raw" || format === "generic") {
-      return InstallCommandBuilder._buildRaw(name, version, workspace, repo, options);
+    if (validatedFormat === "raw" || validatedFormat === "generic") {
+      return InstallCommandBuilder._buildRaw(
+        validatedName,
+        validatedVersion,
+        encodedWorkspace,
+        encodedRepo,
+        options
+      );
     }
 
-    const entry = commands[format];
+    const entry = commands[validatedFormat];
     if (!entry) {
-      const repositoryUrl = buildRepositoryUrl(workspace, repo) || WEB_APP_BASE_URL;
+      const repositoryUrl = buildRepositoryUrl(validatedWorkspace, validatedRepo) || WEB_APP_BASE_URL;
       return {
-        command: `# Verify package details before running\n# No install command template for format: ${format}`,
+        command: `# Verify package details before running\n# No install command template for format: ${validatedFormat}`,
         note: `Visit ${repositoryUrl} for setup instructions.`,
       };
     }
@@ -209,19 +439,27 @@ class InstallCommandBuilder {
    * Build Docker pull command — tag-first with optional digest alternative.
    */
   static _buildDocker(name, version, workspace, repo, opts) {
-    const registry = `docker.cloudsmith.io/${workspace}/${repo}`;
-    const imageName = InstallCommandBuilder._normalizeDockerName(name);
+    InstallCommandBuilder._validateDockerPathComponent(workspace, "Docker workspace slug");
+    InstallCommandBuilder._validateDockerPathComponent(repo, "Docker repository slug");
+    const imageName = InstallCommandBuilder._validateDockerImageName(name);
     const tag = InstallCommandBuilder._resolveDockerTag(version, opts || {});
+    const repositoryName = `${DOCKER_REGISTRY}/${workspace}/${repo}/${imageName}`;
+    if (repositoryName.length > MAX_DOCKER_NAME_LENGTH) {
+      throw new InstallCommandValidationError(
+        "Docker repository name",
+        `must be at most ${MAX_DOCKER_NAME_LENGTH} characters.`
+      );
+    }
     const result = {
-      command: `# Verify package details before running\ndocker pull ${registry}/${imageName}:${tag}`,
-      note: "Run `docker login docker.cloudsmith.io` first for private repositories.",
+      command: `# Verify package details before running\ndocker pull ${repositoryName}:${tag}`,
+      note: `Run \`docker login ${DOCKER_REGISTRY}\` first for private repositories.`,
     };
 
     const digest = InstallCommandBuilder._normalizeDockerDigest((opts || {}).checksumSha256 || (opts || {}).versionDigest);
     if (digest) {
       result.alternatives = [{
         label: "Pull by digest (pinned)",
-        command: `# Verify package details before running\ndocker pull ${registry}/${imageName}@sha256:${digest}`,
+        command: `# Verify package details before running\ndocker pull ${repositoryName}@sha256:${digest}`,
       }];
     }
 
@@ -232,14 +470,13 @@ class InstallCommandBuilder {
    * Build RPM install command — dnf primary, yum alternative.
    */
   static _buildRpm(name, version, workspace, repo) {
-    const safeName = InstallCommandBuilder.shellEscape(name);
-    const safeVersion = InstallCommandBuilder.shellEscape(version);
+    const safeCoordinate = InstallCommandBuilder.shellEscape(`${name}-${version}`);
     return {
-      command: `# Verify package details before running\ndnf install ${safeName}-${safeVersion}`,
+      command: `# Verify package details before running\ndnf install ${safeCoordinate}`,
       note: `Requires a Cloudsmith repository configured in /etc/yum.repos.d/.\nRepository URL: https://dl.cloudsmith.io/basic/${workspace}/${repo}/rpm/`,
       alternatives: [{
         label: "Install via yum",
-        command: `# Verify package details before running\nyum install ${safeName}-${safeVersion}`,
+        command: `# Verify package details before running\nyum install ${safeCoordinate}`,
       }],
     };
   }
@@ -248,16 +485,26 @@ class InstallCommandBuilder {
    * Build Raw/Generic download command — curl primary, wget alternative.
    */
   static _buildRaw(name, version, workspace, repo, opts) {
-    const filename = opts.filename || `${name}-${version}`;
-    const cdnUrl = opts.cdnUrl ||
-      `https://dl.cloudsmith.io/basic/${workspace}/${repo}/raw/names/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/${encodeURIComponent(filename)}`;
+    let cdnUrl;
+    if (opts.cdnUrl != null && opts.cdnUrl !== "") {
+      cdnUrl = InstallCommandBuilder._validateRawDownloadUrl(opts.cdnUrl);
+    } else {
+      const filename = opts.filename
+        ? InstallCommandBuilder._validateFilename(opts.filename)
+        : `${name}-${version}`;
+      cdnUrl = `https://${CLOUDSMITH_DOWNLOAD_HOST}/basic/${workspace}/${repo}`
+        + `/raw/names/${InstallCommandBuilder._encodeUrlPathSegment(name)}`
+        + `/versions/${InstallCommandBuilder._encodeUrlPathSegment(version)}`
+        + `/${InstallCommandBuilder._encodeUrlPathSegment(filename)}`;
+    }
+    const safeCdnUrl = InstallCommandBuilder.shellEscape(cdnUrl);
 
     return {
-      command: `# Verify package details before running\ncurl -L -O "${cdnUrl}"`,
+      command: `# Verify package details before running\ncurl -L -O ${safeCdnUrl}`,
       note: 'For private repositories, replace "basic" with an entitlement token or use authentication headers.',
       alternatives: [{
         label: "Download via wget",
-        command: `# Verify package details before running\nwget "${cdnUrl}"`,
+        command: `# Verify package details before running\nwget ${safeCdnUrl}`,
       }],
     };
   }
@@ -266,7 +513,7 @@ class InstallCommandBuilder {
    * Build a Maven pom.xml snippet with repository and dependency blocks.
    * Splits name on : to get groupId and artifactId.
    */
-  static _buildMaven(name, version, workspace, repo) {
+  static _buildMaven(name, version, repo, encodedWorkspace, encodedRepo) {
     let groupId;
     let artifactId;
     if (name.includes(":")) {
@@ -288,7 +535,7 @@ class InstallCommandBuilder {
       "<!-- Add to pom.xml repositories -->",
       "<repository>",
       `  <id>cloudsmith-${escapeXml(repo)}</id>`,
-      `  <url>https://dl.cloudsmith.io/basic/${escapeXml(workspace)}/${escapeXml(repo)}/maven/</url>`,
+      `  <url>https://dl.cloudsmith.io/basic/${encodedWorkspace}/${encodedRepo}/maven/</url>`,
       "</repository>",
       "",
       "<!-- Add to dependencies -->",
@@ -301,4 +548,4 @@ class InstallCommandBuilder {
   }
 }
 
-module.exports = { InstallCommandBuilder };
+module.exports = { InstallCommandBuilder, InstallCommandValidationError };


### PR DESCRIPTION
### Summary

- Hardened generated install/download commands against shell-active API metadata.
- Added explicit Cloudsmith slug, Docker reference/tag/digest, command-field, and raw filename validation.
- Restricted API-provided raw downloads to credential-free HTTPS URLs on `dl.cloudsmith.io` and encoded constructed URL path components.
- Rendered package coordinates and raw URLs as single shell arguments for POSIX-compatible shells and PowerShell; invalid metadata now fails with an actionable error before clipboard or preview output.
- Kept the verification banner in previews and removed it from clipboard content only after successful validation.
- Added hostile-input regression coverage while preserving expected commands for valid metadata.

### Validation

- `npm run lint` — 0 errors; 2 known pre-existing warnings.
- `npm test` — 370 discovered; 363 passing; 0 failing; 7 skipped without `CLOUDSMITH_TEST_API_KEY`.
- `git diff --check`.
- Non-executing regression construction for the original raw URL and Docker image proof cases.
- `vsce package --no-dependencies` plus `unzip -t` — 1,153-file VSIX passed integrity validation; no tests or internal/development artifacts were added.

### Audit / Roadmap

- General Workspace Trust, external URI policy, and webview-boundary work remains intentionally deferred to M2.
- Custom raw download domains are not implicitly trusted; only the documented `dl.cloudsmith.io` API download host is approved in M1.
