### PR TITLE
fix: make dependency scans transactional

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -357,12 +357,12 @@ function buildPresetQuery(preset, customQuery) {
   return builder.build();
 }
 
-async function resolveDependencyScanTarget(context) {
+async function resolveDependencyScanTarget(context, options = {}) {
   const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-  let scanWorkspace = config.get("dependencyScanWorkspace");
-  let scanRepo = config.get("dependencyScanRepo") || null;
+  let scanWorkspace = options.forcePrompt ? null : config.get("dependencyScanWorkspace");
+  let scanRepo = options.forcePrompt ? null : (config.get("dependencyScanRepo") || null);
 
-  if (!scanWorkspace) {
+  if (!scanWorkspace && !options.forcePrompt) {
     scanWorkspace = getDefaultWorkspace();
   }
 
@@ -444,6 +444,23 @@ async function resolveDependencyScanTarget(context) {
     scanWorkspace,
     scanRepo,
   };
+}
+
+async function runDependencyScan(provider, resolveInitialTarget) {
+  const initialScan = async () => {
+    const scanTarget = await resolveInitialTarget();
+    if (!scanTarget) {
+      return null;
+    }
+
+    return provider.scan(scanTarget.scanWorkspace, scanTarget.scanRepo);
+  };
+
+  if (provider.hasSuccessfulScan()) {
+    return provider.rescan(initialScan);
+  }
+
+  return initialScan();
 }
 
 function buildDependencySortFilterItems(provider) {
@@ -1664,17 +1681,10 @@ async function activate(context) {
 
     // Register scan dependencies command
     vscode.commands.registerCommand("cloudsmith-vsc.scanDependencies", async () => {
-      if (dependencyHealthProvider.lastWorkspace) {
-        await dependencyHealthProvider.rescan();
-        return;
-      }
-
-      const scanTarget = await resolveDependencyScanTarget(context);
-      if (!scanTarget) {
-        return;
-      }
-
-      await dependencyHealthProvider.scan(scanTarget.scanWorkspace, scanTarget.scanRepo);
+      await runDependencyScan(
+        dependencyHealthProvider,
+        () => resolveDependencyScanTarget(context)
+      );
     }),
 
     vscode.commands.registerCommand("cloudsmith-vsc.scanDependenciesPending", async () => {
@@ -1683,6 +1693,29 @@ async function activate(context) {
 
     vscode.commands.registerCommand("cloudsmith-vsc.scanDependenciesComplete", async () => {
       await vscode.commands.executeCommand("cloudsmith-vsc.scanDependencies");
+    }),
+
+    // Historical command IDs remain callable but use the same first-run/refresh behavior.
+    vscode.commands.registerCommand("cloudsmith-vsc.rescanDependencies", async () => {
+      await vscode.commands.executeCommand("cloudsmith-vsc.scanDependencies");
+    }),
+
+    vscode.commands.registerCommand("cloudsmith-vsc.changeDependencyScanScope", async () => {
+      const scanTarget = await resolveDependencyScanTarget(context, { forcePrompt: true });
+      if (!scanTarget) {
+        return;
+      }
+
+      const projectFolder = await dependencyHealthProvider.selectProjectFolder();
+      if (!projectFolder) {
+        return;
+      }
+
+      await dependencyHealthProvider.scan(
+        scanTarget.scanWorkspace,
+        scanTarget.scanRepo,
+        projectFolder
+      );
     }),
 
     vscode.commands.registerCommand("cloudsmith-vsc.pullDependencies", async () => {
@@ -2332,4 +2365,5 @@ module.exports = {
   activate,
   deactivate,
   FORMAT_OPTIONS,
+  runDependencyScan,
 };

--- a/package.json
+++ b/package.json
@@ -200,16 +200,10 @@
         "icon": "$(play)"
       },
       {
-        "command": "cloudsmith-vsc.scanDependenciesPending",
-        "title": "Scan dependencies",
+        "command": "cloudsmith-vsc.changeDependencyScanScope",
+        "title": "Change dependency scan scope",
         "category": "Cloudsmith",
-        "icon": "$(play)"
-      },
-      {
-        "command": "cloudsmith-vsc.scanDependenciesComplete",
-        "title": "Rescan dependencies",
-        "category": "Cloudsmith",
-        "icon": "$(play)"
+        "icon": "$(folder-opened)"
       },
       {
         "command": "cloudsmith-vsc.pullDependencies",
@@ -695,19 +689,19 @@
           "when": "view == cloudsmithSearchView"
         },
         {
-          "command": "cloudsmith-vsc.scanDependenciesPending",
+          "command": "cloudsmith-vsc.scanDependencies",
           "group": "navigation@1",
-          "when": "view == cloudsmithDependencyHealthView && !cloudsmith.depScanComplete"
+          "when": "view == cloudsmithDependencyHealthView && !cloudsmith.depOperationRunning"
         },
         {
-          "command": "cloudsmith-vsc.scanDependenciesComplete",
-          "group": "navigation@1",
-          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanComplete"
+          "command": "cloudsmith-vsc.changeDependencyScanScope",
+          "group": "navigation@1.5",
+          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning"
         },
         {
           "command": "cloudsmith-vsc.pullDependencies",
           "group": "navigation@2",
-          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanComplete"
+          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanComplete && !cloudsmith.depOperationRunning"
         },
         {
           "command": "cloudsmith-vsc.cycleDepViewDirect",

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -2,11 +2,17 @@ const assert = require("assert");
 const vscode = require("vscode");
 const {
   DependencyHealthProvider,
+  SCAN_STATES,
   matchCoverageCandidates,
 } = require("../views/dependencyHealthProvider");
 const { normalizePackageName } = require("../util/packageNameNormalizer");
 
 suite("DependencyHealthProvider Test Suite", () => {
+  let originalWithProgress;
+  let originalShowInformationMessage;
+  let originalShowWarningMessage;
+  let originalShowErrorMessage;
+
   function createContext(isConnected = "true") {
     return {
       secrets: {
@@ -60,6 +66,82 @@ suite("DependencyHealthProvider Test Suite", () => {
     return JSON.parse(JSON.stringify(trees));
   }
 
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  async function waitForTurn() {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  function createDiagnosticsPublisher() {
+    return {
+      current: ["existing-diagnostic"],
+      prepared: [],
+      replacements: [],
+      async prepare(manifests, nodes) {
+        const snapshot = {
+          manifests: manifests.map((manifest) => manifest.filePath),
+          dependencies: nodes.map((node) => node.name),
+        };
+        this.prepared.push(snapshot);
+        return snapshot;
+      },
+      replace(snapshot) {
+        this.current = snapshot;
+        this.replacements.push(snapshot);
+      },
+    };
+  }
+
+  function installScanSteps(provider, steps) {
+    let nextStep = 0;
+    provider._performScan = async function () {
+      const step = steps[nextStep];
+      nextStep += 1;
+      if (!step) {
+        throw new Error("Missing scan test step");
+      }
+
+      if (step.started) {
+        step.started.resolve();
+      }
+      if (step.gate) {
+        await step.gate.promise;
+      }
+
+      const dependency = createFoundDependency(step.name || "dependency", step.version || "1.0.0");
+      const trees = [{
+        ecosystem: "npm",
+        sourceFile: `${step.name || "dependency"}.json`,
+        dependencies: [dependency],
+      }];
+      this._lastManifests = [{
+        filePath: `/${step.name || "dependency"}.json`,
+        format: "npm",
+      }];
+      this._fullTrees = cloneTrees(trees);
+      this._displayTrees = cloneTrees(trees);
+      this._warnings = step.warnings ? step.warnings.slice() : [];
+      this._rebuildSummary();
+      await this._storeReportData(new Date("2026-08-07T12:00:00.000Z"));
+
+      if (step.error) {
+        throw step.error;
+      }
+      if (step.canceled) {
+        return { canceled: true };
+      }
+      return { canceled: false };
+    };
+  }
+
   function buildCoverageIndex(dependencies) {
     const index = new Map();
 
@@ -80,6 +162,310 @@ suite("DependencyHealthProvider Test Suite", () => {
 
   setup(() => {
     DependencyHealthProvider.packageIndexCache.clear();
+    originalWithProgress = vscode.window.withProgress;
+    originalShowInformationMessage = vscode.window.showInformationMessage;
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    originalShowErrorMessage = vscode.window.showErrorMessage;
+
+    vscode.window.withProgress = async (_options, task) => task(
+      { report() {} },
+      {
+        onCancellationRequested() {
+          return { dispose() {} };
+        },
+      }
+    );
+    vscode.window.showInformationMessage = async () => undefined;
+    vscode.window.showWarningMessage = async () => undefined;
+    vscode.window.showErrorMessage = async () => undefined;
+  });
+
+  teardown(() => {
+    vscode.window.withProgress = originalWithProgress;
+    vscode.window.showInformationMessage = originalShowInformationMessage;
+    vscode.window.showWarningMessage = originalShowWarningMessage;
+    vscode.window.showErrorMessage = originalShowErrorMessage;
+  });
+
+  test("starts idle with no successful scan and rescan can fall back to first-scan behavior", async () => {
+    const provider = new DependencyHealthProvider(createContext());
+    let fallbackCalls = 0;
+
+    assert.deepStrictEqual(provider.getScanState(), {
+      status: SCAN_STATES.IDLE,
+      id: 0,
+      startedAt: null,
+      completedAt: null,
+      scope: null,
+      message: null,
+      failureMessage: null,
+      hasSuccessfulScan: false,
+      successfulScope: null,
+    });
+
+    const result = await provider.rescan(async () => {
+      fallbackCalls += 1;
+      return "first-scan";
+    });
+
+    assert.strictEqual(result, "first-scan");
+    assert.strictEqual(fallbackCalls, 1);
+  });
+
+  test("first successful scan atomically commits results, scope, report data, and diagnostics", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    installScanSteps(provider, [{ name: "first-result" }]);
+
+    const result = await provider.scan("workspace-a", "repo-a", "/project-a");
+
+    assert.strictEqual(result.status, SCAN_STATES.SUCCEEDED);
+    assert.strictEqual(provider.dependencies[0].name, "first-result");
+    assert.deepStrictEqual(provider.getLastSuccessfulScope(), {
+      workspace: "workspace-a",
+      repository: "repo-a",
+      projectFolder: "/project-a",
+    });
+    assert.ok(provider.getReportData());
+    assert.strictEqual(provider.getScanState().failureMessage, null);
+    assert.deepStrictEqual(diagnostics.current.dependencies, ["first-result"]);
+    assert.strictEqual(diagnostics.replacements.length, 1);
+  });
+
+  test("first scan failure publishes neither partial results nor diagnostics", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    installScanSteps(provider, [{ name: "partial-result", error: new Error("index unavailable") }]);
+
+    const result = await provider.scan("workspace-a", null, "/project-a");
+
+    assert.strictEqual(result.status, SCAN_STATES.FAILED);
+    assert.strictEqual(provider.dependencies.length, 0);
+    assert.strictEqual(provider.hasSuccessfulScan(), false);
+    assert.strictEqual(provider.getLastSuccessfulScope(), null);
+    assert.deepStrictEqual(diagnostics.current, ["existing-diagnostic"]);
+    assert.strictEqual(diagnostics.replacements.length, 0);
+    const nodes = await provider.getChildren();
+    assert.strictEqual(nodes[0].getTreeItem().label, "Dependency scan failed");
+  });
+
+  test("first scan cancellation publishes neither partial results nor diagnostics", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    installScanSteps(provider, [{ name: "partial-result", canceled: true }]);
+
+    const result = await provider.scan("workspace-a", null, "/project-a");
+
+    assert.strictEqual(result.status, SCAN_STATES.CANCELLED);
+    assert.strictEqual(provider.dependencies.length, 0);
+    assert.strictEqual(provider.hasSuccessfulScan(), false);
+    assert.deepStrictEqual(diagnostics.current, ["existing-diagnostic"]);
+    const nodes = await provider.getChildren();
+    assert.strictEqual(nodes[0].getTreeItem().label, "Dependency scan canceled");
+  });
+
+  test("successful rescan leaves prior results visible while running and replaces them on commit", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    const refreshStarted = deferred();
+    const refreshGate = deferred();
+    installScanSteps(provider, [
+      { name: "old-result" },
+      { name: "new-result", started: refreshStarted, gate: refreshGate },
+    ]);
+
+    await provider.scan("workspace-a", "repo-a", "/project-a");
+    const refreshPromise = provider.rescan();
+    await refreshStarted.promise;
+
+    assert.strictEqual(provider.dependencies[0].name, "old-result");
+    assert.strictEqual(provider.getScanState().status, SCAN_STATES.RUNNING);
+    const runningNodes = await provider.getChildren();
+    assert.strictEqual(runningNodes[0].getTreeItem().label, "Refreshing dependencies");
+    assert.strictEqual(diagnostics.current.dependencies[0], "old-result");
+
+    refreshGate.resolve();
+    const result = await refreshPromise;
+
+    assert.strictEqual(result.status, SCAN_STATES.SUCCEEDED);
+    assert.strictEqual(provider.dependencies[0].name, "new-result");
+    assert.strictEqual(diagnostics.current.dependencies[0], "new-result");
+    assert.strictEqual(provider.isScanRunning(), false);
+  });
+
+  test("failed rescan preserves prior results, diagnostics, and successful scope", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    installScanSteps(provider, [
+      { name: "known-good" },
+      { name: "partial-replacement", error: new Error("refresh failed") },
+    ]);
+
+    await provider.scan("workspace-a", "repo-a", "/project-a");
+    const priorDiagnostics = diagnostics.current;
+    const result = await provider.scan("workspace-b", "repo-b", "/project-b");
+
+    assert.strictEqual(result.status, SCAN_STATES.FAILED);
+    assert.strictEqual(provider.dependencies[0].name, "known-good");
+    assert.deepStrictEqual(provider.getLastSuccessfulScope(), {
+      workspace: "workspace-a",
+      repository: "repo-a",
+      projectFolder: "/project-a",
+    });
+    assert.strictEqual(diagnostics.current, priorDiagnostics);
+    assert.strictEqual(diagnostics.replacements.length, 1);
+    const nodes = await provider.getChildren();
+    assert.strictEqual(nodes[0].getTreeItem().label, "Dependency refresh failed");
+    assert.ok(nodes.length > 1);
+    assert.strictEqual(provider.isScanRunning(), false);
+  });
+
+  test("scope change can select a different project folder without mutating successful scope", async () => {
+    const originalShowQuickPick = vscode.window.showQuickPick;
+    const originalShowOpenDialog = vscode.window.showOpenDialog;
+    vscode.window.showQuickPick = async (items) => items.find((item) => item.browse);
+    vscode.window.showOpenDialog = async () => [{ fsPath: "/project-b" }];
+
+    try {
+      const provider = new DependencyHealthProvider(createContext(), createDiagnosticsPublisher());
+      installScanSteps(provider, [{ name: "known-good" }]);
+      await provider.scan("workspace-a", "repo-a", "/project-a");
+
+      const selectedFolder = await provider.selectProjectFolder();
+
+      assert.strictEqual(selectedFolder, "/project-b");
+      assert.strictEqual(provider.getLastSuccessfulScope().projectFolder, "/project-a");
+    } finally {
+      vscode.window.showQuickPick = originalShowQuickPick;
+      vscode.window.showOpenDialog = originalShowOpenDialog;
+    }
+  });
+
+  test("cancelled rescan preserves prior results and diagnostics", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    installScanSteps(provider, [
+      { name: "known-good" },
+      { name: "partial-replacement", canceled: true },
+    ]);
+
+    await provider.scan("workspace-a", "repo-a", "/project-a");
+    const priorDiagnostics = diagnostics.current;
+    const result = await provider.rescan();
+
+    assert.strictEqual(result.status, SCAN_STATES.CANCELLED);
+    assert.strictEqual(provider.dependencies[0].name, "known-good");
+    assert.strictEqual(diagnostics.current, priorDiagnostics);
+    assert.strictEqual(diagnostics.replacements.length, 1);
+    assert.strictEqual(provider.isScanRunning(), false);
+  });
+
+  test("successful retry clears the failed operation state", async () => {
+    const provider = new DependencyHealthProvider(createContext(), createDiagnosticsPublisher());
+    installScanSteps(provider, [
+      { name: "partial", error: new Error("temporary failure") },
+      { name: "retry-result" },
+    ]);
+
+    await provider.scan("workspace-a", null, "/project-a");
+    assert.strictEqual(provider.getScanState().status, SCAN_STATES.FAILED);
+    assert.match(provider.getScanState().failureMessage, /temporary failure/);
+
+    await provider.scan("workspace-a", null, "/project-a");
+
+    assert.strictEqual(provider.getScanState().status, SCAN_STATES.SUCCEEDED);
+    assert.strictEqual(provider.getScanState().failureMessage, null);
+    assert.strictEqual(provider.dependencies[0].name, "retry-result");
+  });
+
+  test("a superseded scan cannot overwrite a newer scan that finishes first", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    const firstStarted = deferred();
+    const firstGate = deferred();
+    const secondStarted = deferred();
+    const secondGate = deferred();
+    installScanSteps(provider, [
+      { name: "scan-a", started: firstStarted, gate: firstGate },
+      { name: "scan-b", started: secondStarted, gate: secondGate },
+    ]);
+
+    const firstPromise = provider.scan("workspace-a", "repo-a", "/project-a");
+    await firstStarted.promise;
+    const secondPromise = provider.scan("workspace-b", "repo-b", "/project-b");
+    await secondStarted.promise;
+
+    secondGate.resolve();
+    assert.strictEqual((await secondPromise).status, SCAN_STATES.SUCCEEDED);
+    firstGate.resolve();
+    assert.strictEqual((await firstPromise).status, "superseded");
+
+    assert.strictEqual(provider.dependencies[0].name, "scan-b");
+    assert.strictEqual(provider.lastWorkspace, "workspace-b");
+    assert.deepStrictEqual(diagnostics.current.dependencies, ["scan-b"]);
+    assert.strictEqual(diagnostics.replacements.length, 1);
+  });
+
+  test("a superseded scan that finishes first cannot publish before the active scan", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    const firstStarted = deferred();
+    const firstGate = deferred();
+    const secondStarted = deferred();
+    const secondGate = deferred();
+    installScanSteps(provider, [
+      { name: "scan-a", started: firstStarted, gate: firstGate },
+      { name: "scan-b", started: secondStarted, gate: secondGate },
+    ]);
+
+    const firstPromise = provider.scan("workspace-a", "repo-a", "/project-a");
+    await firstStarted.promise;
+    const secondPromise = provider.scan("workspace-b", "repo-b", "/project-b");
+    await secondStarted.promise;
+
+    firstGate.resolve();
+    assert.strictEqual((await firstPromise).status, "superseded");
+    assert.strictEqual(diagnostics.replacements.length, 0);
+    assert.strictEqual(provider.dependencies.length, 0);
+
+    secondGate.resolve();
+    assert.strictEqual((await secondPromise).status, SCAN_STATES.SUCCEEDED);
+    assert.strictEqual(provider.dependencies[0].name, "scan-b");
+    assert.deepStrictEqual(diagnostics.current.dependencies, ["scan-b"]);
+  });
+
+  test("scan context keys expose running and successful state without impossible combinations", async () => {
+    const originalExecuteCommand = vscode.commands.executeCommand;
+    const contextValues = new Map();
+    const scanStarted = deferred();
+    const scanGate = deferred();
+    vscode.commands.executeCommand = async (command, key, value) => {
+      if (command === "setContext") {
+        contextValues.set(key, value);
+      }
+    };
+
+    try {
+      const provider = new DependencyHealthProvider(createContext(), createDiagnosticsPublisher());
+      installScanSteps(provider, [{ name: "result", started: scanStarted, gate: scanGate }]);
+      await provider._updateContexts();
+      assert.strictEqual(contextValues.get("cloudsmith.depScanRunning"), false);
+      assert.strictEqual(contextValues.get("cloudsmith.depScanSucceeded"), false);
+
+      const scanPromise = provider.scan("workspace-a", null, "/project-a");
+      await scanStarted.promise;
+      assert.strictEqual(contextValues.get("cloudsmith.depScanRunning"), true);
+      assert.strictEqual(contextValues.get("cloudsmith.depScanSucceeded"), false);
+
+      scanGate.resolve();
+      await scanPromise;
+      await waitForTurn();
+      assert.strictEqual(contextValues.get("cloudsmith.depScanRunning"), false);
+      assert.strictEqual(contextValues.get("cloudsmith.depScanSucceeded"), true);
+      assert.strictEqual(contextValues.get("cloudsmith.depScanComplete"), true);
+    } finally {
+      vscode.commands.executeCommand = originalExecuteCommand;
+    }
   });
 
   test("getChildren() shows the signed-out state when disconnected before the first scan", async () => {

--- a/test/diagnosticsPublisher.test.js
+++ b/test/diagnosticsPublisher.test.js
@@ -1,0 +1,94 @@
+const assert = require("assert");
+const vscode = require("vscode");
+const { DiagnosticsPublisher } = require("../util/diagnosticsPublisher");
+const { ManifestParser } = require("../util/manifestParser");
+
+suite("DiagnosticsPublisher Test Suite", () => {
+  let originalCreateDiagnosticCollection;
+  let originalFindDependencyLocation;
+  let collection;
+
+  setup(() => {
+    originalCreateDiagnosticCollection = vscode.languages.createDiagnosticCollection;
+    originalFindDependencyLocation = ManifestParser.findDependencyLocation;
+    collection = {
+      setCalls: [],
+      clearCalls: 0,
+      set(entries) {
+        this.setCalls.push(entries);
+      },
+      clear() {
+        this.clearCalls += 1;
+      },
+      dispose() {},
+    };
+    vscode.languages.createDiagnosticCollection = () => collection;
+  });
+
+  teardown(() => {
+    vscode.languages.createDiagnosticCollection = originalCreateDiagnosticCollection;
+    ManifestParser.findDependencyLocation = originalFindDependencyLocation;
+  });
+
+  test("prepare builds a complete snapshot without clearing or publishing current diagnostics", async () => {
+    ManifestParser.findDependencyLocation = async () => ({
+      line: 1,
+      startChar: 2,
+      endChar: 10,
+    });
+    const publisher = new DiagnosticsPublisher();
+
+    const entries = await publisher.prepare(
+      [{ filePath: "/project/package.json", format: "npm" }],
+      [{
+        format: "npm",
+        state: "not_found",
+        name: "left-pad",
+        declaredVersion: "1.0.0",
+        cloudsmithMatch: null,
+      }]
+    );
+
+    assert.strictEqual(collection.clearCalls, 0);
+    assert.strictEqual(collection.setCalls.length, 0);
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0][0].fsPath, "/project/package.json");
+    assert.strictEqual(entries[0][1].length, 1);
+
+    publisher.replace(entries);
+    assert.strictEqual(collection.setCalls.length, 1);
+    assert.strictEqual(collection.setCalls[0], entries);
+  });
+
+  test("a failed diagnostic build cannot publish a partial replacement", async () => {
+    let locationCalls = 0;
+    ManifestParser.findDependencyLocation = async () => {
+      locationCalls += 1;
+      if (locationCalls === 2) {
+        throw new Error("manifest read failed");
+      }
+      return { line: 0, startChar: 0, endChar: 4 };
+    };
+    const publisher = new DiagnosticsPublisher();
+
+    await assert.rejects(
+      publisher.publish(
+        [
+          { filePath: "/project/package.json", format: "npm" },
+          { filePath: "/project/other-package.json", format: "npm" },
+        ],
+        [{
+          format: "npm",
+          state: "not_found",
+          name: "left-pad",
+          declaredVersion: "1.0.0",
+          cloudsmithMatch: null,
+        }]
+      ),
+      /manifest read failed/
+    );
+
+    assert.strictEqual(collection.clearCalls, 0);
+    assert.strictEqual(collection.setCalls.length, 0);
+  });
+});

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,5 +1,7 @@
 const assert = require("assert");
-const { FORMAT_OPTIONS } = require("../extension");
+const fs = require("fs");
+const path = require("path");
+const { FORMAT_OPTIONS, runDependencyScan } = require("../extension");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
 
 suite("Extension Test Suite", () => {
@@ -8,5 +10,88 @@ suite("Extension Test Suite", () => {
     assert.ok(FORMAT_OPTIONS.includes("conan"));
     assert.ok(FORMAT_OPTIONS.includes("terraform"));
     assert.ok(FORMAT_OPTIONS.includes("raw"));
+  });
+
+  test("primary dependency scan command establishes scope on first use", async () => {
+    const calls = [];
+    const provider = {
+      hasSuccessfulScan() {
+        return false;
+      },
+      async scan(workspace, repo) {
+        calls.push({ workspace, repo });
+        return "scanned";
+      },
+    };
+
+    const result = await runDependencyScan(provider, async () => ({
+      scanWorkspace: "workspace-a",
+      scanRepo: "repo-a",
+    }));
+
+    assert.strictEqual(result, "scanned");
+    assert.deepStrictEqual(calls, [{ workspace: "workspace-a", repo: "repo-a" }]);
+  });
+
+  test("primary dependency scan command reuses successful scope on repeat use", async () => {
+    let initialTargetCalls = 0;
+    let rescanCalls = 0;
+    const provider = {
+      hasSuccessfulScan() {
+        return true;
+      },
+      async rescan() {
+        rescanCalls += 1;
+        return "rescanned";
+      },
+    };
+
+    const result = await runDependencyScan(provider, async () => {
+      initialTargetCalls += 1;
+      return { scanWorkspace: "unused", scanRepo: null };
+    });
+
+    assert.strictEqual(result, "rescanned");
+    assert.strictEqual(rescanCalls, 1);
+    assert.strictEqual(initialTargetCalls, 0);
+  });
+
+  test("dependency health title exposes one Scan dependencies action", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
+    const scanCommands = manifest.contributes.commands.filter((entry) => (
+      entry.command === "cloudsmith-vsc.scanDependencies"
+      || entry.command === "cloudsmith-vsc.scanDependenciesPending"
+      || entry.command === "cloudsmith-vsc.scanDependenciesComplete"
+    ));
+    const titleScanCommands = manifest.contributes.menus["view/title"].filter((entry) => (
+      entry.command === "cloudsmith-vsc.scanDependencies"
+      || entry.command === "cloudsmith-vsc.scanDependenciesPending"
+      || entry.command === "cloudsmith-vsc.scanDependenciesComplete"
+    ));
+
+    assert.deepStrictEqual(scanCommands.map((entry) => entry.command), ["cloudsmith-vsc.scanDependencies"]);
+    assert.strictEqual(scanCommands[0].title, "Scan dependencies");
+    assert.deepStrictEqual(titleScanCommands, [{
+      command: "cloudsmith-vsc.scanDependencies",
+      group: "navigation@1",
+      when: "view == cloudsmithDependencyHealthView && !cloudsmith.depOperationRunning",
+    }]);
+
+    const changeScopeEntry = manifest.contributes.menus["view/title"].find(
+      (entry) => entry.command === "cloudsmith-vsc.changeDependencyScanScope"
+    );
+    assert.deepStrictEqual(changeScopeEntry, {
+      command: "cloudsmith-vsc.changeDependencyScanScope",
+      group: "navigation@1.5",
+      when: "view == cloudsmithDependencyHealthView && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning",
+    });
+  });
+
+  test("historical rescan command IDs remain registered as primary-scan aliases", () => {
+    const source = fs.readFileSync(path.join(__dirname, "..", "extension.js"), "utf8");
+
+    assert.match(source, /registerCommand\("cloudsmith-vsc\.scanDependenciesComplete"/);
+    assert.match(source, /registerCommand\("cloudsmith-vsc\.rescanDependencies"/);
+    assert.match(source, /executeCommand\("cloudsmith-vsc\.scanDependencies"\)/);
   });
 });

--- a/test/licenseClassifier.test.js
+++ b/test/licenseClassifier.test.js
@@ -102,6 +102,57 @@ suite("LicenseClassifier Test Suite", () => {
       const result = LicenseClassifier.classify("(MIT OR Apache-2.0) AND GPL-3.0");
       assert.strictEqual(result.tier, "restrictive");
     });
+
+    test("mixed AND and OR operators preserve every identifier", () => {
+      const inspection = LicenseClassifier.inspect("MIT AND Apache-2.0 OR BSD-3-Clause");
+      assert.deepStrictEqual(inspection.identifiers, ["MIT", "Apache-2.0", "BSD-3-Clause"]);
+      assert.strictEqual(inspection.tier, "permissive");
+    });
+
+    test("operators surrounded by multiple spaces are recognized", () => {
+      const inspection = LicenseClassifier.inspect("MIT   OR   GPL-3.0");
+      assert.deepStrictEqual(inspection.identifiers, ["MIT", "GPL-3.0"]);
+      assert.strictEqual(inspection.tier, "restrictive");
+    });
+
+    test("operators surrounded by tabs are recognized", () => {
+      const inspection = LicenseClassifier.inspect("MIT\tAND\tLGPL-3.0");
+      assert.deepStrictEqual(inspection.identifiers, ["MIT", "LGPL-3.0"]);
+      assert.strictEqual(inspection.tier, "cautious");
+    });
+
+    test("operators surrounded by newlines are recognized", () => {
+      const inspection = LicenseClassifier.inspect("MIT\nOR\nGPL-3.0");
+      assert.deepStrictEqual(inspection.identifiers, ["MIT", "GPL-3.0"]);
+      assert.strictEqual(inspection.tier, "restrictive");
+    });
+
+    test("lowercase operators are recognized", () => {
+      const inspection = LicenseClassifier.inspect("MIT and Apache-2.0 or GPL-3.0");
+      assert.deepStrictEqual(inspection.identifiers, ["MIT", "Apache-2.0", "GPL-3.0"]);
+      assert.strictEqual(inspection.tier, "restrictive");
+    });
+
+    test("malformed operators without whitespace boundaries are not split", () => {
+      const license = "MIT ORGPL-3.0";
+      const inspection = LicenseClassifier.inspect(license);
+      assert.deepStrictEqual(inspection.identifiers, [license]);
+      assert.strictEqual(inspection.tier, "unknown");
+    });
+
+    test("license identifiers containing AND or OR letter sequences are not split", () => {
+      const license = "LicenseRef-STANDARD-OR-Clause";
+      const inspection = LicenseClassifier.inspect(license);
+      assert.deepStrictEqual(inspection.identifiers, [license]);
+      assert.strictEqual(inspection.tier, "unknown");
+    });
+
+    test("very long whitespace-heavy malformed input is scanned without partial splitting", () => {
+      const license = `MIT${" ".repeat(25000)}O`;
+      const inspection = LicenseClassifier.inspect(license);
+      assert.deepStrictEqual(inspection.identifiers, [license]);
+      assert.strictEqual(inspection.tier, "unknown");
+    });
   });
 
   // =====================

--- a/util/diagnosticsPublisher.js
+++ b/util/diagnosticsPublisher.js
@@ -11,16 +11,14 @@ class DiagnosticsPublisher {
   }
 
   /**
-   * Publish diagnostics for scanned dependencies on their manifest files.
+   * Build diagnostics for scanned dependencies without changing the published collection.
    *
    * @param {Array<{filePath: string, format: string}>} manifests
    *        Manifest files detected during the scan.
    * @param {Array} dependencies
    *        DependencyHealthNode instances from the scan.
    */
-  async publish(manifests, dependencies) {
-    this.clear();
-
+  async prepare(manifests, dependencies) {
     // Group dependencies by their format to match to the right manifest
     const depsByFormat = {};
     for (const dep of dependencies) {
@@ -30,6 +28,8 @@ class DiagnosticsPublisher {
       }
       depsByFormat[format].push(dep);
     }
+
+    const entries = [];
 
     // For each manifest, find problematic deps and create diagnostics
     for (const manifest of manifests) {
@@ -78,10 +78,21 @@ class DiagnosticsPublisher {
         diagnostics.push(diagnostic);
       }
 
-      if (diagnostics.length > 0) {
-        this.collection.set(vscode.Uri.file(manifest.filePath), diagnostics);
-      }
+      entries.push([vscode.Uri.file(manifest.filePath), diagnostics]);
     }
+
+    return entries;
+  }
+
+  /** Replace the published diagnostic snapshot in one collection update. */
+  replace(entries) {
+    this.collection.set(entries);
+  }
+
+  /** Build and publish a complete diagnostic snapshot. */
+  async publish(manifests, dependencies) {
+    const entries = await this.prepare(manifests, dependencies);
+    this.replace(entries);
   }
 
   /**

--- a/util/licenseClassifier.js
+++ b/util/licenseClassifier.js
@@ -3,6 +3,34 @@
 
 const vscode = require("vscode");
 
+function isExpressionWhitespace(character) {
+  return character.trim() === "";
+}
+
+function matchesAsciiLetter(value, index, uppercaseLetter, lowercaseLetter) {
+  const character = value[index];
+  return character === uppercaseLetter || character === lowercaseLetter;
+}
+
+function getCompoundOperatorLength(value, index) {
+  if (
+    matchesAsciiLetter(value, index, "O", "o")
+    && matchesAsciiLetter(value, index + 1, "R", "r")
+  ) {
+    return 2;
+  }
+
+  if (
+    matchesAsciiLetter(value, index, "A", "a")
+    && matchesAsciiLetter(value, index + 1, "N", "n")
+    && matchesAsciiLetter(value, index + 2, "D", "d")
+  ) {
+    return 3;
+  }
+
+  return 0;
+}
+
 class LicenseClassifier {
   static SPDX_LICENSE_BASE_URL = "https://spdx.org/licenses";
 
@@ -138,7 +166,7 @@ class LicenseClassifier {
       return [];
     }
 
-    const parts = normalized.split(/\s+OR\s+|\s+AND\s+/i);
+    const parts = LicenseClassifier._splitCompoundExpression(normalized);
     const identifiers = [];
     const seen = new Set();
 
@@ -151,6 +179,50 @@ class LicenseClassifier {
     }
 
     return identifiers;
+  }
+
+  /**
+   * Split AND/OR operators surrounded by whitespace in one pass.
+   *
+   * @param   {string} expression
+   * @returns {string[]}
+   */
+  static _splitCompoundExpression(expression) {
+    const parts = [];
+    let partStart = 0;
+    let index = 0;
+
+    while (index < expression.length) {
+      if (!isExpressionWhitespace(expression[index])) {
+        index += 1;
+        continue;
+      }
+
+      const separatorStart = index;
+      while (index < expression.length && isExpressionWhitespace(expression[index])) {
+        index += 1;
+      }
+
+      const operatorLength = getCompoundOperatorLength(expression, index);
+      const afterOperator = index + operatorLength;
+      if (
+        operatorLength === 0
+        || afterOperator >= expression.length
+        || !isExpressionWhitespace(expression[afterOperator])
+      ) {
+        continue;
+      }
+
+      parts.push(expression.slice(partStart, separatorStart));
+      index = afterOperator;
+      while (index < expression.length && isExpressionWhitespace(expression[index])) {
+        index += 1;
+      }
+      partStart = index;
+    }
+
+    parts.push(expression.slice(partStart));
+    return parts;
   }
 
   /**

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -59,6 +59,15 @@ const SORT_MODES = Object.freeze({
 
 const VIEW_MODES = ["direct", "flat", "tree"];
 
+const SCAN_STATES = Object.freeze({
+  IDLE: "idle",
+  SELECTING: "selecting",
+  RUNNING: "running",
+  SUCCEEDED: "succeeded",
+  FAILED: "failed",
+  CANCELLED: "cancelled",
+});
+
 class DependencyHealthProvider {
   constructor(context, diagnosticsPublisher, options = {}) {
     this.context = context;
@@ -68,7 +77,7 @@ class DependencyHealthProvider {
       enrichLicenses: options.enrichLicenses || enrichLicenses,
       enrichPolicies: options.enrichPolicies || enrichPolicies,
       analyzeUpstreamGaps: options.analyzeUpstreamGaps || analyzeUpstreamGaps,
-      fetchRepositories: options.fetchRepositories || this._fetchWorkspaceRepositories.bind(this),
+      fetchRepositories: options.fetchRepositories || null,
       upstreamPullService: options.upstreamPullService || new UpstreamPullService(context),
     };
     this._reportDateFactory = typeof options.reportDateFactory === "function"
@@ -79,13 +88,9 @@ class DependencyHealthProvider {
     this.dependencies = [];
     this.lastWorkspace = null;
     this.lastRepo = null;
-    this._scanning = false;
-    this._statusMessage = null;
-    this._failureMessage = null;
     this._warnings = [];
     this._lastManifests = [];
     this._projectFolderPath = null;
-    this._hasScannedOnce = false;
     this._noManifestsFolder = null;
     this._fullTrees = [];
     this._displayTrees = [];
@@ -95,6 +100,11 @@ class DependencyHealthProvider {
     this._filterMode = null;
     this._reportData = null;
     this._lastScanTimestamp = null;
+    this._nextScanOperationId = 0;
+    this._activeScanCancellation = null;
+    this._dependencyOperationRunning = false;
+    this._scanOperation = createScanOperation(SCAN_STATES.IDLE, 0);
+    this._hasSuccessfulScan = false;
 
     if (this.context && this.context.secrets && typeof this.context.secrets.onDidChange === "function") {
       this.context.secrets.onDidChange((event) => {
@@ -118,11 +128,48 @@ class DependencyHealthProvider {
   }
 
   async _updateContexts() {
+    const scanRunning = this.isScanRunning();
     await vscode.commands.executeCommand("setContext", "cloudsmith.depView", this._viewMode);
     await vscode.commands.executeCommand("setContext", "cloudsmith.depViewMode", this._viewMode);
     await vscode.commands.executeCommand("setContext", "cloudsmith.depFilterActive", Boolean(this._filterMode));
-    await vscode.commands.executeCommand("setContext", "cloudsmith.depScanComplete", Boolean(this._reportData));
+    await vscode.commands.executeCommand("setContext", "cloudsmith.depScanComplete", this._hasSuccessfulScan);
+    await vscode.commands.executeCommand("setContext", "cloudsmith.depScanSucceeded", this._hasSuccessfulScan);
+    await vscode.commands.executeCommand("setContext", "cloudsmith.depScanRunning", scanRunning);
+    await vscode.commands.executeCommand(
+      "setContext",
+      "cloudsmith.depOperationRunning",
+      scanRunning || this._dependencyOperationRunning
+    );
     await vscode.commands.executeCommand("setContext", "cloudsmith.depRepoSelected", Boolean(this.lastRepo));
+  }
+
+  hasSuccessfulScan() {
+    return this._hasSuccessfulScan;
+  }
+
+  isScanRunning() {
+    return this._scanOperation.status === SCAN_STATES.SELECTING
+      || this._scanOperation.status === SCAN_STATES.RUNNING;
+  }
+
+  getScanState() {
+    return {
+      ...this._scanOperation,
+      hasSuccessfulScan: this._hasSuccessfulScan,
+      successfulScope: this.getLastSuccessfulScope(),
+    };
+  }
+
+  getLastSuccessfulScope() {
+    if (!this._hasSuccessfulScan) {
+      return null;
+    }
+
+    return {
+      workspace: this.lastWorkspace,
+      repository: this.lastRepo,
+      projectFolder: this._projectFolderPath,
+    };
   }
 
   async setViewMode(mode) {
@@ -201,10 +248,6 @@ class DependencyHealthProvider {
     return folders && folders[0] ? folders[0].uri.fsPath : null;
   }
 
-  setProjectFolder(folderPath) {
-    this._projectFolderPath = folderPath;
-  }
-
   async promptForFolder() {
     const choice = await vscode.window.showQuickPick(
       [
@@ -242,40 +285,105 @@ class DependencyHealthProvider {
       return null;
     }
 
-    this._projectFolderPath = selected[0].fsPath;
-    return this._projectFolderPath;
+    return selected[0].fsPath;
+  }
+
+  async selectProjectFolder() {
+    const foldersByPath = new Map();
+    for (const folder of vscode.workspace.workspaceFolders || []) {
+      foldersByPath.set(folder.uri.fsPath, {
+        label: folder.name || path.basename(folder.uri.fsPath),
+        description: folder.uri.fsPath,
+        folderPath: folder.uri.fsPath,
+      });
+    }
+
+    if (this._projectFolderPath && !foldersByPath.has(this._projectFolderPath)) {
+      foldersByPath.set(this._projectFolderPath, {
+        label: path.basename(this._projectFolderPath),
+        description: this._projectFolderPath,
+        folderPath: this._projectFolderPath,
+      });
+    }
+
+    const selected = await vscode.window.showQuickPick(
+      [
+        ...foldersByPath.values(),
+        {
+          label: "$(folder-opened) Browse for a project folder",
+          description: "Select a folder outside the open workspace",
+          browse: true,
+        },
+      ],
+      { placeHolder: "Select a project folder to scan" }
+    );
+
+    if (!selected) {
+      return null;
+    }
+    if (!selected.browse) {
+      return selected.folderPath;
+    }
+
+    const pickedFolders = await vscode.window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+      openLabel: "Select project folder",
+    });
+    return pickedFolders && pickedFolders[0] ? pickedFolders[0].fsPath : null;
   }
 
   async scan(cloudsmithWorkspace, cloudsmithRepo, projectFolder) {
-    if (this._scanning) {
-      vscode.window.showWarningMessage("A dependency scan is already in progress.");
-      return;
+    if (this._dependencyOperationRunning) {
+      vscode.window.showWarningMessage("Wait for the current dependency operation to finish.");
+      return { status: "blocked" };
     }
+
+    const operationId = ++this._nextScanOperationId;
+    const previousCancellation = this._activeScanCancellation;
+    if (previousCancellation) {
+      previousCancellation.cancel();
+    }
+
+    this._scanOperation = createScanOperation(SCAN_STATES.SELECTING, operationId, {
+      startedAt: Date.now(),
+      scope: {
+        workspace: cloudsmithWorkspace,
+        repository: cloudsmithRepo || null,
+        projectFolder: projectFolder || null,
+      },
+    });
+    await this._updateContexts();
+    this.refresh();
 
     let folderPath = projectFolder || this.getProjectFolder();
     if (!folderPath) {
       folderPath = await this.promptForFolder();
+      if (!this._isCurrentScan(operationId)) {
+        return { status: "superseded" };
+      }
       if (!folderPath) {
-        return;
+        await this._finishCancelledScan(operationId);
+        return { status: SCAN_STATES.CANCELLED };
       }
     }
 
-    this._scanning = true;
-    this._hasScannedOnce = true;
-    this.lastWorkspace = cloudsmithWorkspace;
-    this.lastRepo = cloudsmithRepo;
-    this._reportData = null;
-    this._failureMessage = null;
-    this._warnings = [];
-    this._noManifestsFolder = null;
-    this._statusMessage = "Parsing lockfiles...";
-    this._displayTrees = [];
-    this._fullTrees = [];
-    this._summary = emptySummary();
+    const scope = {
+      workspace: cloudsmithWorkspace,
+      repository: cloudsmithRepo || null,
+      projectFolder: folderPath,
+    };
+    this._scanOperation = createScanOperation(SCAN_STATES.RUNNING, operationId, {
+      startedAt: this._scanOperation.startedAt,
+      scope,
+    });
     await this._updateContexts();
     this.refresh();
 
     const cancellationSource = new vscode.CancellationTokenSource();
+    this._activeScanCancellation = cancellationSource;
+    const scanWorker = this._createScanWorker(scope);
 
     try {
       const result = await vscode.window.withProgress(
@@ -287,7 +395,7 @@ class DependencyHealthProvider {
         async (progress, token) => {
           const subscription = token.onCancellationRequested(() => cancellationSource.cancel());
           try {
-            return await this._performScan(
+            return await scanWorker._performScan(
               cloudsmithWorkspace,
               cloudsmithRepo,
               folderPath,
@@ -300,30 +408,147 @@ class DependencyHealthProvider {
         }
       );
 
-      if (result && result.canceled) {
-        this._statusMessage = null;
-        if (this._diagnosticsPublisher) {
-          this._diagnosticsPublisher.clear();
-        }
+      if (!this._isCurrentScan(operationId)) {
+        return { status: "superseded" };
+      }
+
+      if ((result && result.canceled) || cancellationSource.token.isCancellationRequested) {
+        await this._finishCancelledScan(operationId);
         vscode.window.showInformationMessage("Dependency scan canceled.");
+        return { status: SCAN_STATES.CANCELLED };
       }
-    } catch (error) {
-      const reason = error && error.message ? error.message : "Check the Cloudsmith connection.";
-      this._displayTrees = [];
-      this._fullTrees = [];
-      this._summary = emptySummary();
+
+      const preparedDiagnostics = await this._prepareDiagnostics(scanWorker);
+      if (!this._isCurrentScan(operationId)) {
+        return { status: "superseded" };
+      }
+
+      if (cancellationSource.token.isCancellationRequested) {
+        await this._finishCancelledScan(operationId);
+        vscode.window.showInformationMessage("Dependency scan canceled.");
+        return { status: SCAN_STATES.CANCELLED };
+      }
+
       if (this._diagnosticsPublisher) {
-        this._diagnosticsPublisher.clear();
+        this._diagnosticsPublisher.replace(preparedDiagnostics);
       }
-      this._statusMessage = null;
-      this._failureMessage = `Scan failed. ${reason}`;
-      vscode.window.showErrorMessage(this._failureMessage);
-    } finally {
-      cancellationSource.dispose();
-      this._scanning = false;
+      this._commitSuccessfulScan(scanWorker, scope, operationId);
       await this._updateContexts();
       this.refresh();
+      return { status: SCAN_STATES.SUCCEEDED };
+    } catch (error) {
+      if (!this._isCurrentScan(operationId)) {
+        return { status: "superseded" };
+      }
+
+      if (cancellationSource.token.isCancellationRequested) {
+        await this._finishCancelledScan(operationId);
+        vscode.window.showInformationMessage("Dependency scan canceled.");
+        return { status: SCAN_STATES.CANCELLED };
+      }
+
+      const reason = error && error.message ? error.message : "Check the Cloudsmith connection.";
+      const message = this._hasSuccessfulScan
+        ? `Dependency refresh failed. Previous scan results are still available. ${reason}`
+        : `Dependency scan failed. ${reason}`;
+      this._scanOperation = createScanOperation(SCAN_STATES.FAILED, operationId, {
+        startedAt: this._scanOperation.startedAt,
+        completedAt: Date.now(),
+        failureMessage: message,
+        scope,
+      });
+      await this._updateContexts();
+      this.refresh();
+      if (this._hasSuccessfulScan) {
+        vscode.window.showWarningMessage(message);
+      } else {
+        vscode.window.showErrorMessage(message);
+      }
+      return { status: SCAN_STATES.FAILED, error };
+    } finally {
+      cancellationSource.dispose();
+      if (this._activeScanCancellation === cancellationSource) {
+        this._activeScanCancellation = null;
+      }
     }
+  }
+
+  _isCurrentScan(operationId) {
+    return this._scanOperation.id === operationId;
+  }
+
+  _createScanWorker(scope) {
+    // Reuse the scan pipeline while giving the operation its own mutable result fields.
+    // Nothing copied from this worker becomes visible until _commitSuccessfulScan runs.
+    const worker = Object.create(this);
+    worker.dependencies = [];
+    worker.lastWorkspace = scope.workspace;
+    worker.lastRepo = scope.repository;
+    worker._warnings = [];
+    worker._lastManifests = [];
+    worker._projectFolderPath = scope.projectFolder;
+    worker._noManifestsFolder = null;
+    worker._fullTrees = [];
+    worker._displayTrees = [];
+    worker._summary = emptySummary();
+    worker._reportData = null;
+    worker._lastScanTimestamp = null;
+    worker._statusMessage = "Parsing lockfiles...";
+    worker._diagnosticsPublisher = null;
+    worker._updateContexts = async () => {};
+    worker.refresh = () => {};
+    return worker;
+  }
+
+  async _finishCancelledScan(operationId) {
+    if (!this._isCurrentScan(operationId)) {
+      return;
+    }
+
+    const currentOperation = this._scanOperation;
+    this._scanOperation = createScanOperation(SCAN_STATES.CANCELLED, operationId, {
+      startedAt: currentOperation.startedAt,
+      completedAt: Date.now(),
+      scope: currentOperation.scope,
+      message: this._hasSuccessfulScan
+        ? "Dependency refresh canceled. Previous scan results are shown."
+        : "Dependency scan canceled.",
+    });
+    await this._updateContexts();
+    this.refresh();
+  }
+
+  _commitSuccessfulScan(scanWorker, scope, operationId) {
+    this.lastWorkspace = scope.workspace;
+    this.lastRepo = scope.repository;
+    this._warnings = scanWorker._warnings;
+    this._lastManifests = scanWorker._lastManifests;
+    this._projectFolderPath = scope.projectFolder;
+    this._noManifestsFolder = scanWorker._noManifestsFolder;
+    this._fullTrees = scanWorker._fullTrees;
+    this._displayTrees = scanWorker._displayTrees;
+    this._reportData = scanWorker._reportData;
+    this._lastScanTimestamp = scanWorker._lastScanTimestamp;
+    this._rebuildSummary();
+    this._hasSuccessfulScan = true;
+    this._scanOperation = createScanOperation(SCAN_STATES.SUCCEEDED, operationId, {
+      startedAt: this._scanOperation.startedAt,
+      completedAt: Date.now(),
+      scope,
+    });
+  }
+
+  async _prepareDiagnostics(scanState) {
+    if (!this._diagnosticsPublisher) {
+      return [];
+    }
+
+    const diagnosticNodes = scanState._fullTrees
+      .flatMap((tree) => tree.dependencies)
+      .filter((dependency) => dependency.isDirect)
+      .map((dependency) => new DependencyHealthNode(dependency, null, this.context));
+
+    return this._diagnosticsPublisher.prepare(scanState._lastManifests, diagnosticNodes);
   }
 
   _getMaxDependenciesToScan() {
@@ -337,6 +562,9 @@ class DependencyHealthProvider {
   async _performScan(cloudsmithWorkspace, cloudsmithRepo, folderPath, progress, token) {
     progress.report({ message: "Parsing lockfiles..." });
     this._lastManifests = await ManifestParser.detectManifests(folderPath);
+    if (token.isCancellationRequested) {
+      return { canceled: true };
+    }
 
     const resolveTransitives = vscode.workspace.getConfiguration("cloudsmith-vsc").get("resolveTransitiveDependencies") !== false;
     const trees = [];
@@ -344,6 +572,9 @@ class DependencyHealthProvider {
 
     if (resolveTransitives) {
       const detections = await LockfileResolver.detectResolvers(folderPath);
+      if (token.isCancellationRequested) {
+        return { canceled: true };
+      }
       for (const detection of detections) {
         if (token.isCancellationRequested) {
           return { canceled: true };
@@ -372,6 +603,9 @@ class DependencyHealthProvider {
 
     if (trees.length === 0) {
       const fallbackTrees = await this._buildManifestFallbackTrees(this._lastManifests);
+      if (token.isCancellationRequested) {
+        return { canceled: true };
+      }
       trees.push(...fallbackTrees);
     }
 
@@ -410,7 +644,6 @@ class DependencyHealthProvider {
       const warning = `Dependency display is capped at ${this._getMaxDependenciesToScan()} items `
         + `out of ${limited.totalDependencies} resolved dependencies.`;
       this._warnings.push(warning);
-      vscode.window.showWarningMessage(warning);
     }
     this._statusMessage = null;
     this._rebuildSummary();
@@ -917,7 +1150,9 @@ class DependencyHealthProvider {
   async _runUpstreamGapAnalysis(uncoveredDependencies, workspace, repo, progress, token) {
     const repositories = repo
       ? [repo]
-      : await this._services.fetchRepositories(workspace, token);
+      : await (this._services.fetchRepositories
+        ? this._services.fetchRepositories(workspace, token)
+        : this._fetchWorkspaceRepositories(workspace, token));
 
     const handler = this._createDebouncedEnrichmentHandler((patchMap) => {
       this._fullTrees = applyUncoveredOverlayPatch(this._fullTrees, patchMap, (dependency, gap) => ({
@@ -1063,7 +1298,7 @@ class DependencyHealthProvider {
   }
 
   async pullDependencies() {
-    if (this._scanning) {
+    if (this.isScanRunning() || this._dependencyOperationRunning) {
       vscode.window.showWarningMessage("Wait for the current dependency operation to finish.");
       return;
     }
@@ -1080,8 +1315,7 @@ class DependencyHealthProvider {
     }
 
     const cancellationSource = new vscode.CancellationTokenSource();
-    this._scanning = true;
-    this._failureMessage = null;
+    this._dependencyOperationRunning = true;
     await this._updateContexts();
 
     try {
@@ -1145,14 +1379,14 @@ class DependencyHealthProvider {
       }
     } finally {
       cancellationSource.dispose();
-      this._scanning = false;
+      this._dependencyOperationRunning = false;
       await this._updateContexts();
       this.refresh();
     }
   }
 
   async pullSingleDependency(item) {
-    if (this._scanning) {
+    if (this.isScanRunning() || this._dependencyOperationRunning) {
       vscode.window.showWarningMessage("Wait for the current dependency operation to finish.");
       return;
     }
@@ -1178,8 +1412,7 @@ class DependencyHealthProvider {
     }
 
     const cancellationSource = new vscode.CancellationTokenSource();
-    this._scanning = true;
-    this._failureMessage = null;
+    this._dependencyOperationRunning = true;
     await this._updateContexts();
 
     try {
@@ -1248,7 +1481,7 @@ class DependencyHealthProvider {
       }
     } finally {
       cancellationSource.dispose();
-      this._scanning = false;
+      this._dependencyOperationRunning = false;
       await this._updateContexts();
       this.refresh();
     }
@@ -1381,12 +1614,14 @@ class DependencyHealthProvider {
     return newlyFoundDependencies;
   }
 
-  async rescan() {
-    if (!this.lastWorkspace) {
-      vscode.window.showInformationMessage('No previous scan. Run "Scan dependencies" first.');
-      return;
+  async rescan(initialScan) {
+    const scope = this.getLastSuccessfulScope();
+    if (!scope) {
+      return typeof initialScan === "function"
+        ? initialScan()
+        : { status: "needs-initial-scan" };
     }
-    await this.scan(this.lastWorkspace, this.lastRepo);
+    return this.scan(scope.workspace, scope.repository, scope.projectFolder);
   }
 
   getTreeItem(element) {
@@ -1398,44 +1633,31 @@ class DependencyHealthProvider {
       return element.getChildren();
     }
 
-    if (this._statusMessage) {
-      return [
-        new InfoNode(
-          this._statusMessage,
-          "",
-          this._statusMessage,
-          "loading~spin",
-          "statusMessage"
-        ),
-      ];
+    const operationNode = this._getScanOperationNode();
+    if (operationNode && !this._hasSuccessfulScan) {
+      return [operationNode];
     }
 
-    if (this._failureMessage) {
-      return [
-        new InfoNode(
-          this._failureMessage,
-          "",
-          this._failureMessage,
-          "error",
-          "statusMessage"
-        ),
-      ];
+    const nodes = [];
+    if (operationNode) {
+      nodes.push(operationNode);
     }
 
     if (this._noManifestsFolder) {
-      return [
+      nodes.push(
         new InfoNode(
           "No dependency manifests or lockfiles found",
           this._noManifestsFolder,
           "Supported formats include npm, Python, Maven, Gradle, Go, Cargo, Ruby, Docker, NuGet, Dart, Composer, Helm, Swift, and Hex.",
           "warning",
           "infoNode"
-        ),
-      ];
+        )
+      );
+      return nodes;
     }
 
     if (this._displayTrees.length > 0) {
-      const nodes = [new DependencySummaryNode(this._summary)];
+      nodes.push(new DependencySummaryNode(this._summary));
       if (this._warnings.length > 0) {
         nodes.push(new InfoNode(
           this._warnings[0],
@@ -1449,7 +1671,7 @@ class DependencyHealthProvider {
       return nodes;
     }
 
-    if (!this._hasScannedOnce) {
+    if (!this._hasSuccessfulScan && this._scanOperation.status === SCAN_STATES.IDLE) {
       const isConnected = this.context && this.context.secrets
         ? await this.context.secrets.get("cloudsmith-vsc.isConnected")
         : "false";
@@ -1477,15 +1699,52 @@ class DependencyHealthProvider {
       ];
     }
 
-    return [
-      new InfoNode(
-        "No dependencies found",
-        "",
-        "The detected dependency files did not contain any dependencies to scan.",
-        "info",
-        "infoNode"
-      ),
-    ];
+    nodes.push(new InfoNode(
+      "No dependencies found",
+      "",
+      "The detected dependency files did not contain any dependencies to scan.",
+      "info",
+      "infoNode"
+    ));
+    return nodes;
+  }
+
+  _getScanOperationNode() {
+    const status = this._scanOperation.status;
+    if (status === SCAN_STATES.SELECTING || status === SCAN_STATES.RUNNING) {
+      const refreshing = this._hasSuccessfulScan;
+      const label = refreshing ? "Refreshing dependencies" : "Scanning dependencies";
+      const detail = refreshing
+        ? "Previous scan results are shown until the refresh finishes."
+        : "Dependency health results will appear when the scan finishes.";
+      return new InfoNode(label, detail, detail, "loading~spin", "statusMessage");
+    }
+
+    if (status === SCAN_STATES.FAILED) {
+      const refreshing = this._hasSuccessfulScan;
+      const label = refreshing ? "Dependency refresh failed" : "Dependency scan failed";
+      const detail = refreshing
+        ? "Previous scan results are shown. Run Scan dependencies to retry."
+        : "Run Scan dependencies to retry.";
+      return new InfoNode(
+        label,
+        detail,
+        this._scanOperation.failureMessage || detail,
+        "error",
+        "statusMessage"
+      );
+    }
+
+    if (status === SCAN_STATES.CANCELLED) {
+      const refreshing = this._hasSuccessfulScan;
+      const label = refreshing ? "Dependency refresh canceled" : "Dependency scan canceled";
+      const detail = refreshing
+        ? "Previous scan results are shown."
+        : "Run Scan dependencies to try again.";
+      return new InfoNode(label, detail, this._scanOperation.message || detail, "info", "statusMessage");
+    }
+
+    return null;
   }
 
   refresh() {
@@ -1498,6 +1757,18 @@ class DependencyHealthProvider {
     });
     this.dependencies = this._displayTrees.flatMap((tree) => tree.dependencies);
   }
+}
+
+function createScanOperation(status, id, values = {}) {
+  return {
+    status,
+    id,
+    startedAt: values.startedAt || null,
+    completedAt: values.completedAt || null,
+    scope: values.scope || null,
+    message: values.message || null,
+    failureMessage: values.failureMessage || null,
+  };
 }
 
 DependencyHealthProvider.packageIndexCache = new Map();
@@ -2816,6 +3087,7 @@ function getDependencyLicenseClassification(dependency) {
 module.exports = {
   DependencyHealthProvider,
   FILTER_MODES,
+  SCAN_STATES,
   SORT_MODES,
   buildComplianceReportData,
   buildDependencyHealthReport,


### PR DESCRIPTION
### Summary

- Made dependency scan results transactional with explicit lifecycle state and last-successful scope ownership.
- Preserved previous successful results and diagnostics across failed or canceled refreshes.
- Prevented superseded scans from publishing stale results, diagnostics, errors, or scope.
- Consolidated first-run and refresh behavior behind one contextual Scan dependencies action while preserving historical rescan command compatibility.
- Added a secondary Change dependency scan scope action for selecting a different Cloudsmith scope and project folder.
- Replaced the compound license-expression regular expression with a predictable single-pass AND/OR scanner.
- Added regression coverage for scan state transitions and license-expression parsing, including long whitespace-heavy input.

### Validation

- npm run lint — passed with 2 known pre-existing warnings
- npm test — 389 passing, 7 skipped on VS Code 1.109.5
- git diff --check — passed
