### PR TITLE
refactor: introduce dependency adapter contract

### DIFF
--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -20,7 +20,19 @@ class DependencyHealthNode {
     this.context = hasExplicitCloudsmithMatch ? maybeContext : cloudsmithMatchOrContext;
     this.options = hasExplicitCloudsmithMatch ? (maybeOptions || {}) : (maybeContext || {});
     this.name = dep.name;
-    this.declaredVersion = dep.version;
+    this.declaredConstraint = dep.declaredConstraint || null;
+    this.resolvedVersion = dep.resolvedVersion || null;
+    this.versionState = dep.versionState || null;
+    this.resolutionSource = dep.resolutionSource || null;
+    this.sourceManifest = dep.sourceManifest || null;
+    this.normalizedName = dep.normalizedName || null;
+    this.legacyVersion = Object.prototype.hasOwnProperty.call(dep, "legacyVersion")
+      ? dep.legacyVersion
+      : dep.version;
+    // Retained for existing display and diagnostic consumers during M4 migration.
+    this.declaredVersion = Object.prototype.hasOwnProperty.call(dep, "version")
+      ? dep.version
+      : dep.legacyVersion;
     this.format = dep.format || canonicalFormat(dep.ecosystem);
     this.ecosystem = dep.ecosystem || this.format;
     this.sourceFile = dep.sourceFile || null;

--- a/test/dependencyAdapterRegistry.test.js
+++ b/test/dependencyAdapterRegistry.test.js
@@ -1,0 +1,196 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const {
+  ADAPTER_RESULT_STATUSES,
+  DependencyAdapterRegistry,
+  createDefaultDependencyAdapterRegistry,
+} = require("../util/dependencyAdapterRegistry");
+const {
+  DEPENDENCY_VERSION_STATES,
+  RESOLUTION_SOURCE_KINDS,
+} = require("../util/dependencyRecord");
+const {
+  makeTempWorkspace,
+  removeDirectory,
+  writeTextFile,
+} = require("./helpers/fixtureWorkspace");
+
+suite("dependencyAdapterRegistry", () => {
+  const fixtureDir = path.join(__dirname, "fixtures", "npm");
+  const tempDirs = [];
+
+  async function createWorkspace() {
+    const workspace = await makeTempWorkspace("cloudsmith-dependency-adapter-");
+    tempDirs.push(workspace);
+    return workspace;
+  }
+
+  suiteTeardown(async () => {
+    await Promise.all(tempDirs.map((tempDir) => removeDirectory(tempDir)));
+  });
+
+  test("maps a known package.json manifest to the npm adapter", () => {
+    const registry = createDefaultDependencyAdapterRegistry();
+    const adapter = registry.getAdapterForManifest("package.json");
+
+    assert.ok(registry instanceof DependencyAdapterRegistry);
+    assert.ok(adapter);
+    assert.strictEqual(adapter.id, "npmParser");
+    assert.strictEqual(adapter.ecosystem, "npm");
+  });
+
+  test("returns an explicit unsupported result for unknown manifests", async () => {
+    const workspace = await createWorkspace();
+    const filePath = path.join(workspace, "dependencies.custom");
+    await writeTextFile(filePath, "package-a=1.0.0\n");
+
+    const result = await createDefaultDependencyAdapterRegistry().parseManifest({
+      filePath,
+      format: "custom",
+      workspaceFolder: workspace,
+    });
+
+    assert.strictEqual(result.status, ADAPTER_RESULT_STATUSES.UNSUPPORTED);
+    assert.deepStrictEqual(result.dependencies, []);
+    assert.ok(result.error);
+    assert.strictEqual(result.error.code, "unsupported-manifest");
+  });
+
+  test("returns canonical records for supported manifest dependencies", async () => {
+    const registry = createDefaultDependencyAdapterRegistry();
+    const filePath = path.join(fixtureDir, "package.json");
+    const result = await registry.parseManifest({
+      filePath,
+      format: "npm",
+      workspaceFolder: fixtureDir,
+    });
+    const express = result.dependencies.find((dependency) => dependency.name === "express");
+
+    assert.strictEqual(result.status, ADAPTER_RESULT_STATUSES.SUCCESS);
+    assert.ok(express);
+    assert.strictEqual(Object.isFrozen(express), true);
+    assert.strictEqual(express.ecosystem, "npm");
+    assert.strictEqual(express.format, "npm");
+    assert.strictEqual(express.normalizedName, "express");
+    assert.strictEqual(express.declaredConstraint, "^4.18.2");
+    assert.strictEqual(express.resolvedVersion, null);
+    assert.strictEqual(express.versionState, DEPENDENCY_VERSION_STATES.RANGE);
+    assert.strictEqual(express.resolutionSource, null);
+    assert.strictEqual(express.sourceManifest.kind, RESOLUTION_SOURCE_KINDS.MANIFEST);
+    assert.strictEqual(express.sourceManifest.filePath, filePath);
+    assert.strictEqual(express.sourceManifest.type, "package.json");
+    assert.strictEqual(express.isDirect, true);
+    assert.strictEqual(express.legacyVersion, "4.18.2");
+  });
+
+  test("distinguishes malformed package.json from a valid empty manifest", async () => {
+    const workspace = await createWorkspace();
+    const validPath = path.join(workspace, "package.json");
+    const malformedPath = path.join(workspace, "nested", "package.json");
+    await writeTextFile(validPath, "{}\n");
+    await writeTextFile(malformedPath, "{ not valid JSON\n");
+    const registry = createDefaultDependencyAdapterRegistry();
+
+    const valid = await registry.parseManifest({
+      filePath: validPath,
+      format: "npm",
+      workspaceFolder: workspace,
+    });
+    const malformed = await registry.parseManifest({
+      filePath: malformedPath,
+      format: "npm",
+      workspaceFolder: workspace,
+    });
+
+    assert.strictEqual(valid.status, ADAPTER_RESULT_STATUSES.SUCCESS);
+    assert.deepStrictEqual(valid.dependencies, []);
+    assert.strictEqual(valid.error, null);
+    assert.strictEqual(malformed.status, ADAPTER_RESULT_STATUSES.ERROR);
+    assert.deepStrictEqual(malformed.dependencies, []);
+    assert.ok(malformed.error);
+    assert.strictEqual(malformed.error.code, "parse-error");
+  });
+
+  test("retains distinct provenance for same-ecosystem manifests", async () => {
+    const workspace = await createWorkspace();
+    const firstPath = path.join(workspace, "package.json");
+    const secondPath = path.join(workspace, "packages", "nested", "package.json");
+    const content = JSON.stringify({ dependencies: { "package-a": "^1.0.0" } });
+    await writeTextFile(firstPath, content);
+    await writeTextFile(secondPath, content);
+    const registry = createDefaultDependencyAdapterRegistry();
+
+    const first = await registry.parseManifest({
+      filePath: firstPath,
+      format: "npm",
+      workspaceFolder: workspace,
+    });
+    const second = await registry.parseManifest({
+      filePath: secondPath,
+      format: "npm",
+      workspaceFolder: workspace,
+    });
+
+    assert.strictEqual(first.status, ADAPTER_RESULT_STATUSES.SUCCESS);
+    assert.strictEqual(second.status, ADAPTER_RESULT_STATUSES.SUCCESS);
+    assert.strictEqual(first.dependencies[0].ecosystem, "npm");
+    assert.strictEqual(second.dependencies[0].ecosystem, "npm");
+    assert.strictEqual(first.dependencies[0].sourceManifest.filePath, await fs.promises.realpath(firstPath));
+    assert.strictEqual(second.dependencies[0].sourceManifest.filePath, await fs.promises.realpath(secondPath));
+    assert.notStrictEqual(
+      first.dependencies[0].sourceManifest.uri,
+      second.dependencies[0].sourceManifest.uri
+    );
+  });
+
+  test("adapts the npm fixture without losing its raw declaration or resolution provenance", async () => {
+    const manifestPath = path.join(fixtureDir, "package.json");
+    const lockfilePath = path.join(fixtureDir, "package-lock.json");
+    const result = await createDefaultDependencyAdapterRegistry().parse({
+      adapterId: "npmParser",
+      resolverName: "npmParser",
+      ecosystem: "npm",
+      workspaceFolder: fixtureDir,
+      lockfilePath,
+      manifestPath,
+      sourceFile: "package-lock.json",
+    }, {
+      maxDependenciesToScan: 10000,
+    });
+    const express = result.dependencies.find((dependency) => dependency.name === "express");
+
+    assert.strictEqual(result.status, ADAPTER_RESULT_STATUSES.SUCCESS);
+    assert.ok(express);
+    assert.strictEqual(express.declaredConstraint, "^4.18.2");
+    assert.strictEqual(express.resolvedVersion, "4.18.2");
+    assert.strictEqual(express.versionState, DEPENDENCY_VERSION_STATES.RESOLVED);
+    assert.strictEqual(express.legacyVersion, "4.18.2");
+    assert.strictEqual(express.sourceManifest.kind, RESOLUTION_SOURCE_KINDS.MANIFEST);
+    assert.strictEqual(express.sourceManifest.filePath, manifestPath);
+    assert.strictEqual(express.resolutionSource.kind, RESOLUTION_SOURCE_KINDS.LOCKFILE);
+    assert.strictEqual(express.resolutionSource.filePath, lockfilePath);
+  });
+
+  test("preserves the workspace trust boundary on adapter detections", async () => {
+    const workspace = await createWorkspace();
+    const otherWorkspace = await createWorkspace();
+    const nestedPath = path.join(workspace, "target", "dependency-tree.txt");
+    await writeTextFile(path.join(workspace, "pom.xml"), "<project></project>\n");
+    await writeTextFile(nestedPath, "\n");
+
+    const detections = await createDefaultDependencyAdapterRegistry().detect(workspace);
+    const mavenDetection = detections.find((detection) => detection.adapterId === "mavenParser");
+
+    assert.ok(mavenDetection);
+    assert.strictEqual(mavenDetection.workspaceFolder, workspace);
+    assert.strictEqual(mavenDetection.lockfilePath, nestedPath);
+    const result = await createDefaultDependencyAdapterRegistry().parse(mavenDetection);
+    assert.notStrictEqual(result.status, ADAPTER_RESULT_STATUSES.ERROR);
+    const rejected = await createDefaultDependencyAdapterRegistry().parse(mavenDetection, {
+      workspaceFolder: otherWorkspace,
+    });
+    assert.strictEqual(rejected.status, ADAPTER_RESULT_STATUSES.ERROR);
+    assert.match(rejected.error.message, /workspace folder/);
+  });
+});

--- a/test/dependencyAdapterRegistry.test.js
+++ b/test/dependencyAdapterRegistry.test.js
@@ -26,6 +26,22 @@ suite("dependencyAdapterRegistry", () => {
     return workspace;
   }
 
+  function createContractAdapter(id, detect) {
+    return {
+      id,
+      ecosystem: "npm",
+      manifestTypes: [],
+      detect,
+      async parse() {
+        return {
+          status: ADAPTER_RESULT_STATUSES.SUCCESS,
+          dependencies: [],
+          warnings: [],
+        };
+      },
+    };
+  }
+
   suiteTeardown(async () => {
     await Promise.all(tempDirs.map((tempDir) => removeDirectory(tempDir)));
   });
@@ -38,6 +54,75 @@ suite("dependencyAdapterRegistry", () => {
     assert.ok(adapter);
     assert.strictEqual(adapter.id, "npmParser");
     assert.strictEqual(adapter.ecosystem, "npm");
+  });
+
+  test("accepts an empty adapter detection array", async () => {
+    const registry = new DependencyAdapterRegistry([
+      createContractAdapter("empty-detector", async () => []),
+    ]);
+
+    assert.deepStrictEqual(await registry.detect("/workspace"), []);
+  });
+
+  test("preserves valid adapter detections", async () => {
+    const registry = new DependencyAdapterRegistry([
+      createContractAdapter("valid-detector", async () => [{ sourceFile: "package.json" }]),
+    ]);
+
+    assert.deepStrictEqual(await registry.detect("/workspace"), [{
+      sourceFile: "package.json",
+      adapterId: "valid-detector",
+      resolverName: "valid-detector",
+      ecosystem: "npm",
+      workspaceFolder: "/workspace",
+    }]);
+  });
+
+  for (const [label, invalidResult] of [
+    ["null", null],
+    ["undefined", undefined],
+    ["an object", {}],
+    ["a string", "package.json"],
+  ]) {
+    test(`rejects ${label} adapter detection output with an actionable contract error`, async () => {
+      const adapterId = `invalid-${label.replace(/\s+/g, "-")}-detector`;
+      const registry = new DependencyAdapterRegistry([
+        createContractAdapter(adapterId, async () => invalidResult),
+      ]);
+
+      await assert.rejects(
+        () => registry.detect("/workspace"),
+        (error) => {
+          assert.ok(error instanceof TypeError);
+          assert.strictEqual(
+            error.message,
+            `Dependency adapter "${adapterId}" detect() must return an array.`
+          );
+          return true;
+        }
+      );
+    });
+  }
+
+  test("rejects invalid parse result objects at equivalent adapter boundaries", async () => {
+    const parseAdapter = createContractAdapter("invalid-parser", async () => []);
+    parseAdapter.parse = async () => null;
+    const parseRegistry = new DependencyAdapterRegistry([parseAdapter]);
+
+    await assert.rejects(
+      () => parseRegistry.parse({ adapterId: "invalid-parser" }),
+      /Dependency adapter "invalid-parser" parse\(\) must return an adapter result object\./
+    );
+
+    const manifestAdapter = createContractAdapter("invalid-manifest-parser", async () => []);
+    manifestAdapter.manifestTypes = ["package.json"];
+    manifestAdapter.parseManifest = async () => "not-a-result";
+    const manifestRegistry = new DependencyAdapterRegistry([manifestAdapter]);
+
+    await assert.rejects(
+      () => manifestRegistry.parseManifest({ manifestType: "package.json" }),
+      /Dependency adapter "invalid-manifest-parser" parseManifest\(\) must return an adapter result object\./
+    );
   });
 
   test("returns an explicit unsupported result for unknown manifests", async () => {

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -5,6 +5,13 @@ const {
   SCAN_STATES,
   matchCoverageCandidates,
 } = require("../views/dependencyHealthProvider");
+const { ADAPTER_RESULT_STATUSES } = require("../util/dependencyAdapterRegistry");
+const {
+  DEPENDENCY_VERSION_STATES,
+  RESOLUTION_SOURCE_KINDS,
+  createDependencyRecord,
+  createDependencySource,
+} = require("../util/dependencyRecord");
 const { normalizePackageName } = require("../util/packageNameNormalizer");
 
 suite("DependencyHealthProvider Test Suite", () => {
@@ -474,6 +481,84 @@ suite("DependencyHealthProvider Test Suite", () => {
 
     assert.strictEqual(nodes.length, 1);
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
+  });
+
+  test("_performScan projects canonical adapter records into the compatibility tree", async () => {
+    const originalGetConfiguration = vscode.workspace.getConfiguration;
+    const manifestSource = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.MANIFEST,
+      filePath: "/project/package.json",
+      type: "package.json",
+    });
+    const dependency = createDependencyRecord({
+      ecosystem: "npm",
+      format: "npm",
+      name: "left-pad",
+      declaredConstraint: "^1.0.0",
+      resolvedVersion: null,
+      versionState: DEPENDENCY_VERSION_STATES.RANGE,
+      sourceManifest: manifestSource,
+      isDirect: true,
+      legacyVersion: "1.0.0",
+    });
+    const dependencyAdapters = {
+      async detectManifests() {
+        return [{
+          adapterId: "npmParser",
+          filePath: "/project/package.json",
+          format: "npm",
+          manifestType: "package.json",
+        }];
+      },
+      async detect() {
+        return [];
+      },
+      async parseManifest() {
+        return {
+          status: ADAPTER_RESULT_STATUSES.SUCCESS,
+          adapterId: "npmParser",
+          ecosystem: "npm",
+          sourceFile: "package.json",
+          source: { manifest: manifestSource, resolution: null },
+          dependencies: [dependency],
+          warnings: [],
+          error: null,
+        };
+      },
+    };
+
+    vscode.workspace.getConfiguration = () => ({
+      get(key) {
+        return key === "resolveTransitiveDependencies" ? false : 10000;
+      },
+    });
+
+    try {
+      const provider = new DependencyHealthProvider(createContext(), null, { dependencyAdapters });
+      provider._runCoverageChecks = async () => {};
+      provider._runEnrichmentPasses = async () => {};
+      provider._publishDiagnostics = async () => {};
+      provider._storeReportData = async () => {};
+      provider.refresh = () => {};
+
+      const result = await provider._performScan(
+        "workspace-a",
+        "repo-a",
+        "/project",
+        { report() {} },
+        { isCancellationRequested: false }
+      );
+      const projected = provider._fullTrees[0].dependencies[0];
+
+      assert.deepStrictEqual(result, { canceled: false });
+      assert.strictEqual(projected.version, "1.0.0");
+      assert.strictEqual(projected.declaredConstraint, "^1.0.0");
+      assert.strictEqual(projected.resolvedVersion, null);
+      assert.strictEqual(projected.sourceManifest.filePath, "/project/package.json");
+      assert.strictEqual(projected.cloudsmithStatus, "CHECKING");
+    } finally {
+      vscode.workspace.getConfiguration = originalGetConfiguration;
+    }
   });
 
   test("_runCoverageChecks batches tree rebuilds and refreshes while preserving matches", async () => {

--- a/test/dependencyRecord.test.js
+++ b/test/dependencyRecord.test.js
@@ -46,7 +46,16 @@ suite("dependencyRecord", () => {
       type: "package-lock.json",
     });
     const parentChain = ["fixture-app"];
-    const transitives = [{ name: "child-package" }];
+    const transitive = createDependencyRecord({
+      ecosystem: "npm",
+      name: "child-package",
+      resolvedVersion: "1.0.0",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      parent: "package-a",
+      parentChain: ["package-a"],
+      legacyVersion: "1.0.0",
+    });
+    const transitives = [transitive];
     const dependency = createDependencyRecord({
       ecosystem: "npm",
       format: "npm",
@@ -65,7 +74,10 @@ suite("dependencyRecord", () => {
     });
 
     parentChain.push("mutated-parent");
-    transitives.push({ name: "mutated-child" });
+    transitives.push(createDependencyRecord({
+      ecosystem: "npm",
+      name: "mutated-child",
+    }));
 
     assert.strictEqual(Object.isFrozen(dependency), true);
     assert.strictEqual(dependency.ecosystem, "npm");
@@ -81,10 +93,88 @@ suite("dependencyRecord", () => {
     assert.strictEqual(dependency.isDevelopmentDependency, false);
     assert.strictEqual(dependency.parent, "fixture-app");
     assert.deepStrictEqual(dependency.parentChain, ["fixture-app"]);
-    assert.deepStrictEqual(dependency.transitives, [{ name: "child-package" }]);
+    assert.deepStrictEqual(dependency.transitives, [transitive]);
     assert.strictEqual(dependency.legacyVersion, "1.7.4");
     assert.strictEqual(Object.isFrozen(dependency.parentChain), true);
     assert.strictEqual(Object.isFrozen(dependency.transitives), true);
+    assert.strictEqual(Object.isFrozen(dependency.transitives[0]), true);
+  });
+
+  test("canonicalizes nested transitive inputs without mutating caller-owned objects", () => {
+    const grandchildInput = {
+      ecosystem: "npm",
+      name: "grandchild-package",
+      resolvedVersion: "3.0.0",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      parent: "child-package",
+      parentChain: ["root-package", "child-package"],
+      transitives: [],
+      legacyVersion: "3.0.0",
+    };
+    const childParentChain = ["root-package"];
+    const childTransitives = [grandchildInput];
+    const childInput = {
+      ecosystem: "npm",
+      name: "child-package",
+      resolvedVersion: "2.0.0",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      parent: "root-package",
+      parentChain: childParentChain,
+      transitives: childTransitives,
+      legacyVersion: "2.0.0",
+    };
+    const dependency = createDependencyRecord({
+      ecosystem: "npm",
+      name: "root-package",
+      resolvedVersion: "1.0.0",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      transitives: [childInput],
+      legacyVersion: "1.0.0",
+    });
+    const child = dependency.transitives[0];
+    const grandchild = child.transitives[0];
+
+    assert.notStrictEqual(child, childInput);
+    assert.notStrictEqual(grandchild, grandchildInput);
+    assert.strictEqual(Object.isFrozen(dependency.transitives), true);
+    assert.strictEqual(Object.isFrozen(child), true);
+    assert.strictEqual(Object.isFrozen(child.parentChain), true);
+    assert.strictEqual(Object.isFrozen(child.transitives), true);
+    assert.strictEqual(Object.isFrozen(grandchild), true);
+    assert.strictEqual(Object.isFrozen(grandchild.parentChain), true);
+    assert.strictEqual(Object.isFrozen(grandchild.transitives), true);
+
+    childInput.name = "mutated-child";
+    childParentChain.push("mutated-parent");
+    grandchildInput.name = "mutated-grandchild";
+    childTransitives.push({ name: "mutated-entry" });
+    child.name = "mutated-canonical-child";
+
+    assert.strictEqual(child.name, "child-package");
+    assert.deepStrictEqual(child.parentChain, ["root-package"]);
+    assert.strictEqual(child.transitives.length, 1);
+    assert.strictEqual(grandchild.name, "grandchild-package");
+    assert.strictEqual(Object.isFrozen(childInput), false);
+    assert.strictEqual(Object.isFrozen(childParentChain), false);
+    assert.strictEqual(Object.isFrozen(childTransitives), false);
+    assert.strictEqual(Object.isFrozen(grandchildInput), false);
+    assert.throws(() => dependency.transitives.push(child), TypeError);
+    assert.throws(() => child.parentChain.push("another-parent"), TypeError);
+  });
+
+  test("rejects cyclic transitive input without recursive overflow", () => {
+    const cyclicInput = {
+      ecosystem: "npm",
+      name: "cyclic-package",
+      versionState: DEPENDENCY_VERSION_STATES.UNRESOLVED,
+      transitives: [],
+    };
+    cyclicInput.transitives.push(cyclicInput);
+
+    assert.throws(
+      () => createDependencyRecord(cyclicInput),
+      /Dependency transitive graphs must not contain cycles\./
+    );
   });
 
   test("represents an unresolved range without inventing a resolved version", () => {

--- a/test/dependencyRecord.test.js
+++ b/test/dependencyRecord.test.js
@@ -1,0 +1,207 @@
+const assert = require("assert");
+const path = require("path");
+const {
+  DEPENDENCY_VERSION_STATES,
+  RESOLUTION_SOURCE_KINDS,
+  createDependencyRecord,
+  createDependencySource,
+  getDependencyOccurrenceKey,
+} = require("../util/dependencyRecord");
+
+suite("dependencyRecord", () => {
+  function createManifestSource(fileName = "package.json", range) {
+    return createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.MANIFEST,
+      filePath: path.resolve("test", "fixtures", "npm", fileName),
+      type: fileName,
+      range,
+    });
+  }
+
+  test("creates immutable dependency sources with URI, path, type, kind, and range", () => {
+    const range = {
+      start: { line: 3, character: 4 },
+      end: { line: 3, character: 11 },
+    };
+    const source = createManifestSource("package.json", range);
+
+    assert.strictEqual(Object.getPrototypeOf(source), Object.prototype);
+    assert.strictEqual(Object.isFrozen(source), true);
+    assert.strictEqual(source.kind, RESOLUTION_SOURCE_KINDS.MANIFEST);
+    assert.strictEqual(source.filePath, path.resolve("test", "fixtures", "npm", "package.json"));
+    assert.strictEqual(source.type, "package.json");
+    assert.match(source.uri, /^file:/);
+    assert.deepStrictEqual(source.range, range);
+    assert.notStrictEqual(source.range, range);
+    assert.strictEqual(Object.isFrozen(source.range), true);
+    assert.strictEqual(Object.isFrozen(source.range.start), true);
+    assert.strictEqual(Object.isFrozen(source.range.end), true);
+  });
+
+  test("preserves declared constraints separately from resolved versions", () => {
+    const manifestSource = createManifestSource();
+    const lockfileSource = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.LOCKFILE,
+      filePath: path.resolve("test", "fixtures", "npm", "package-lock.json"),
+      type: "package-lock.json",
+    });
+    const parentChain = ["fixture-app"];
+    const transitives = [{ name: "child-package" }];
+    const dependency = createDependencyRecord({
+      ecosystem: "npm",
+      format: "npm",
+      name: "package-a",
+      declaredConstraint: "^1.2.3",
+      resolvedVersion: "1.7.4",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      resolutionSource: lockfileSource,
+      sourceManifest: manifestSource,
+      isDirect: true,
+      isDevelopmentDependency: false,
+      parent: "fixture-app",
+      parentChain,
+      transitives,
+      legacyVersion: "1.7.4",
+    });
+
+    parentChain.push("mutated-parent");
+    transitives.push({ name: "mutated-child" });
+
+    assert.strictEqual(Object.isFrozen(dependency), true);
+    assert.strictEqual(dependency.ecosystem, "npm");
+    assert.strictEqual(dependency.format, "npm");
+    assert.strictEqual(dependency.name, "package-a");
+    assert.strictEqual(dependency.normalizedName, "package-a");
+    assert.strictEqual(dependency.declaredConstraint, "^1.2.3");
+    assert.strictEqual(dependency.resolvedVersion, "1.7.4");
+    assert.strictEqual(dependency.versionState, DEPENDENCY_VERSION_STATES.RESOLVED);
+    assert.strictEqual(dependency.resolutionSource.kind, RESOLUTION_SOURCE_KINDS.LOCKFILE);
+    assert.strictEqual(dependency.sourceManifest.kind, RESOLUTION_SOURCE_KINDS.MANIFEST);
+    assert.strictEqual(dependency.isDirect, true);
+    assert.strictEqual(dependency.isDevelopmentDependency, false);
+    assert.strictEqual(dependency.parent, "fixture-app");
+    assert.deepStrictEqual(dependency.parentChain, ["fixture-app"]);
+    assert.deepStrictEqual(dependency.transitives, [{ name: "child-package" }]);
+    assert.strictEqual(dependency.legacyVersion, "1.7.4");
+    assert.strictEqual(Object.isFrozen(dependency.parentChain), true);
+    assert.strictEqual(Object.isFrozen(dependency.transitives), true);
+  });
+
+  test("represents an unresolved range without inventing a resolved version", () => {
+    const dependency = createDependencyRecord({
+      ecosystem: "python",
+      format: "python",
+      name: "requests",
+      declaredConstraint: ">=1.0,<2",
+      resolvedVersion: null,
+      versionState: DEPENDENCY_VERSION_STATES.RANGE,
+      resolutionSource: createManifestSource("requirements.txt"),
+      sourceManifest: createManifestSource("requirements.txt"),
+      isDirect: true,
+      legacyVersion: "1.0",
+    });
+
+    assert.strictEqual(dependency.declaredConstraint, ">=1.0,<2");
+    assert.strictEqual(dependency.resolvedVersion, null);
+    assert.strictEqual(dependency.versionState, DEPENDENCY_VERSION_STATES.RANGE);
+  });
+
+  test("rejects contradictory resolved-version states", () => {
+    assert.throws(() => createDependencyRecord({
+      ecosystem: "npm",
+      name: "package-a",
+      resolvedVersion: "1.2.3",
+      versionState: DEPENDENCY_VERSION_STATES.RANGE,
+    }), /must use the resolved version state/);
+    assert.throws(() => createDependencyRecord({
+      ecosystem: "npm",
+      name: "package-a",
+      resolvedVersion: null,
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+    }), /require a resolved version/);
+  });
+
+  test("keeps multiple resolved versions and provenance-distinct occurrences separate", () => {
+    const firstManifest = createManifestSource("package.json");
+    const secondManifest = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.MANIFEST,
+      filePath: path.resolve("test", "fixtures", "npm", "nested", "package.json"),
+      type: "package.json",
+    });
+    const resolutionSource = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.LOCKFILE,
+      filePath: path.resolve("test", "fixtures", "npm", "package-lock.json"),
+      type: "package-lock.json",
+    });
+    const createPackageA = (resolvedVersion, sourceManifest) => createDependencyRecord({
+      ecosystem: "npm",
+      format: "npm",
+      name: "package-a",
+      declaredConstraint: `^${resolvedVersion}`,
+      resolvedVersion,
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      resolutionSource,
+      sourceManifest,
+      isDirect: true,
+      legacyVersion: resolvedVersion,
+    });
+
+    const versionOne = createPackageA("1.0.0", firstManifest);
+    const versionTwo = createPackageA("2.0.0", firstManifest);
+    const secondManifestVersionOne = createPackageA("1.0.0", secondManifest);
+    const occurrences = new Set([
+      getDependencyOccurrenceKey(versionOne),
+      getDependencyOccurrenceKey(versionTwo),
+      getDependencyOccurrenceKey(secondManifestVersionOne),
+    ]);
+
+    assert.strictEqual(occurrences.size, 3);
+    assert.deepStrictEqual(
+      [versionOne, versionTwo].map((dependency) => dependency.resolvedVersion),
+      ["1.0.0", "2.0.0"]
+    );
+    assert.notStrictEqual(versionOne.sourceManifest.uri, secondManifestVersionOne.sourceManifest.uri);
+  });
+
+  test("includes declaration ranges, resolution sources, and parent paths in occurrence identity", () => {
+    const firstManifest = createManifestSource("package.json", {
+      start: { line: 1, character: 2 },
+      end: { line: 1, character: 10 },
+    });
+    const secondManifest = createManifestSource("package.json", {
+      start: { line: 2, character: 2 },
+      end: { line: 2, character: 10 },
+    });
+    const firstLockfile = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.LOCKFILE,
+      filePath: path.resolve("test", "fixtures", "npm", "package-lock.json"),
+      type: "package-lock.json",
+    });
+    const secondLockfile = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.LOCKFILE,
+      filePath: path.resolve("test", "fixtures", "npm", "nested", "package-lock.json"),
+      type: "package-lock.json",
+    });
+    const createOccurrence = (sourceManifest, resolutionSource, parentChain) => createDependencyRecord({
+      ecosystem: "npm",
+      name: "package-a",
+      declaredConstraint: "^1.0.0",
+      resolvedVersion: "1.2.0",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      sourceManifest,
+      resolutionSource,
+      isDirect: false,
+      parent: parentChain[parentChain.length - 1],
+      parentChain,
+      legacyVersion: "1.2.0",
+    });
+    const keys = new Set([
+      getDependencyOccurrenceKey(createOccurrence(firstManifest, firstLockfile, ["parent-a"])),
+      getDependencyOccurrenceKey(createOccurrence(secondManifest, firstLockfile, ["parent-a"])),
+      getDependencyOccurrenceKey(createOccurrence(firstManifest, secondLockfile, ["parent-a"])),
+      getDependencyOccurrenceKey(createOccurrence(firstManifest, firstLockfile, ["parent-b"])),
+    ]);
+
+    assert.strictEqual(keys.size, 4);
+  });
+});

--- a/util/dependencyAdapterRegistry.js
+++ b/util/dependencyAdapterRegistry.js
@@ -1,0 +1,571 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const path = require("path");
+const { ManifestParser } = require("./manifestParser");
+const { LockfileResolver } = require("./lockfileResolver");
+const {
+  DEPENDENCY_VERSION_STATES,
+  RESOLUTION_SOURCE_KINDS,
+  createDependencyRecord,
+  createDependencySource,
+} = require("./dependencyRecord");
+const {
+  getWorkspacePath,
+  readUtf8,
+  resolveWorkspaceFilePath,
+} = require("./lockfileParsers/shared");
+const {
+  canonicalFormat,
+  normalizePackageName,
+} = require("./packageNameNormalizer");
+
+const ADAPTER_RESULT_STATUSES = Object.freeze({
+  SUCCESS: "success",
+  PARTIAL: "partial",
+  ERROR: "error",
+  UNSUPPORTED: "unsupported",
+});
+
+const RESOLUTION_AVAILABILITY = Object.freeze({
+  AVAILABLE: "available",
+  MISSING: "missing",
+  NOT_APPLICABLE: "not-applicable",
+});
+
+const RESOLVER_MANIFEST_TYPES = Object.freeze({
+  npmParser: ["package.json"],
+  pythonParser: ["requirements.txt", "pyproject.toml"],
+  mavenParser: ["pom.xml"],
+  gradleParser: ["build.gradle", "build.gradle.kts"],
+  goParser: ["go.mod"],
+  cargoParser: ["Cargo.toml"],
+  rubyParser: ["Gemfile"],
+  dockerParser: ["Dockerfile", "docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"],
+  nugetParser: [],
+  dartParser: ["pubspec.yaml"],
+  composerParser: ["composer.json"],
+  helmParser: ["Chart.yaml"],
+  swiftParser: ["Package.swift"],
+  hexParser: ["mix.exs"],
+});
+
+const LEGACY_MANIFEST_PARSERS = Object.freeze({
+  "package.json": (content) => ManifestParser.parseNpm(content, "npm"),
+  "requirements.txt": (content) => ManifestParser.parsePythonRequirements(content, "python"),
+  "pyproject.toml": (content) => ManifestParser.parsePyproject(content, "python"),
+  "pom.xml": (content) => ManifestParser.parseMaven(content, "maven"),
+  "go.mod": (content) => ManifestParser.parseGoMod(content, "go"),
+  "cargo.toml": (content) => ManifestParser.parseCargo(content, "cargo"),
+});
+
+const LOCKFILE_TYPES = new Set([
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "uv.lock",
+  "poetry.lock",
+  "pipfile.lock",
+  "gradle.lockfile",
+  "cargo.lock",
+  "gemfile.lock",
+  "packages.lock.json",
+  "pubspec.lock",
+  "composer.lock",
+  "chart.lock",
+  "package.resolved",
+  "mix.lock",
+]);
+
+const PACKAGE_MANAGER_OUTPUT_TYPES = new Set([
+  "dependency-tree.txt",
+]);
+
+class DependencyAdapterRegistry {
+  constructor(adapters = []) {
+    this._adapters = new Map();
+    this._manifestAdapters = new Map();
+
+    for (const adapter of adapters) {
+      this.register(adapter);
+    }
+  }
+
+  register(adapter) {
+    if (
+      !adapter
+      || typeof adapter.id !== "string"
+      || !adapter.id
+      || typeof adapter.detect !== "function"
+      || typeof adapter.parse !== "function"
+    ) {
+      throw new TypeError("Dependency adapters require an id, detect(), and parse().");
+    }
+
+    if (this._adapters.has(adapter.id)) {
+      throw new Error(`Dependency adapter already registered: ${adapter.id}`);
+    }
+
+    this._adapters.set(adapter.id, adapter);
+    for (const manifestType of adapter.manifestTypes || []) {
+      const key = normalizeManifestType(manifestType);
+      if (key && !this._manifestAdapters.has(key)) {
+        this._manifestAdapters.set(key, adapter);
+      }
+    }
+  }
+
+  getAdapter(id) {
+    return this._adapters.get(id) || null;
+  }
+
+  getAdapterForManifest(manifestType) {
+    const normalizedType = normalizeManifestType(manifestType);
+    if (this._manifestAdapters.has(normalizedType)) {
+      return this._manifestAdapters.get(normalizedType);
+    }
+    if (normalizedType.startsWith("dockerfile.")) {
+      return this._adapters.get("dockerParser") || null;
+    }
+    if (normalizedType.endsWith(".csproj")) {
+      return this._adapters.get("nugetParser") || null;
+    }
+    return null;
+  }
+
+  async detect(workspaceFolder) {
+    const workspaceRoot = getWorkspacePath(workspaceFolder);
+    const detections = [];
+    for (const adapter of this._adapters.values()) {
+      const adapterDetections = await adapter.detect(workspaceFolder);
+      for (const detection of adapterDetections) {
+        detections.push({
+          ...detection,
+          adapterId: adapter.id,
+          resolverName: adapter.id,
+          ecosystem: detection.ecosystem || adapter.ecosystem,
+          workspaceFolder: workspaceRoot,
+        });
+      }
+    }
+    return detections;
+  }
+
+  async detectManifests(workspaceFolder) {
+    const manifests = await ManifestParser.detectManifests(workspaceFolder);
+    return manifests.map((manifest) => {
+      const adapter = this.getAdapterForManifest(path.basename(manifest.filePath));
+      return {
+        ...manifest,
+        adapterId: adapter ? adapter.id : null,
+        manifestType: path.basename(manifest.filePath),
+      };
+    });
+  }
+
+  async parse(detection, options = {}) {
+    const adapterId = detection && (detection.adapterId || detection.resolverName);
+    const adapter = this.getAdapter(adapterId);
+    if (!adapter) {
+      return createAdapterResult({
+        status: ADAPTER_RESULT_STATUSES.UNSUPPORTED,
+        adapterId: adapterId || null,
+        ecosystem: detection && detection.ecosystem || null,
+        sourceFile: detection && detection.sourceFile || null,
+        resolutionAvailability: RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+        error: {
+          code: "unsupported-adapter",
+          message: `No dependency adapter is registered for ${adapterId || "this source"}.`,
+        },
+      });
+    }
+
+    return adapter.parse(detection, options);
+  }
+
+  async parseManifest(manifest) {
+    const manifestType = path.basename(String(manifest && manifest.filePath || manifest && manifest.manifestType || ""));
+    const adapter = this.getAdapterForManifest(manifestType);
+    if (!adapter || typeof adapter.parseManifest !== "function") {
+      return createAdapterResult({
+        status: ADAPTER_RESULT_STATUSES.UNSUPPORTED,
+        adapterId: adapter ? adapter.id : null,
+        ecosystem: manifest && manifest.format || null,
+        sourceFile: manifestType || null,
+        resolutionAvailability: RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+        error: {
+          code: "unsupported-manifest",
+          message: `No dependency adapter supports ${manifestType || "this manifest"}.`,
+        },
+      });
+    }
+
+    return adapter.parseManifest(manifest);
+  }
+}
+
+function createDefaultDependencyAdapterRegistry() {
+  return new DependencyAdapterRegistry(
+    LockfileResolver.getResolvers().map((resolver) => createResolverAdapter(resolver))
+  );
+}
+
+function createResolverAdapter(resolver) {
+  const manifestTypes = RESOLVER_MANIFEST_TYPES[resolver.name] || [];
+  return Object.freeze({
+    id: resolver.name,
+    ecosystem: resolver.ecosystem,
+    manifestTypes: Object.freeze(manifestTypes.slice()),
+    normalizeName(name) {
+      return normalizePackageName(name, resolver.ecosystem);
+    },
+    async detect(workspaceFolder) {
+      const rootPath = getWorkspacePath(workspaceFolder);
+      if (!rootPath || (typeof resolver.canResolve === "function" && !(await resolver.canResolve(rootPath)))) {
+        return [];
+      }
+      const detections = typeof resolver.detect === "function"
+        ? await resolver.detect(rootPath)
+        : [];
+      return Array.isArray(detections) ? detections : [];
+    },
+    async parse(detection, options) {
+      try {
+        const safeDetection = await resolveDetectionPaths(
+          detection,
+          options && options.workspaceFolder
+        );
+        const legacyTree = await LockfileResolver.resolve(
+          resolver.name,
+          safeDetection.lockfilePath,
+          safeDetection.manifestPath,
+          {
+            ...options,
+            workspaceFolder: safeDetection.workspaceFolder,
+          }
+        );
+        const sources = createSourceSet(safeDetection, resolver);
+        const declaredConstraints = await readDeclaredConstraintIndex(
+          sources.manifest,
+          resolver.ecosystem,
+          safeDetection.workspaceFolder
+        );
+        const dependencies = (legacyTree && legacyTree.dependencies || []).map((dependency) => (
+          adaptLegacyDependency(dependency, legacyTree, sources, declaredConstraints)
+        ));
+        const warnings = Array.isArray(legacyTree && legacyTree.warnings)
+          ? legacyTree.warnings.slice()
+          : [];
+
+        return createAdapterResult({
+          status: warnings.length > 0
+            ? ADAPTER_RESULT_STATUSES.PARTIAL
+            : ADAPTER_RESULT_STATUSES.SUCCESS,
+          adapterId: resolver.name,
+          ecosystem: resolver.ecosystem,
+          sourceFile: legacyTree && legacyTree.sourceFile || safeDetection.sourceFile,
+          source: sources,
+          dependencies,
+          warnings,
+          resolutionAvailability: sources.resolution
+            ? RESOLUTION_AVAILABILITY.AVAILABLE
+            : missingResolutionAvailability(resolver.name),
+        });
+      } catch (error) {
+        return createAdapterResult({
+          status: ADAPTER_RESULT_STATUSES.ERROR,
+          adapterId: resolver.name,
+          ecosystem: resolver.ecosystem,
+          sourceFile: detection && detection.sourceFile || null,
+          resolutionAvailability: RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+          error: {
+            code: "parse-error",
+            message: error && error.message ? error.message : "Dependency parsing failed.",
+          },
+        });
+      }
+    },
+    parseManifest: manifestTypes.some((manifestType) => LEGACY_MANIFEST_PARSERS[normalizeManifestType(manifestType)])
+      ? (manifest) => parseLegacyManifest(resolver, manifest)
+      : undefined,
+  });
+}
+
+async function parseLegacyManifest(resolver, manifest) {
+  const manifestType = normalizeManifestType(path.basename(String(manifest && manifest.filePath || "")));
+  const parser = LEGACY_MANIFEST_PARSERS[manifestType];
+  if (!parser) {
+    return createAdapterResult({
+      status: ADAPTER_RESULT_STATUSES.UNSUPPORTED,
+      adapterId: resolver.name,
+      ecosystem: resolver.ecosystem,
+      sourceFile: manifestType || null,
+      resolutionAvailability: RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+      error: {
+        code: "unsupported-manifest",
+        message: `No direct manifest parser supports ${manifestType || "this manifest"}.`,
+      },
+    });
+  }
+
+  try {
+    const workspaceFolder = getWorkspacePath(manifest.workspaceFolder);
+    if (!workspaceFolder) {
+      throw new Error("Dependency manifests require a workspace folder.");
+    }
+    const safeFilePath = await resolveWorkspaceFilePath(manifest.filePath, workspaceFolder);
+    if (!safeFilePath) {
+      throw new Error("Manifest paths must stay within the workspace folder.");
+    }
+    const content = await readUtf8(safeFilePath, workspaceFolder);
+    if (manifestType === "package.json") {
+      JSON.parse(content);
+    }
+
+    const sourceManifest = createDependencySource({
+      kind: RESOLUTION_SOURCE_KINDS.MANIFEST,
+      filePath: safeFilePath,
+      type: path.basename(safeFilePath),
+    });
+    const dependencies = parser(content).map((dependency) => adaptLegacyManifestDependency(
+      dependency,
+      resolver.ecosystem,
+      sourceManifest
+    ));
+
+    return createAdapterResult({
+      status: ADAPTER_RESULT_STATUSES.SUCCESS,
+      adapterId: resolver.name,
+      ecosystem: resolver.ecosystem,
+      sourceFile: path.basename(safeFilePath),
+      source: Object.freeze({ manifest: sourceManifest, resolution: null }),
+      dependencies,
+      resolutionAvailability: missingResolutionAvailability(resolver.name),
+    });
+  } catch (error) {
+    return createAdapterResult({
+      status: ADAPTER_RESULT_STATUSES.ERROR,
+      adapterId: resolver.name,
+      ecosystem: resolver.ecosystem,
+      sourceFile: manifestType || null,
+      resolutionAvailability: RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+      error: {
+        code: "parse-error",
+        message: error && error.message ? error.message : "Manifest parsing failed.",
+      },
+    });
+  }
+}
+
+async function resolveDetectionPaths(detection, callerWorkspaceFolder) {
+  const workspaceFolder = getWorkspacePath(
+    callerWorkspaceFolder || detection && detection.workspaceFolder
+  );
+  if (!workspaceFolder) {
+    throw new Error("Dependency detections require a workspace folder.");
+  }
+
+  const lockfilePath = detection && detection.lockfilePath
+    ? await resolveWorkspaceFilePath(detection.lockfilePath, workspaceFolder)
+    : null;
+  const manifestPath = detection && detection.manifestPath
+    ? await resolveWorkspaceFilePath(detection.manifestPath, workspaceFolder)
+    : null;
+  if (detection && detection.lockfilePath && !lockfilePath) {
+    throw new Error("Lockfile paths must stay within the workspace folder.");
+  }
+  if (detection && detection.manifestPath && !manifestPath) {
+    throw new Error("Manifest paths must stay within the workspace folder.");
+  }
+
+  return {
+    ...detection,
+    workspaceFolder,
+    lockfilePath,
+    manifestPath,
+    sourceFile: detection && detection.sourceFile
+      || path.basename(lockfilePath || manifestPath || ""),
+  };
+}
+
+function createSourceSet(detection, resolver) {
+  const lockfileKind = getSourceKind(detection.lockfilePath);
+  const manifestPath = lockfileKind === RESOLUTION_SOURCE_KINDS.MANIFEST
+    ? detection.lockfilePath
+    : detection.manifestPath;
+  const resolutionPath = lockfileKind && lockfileKind !== RESOLUTION_SOURCE_KINDS.MANIFEST
+    ? detection.lockfilePath
+    : null;
+
+  return Object.freeze({
+    manifest: manifestPath
+      ? createDependencySource({
+        kind: RESOLUTION_SOURCE_KINDS.MANIFEST,
+        filePath: manifestPath,
+        type: path.basename(manifestPath),
+      })
+      : null,
+    resolution: resolutionPath
+      ? createDependencySource({
+        kind: lockfileKind,
+        filePath: resolutionPath,
+        type: path.basename(resolutionPath),
+      })
+      : null,
+    adapterId: resolver.name,
+  });
+}
+
+function getSourceKind(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  const type = normalizeManifestType(path.basename(filePath));
+  if (LOCKFILE_TYPES.has(type)) {
+    return RESOLUTION_SOURCE_KINDS.LOCKFILE;
+  }
+  if (PACKAGE_MANAGER_OUTPUT_TYPES.has(type)) {
+    return RESOLUTION_SOURCE_KINDS.PACKAGE_MANAGER;
+  }
+  return RESOLUTION_SOURCE_KINDS.MANIFEST;
+}
+
+async function readDeclaredConstraintIndex(sourceManifest, ecosystem, workspaceFolder) {
+  const index = new Map();
+  if (!sourceManifest) {
+    return index;
+  }
+  const parser = LEGACY_MANIFEST_PARSERS[normalizeManifestType(sourceManifest.type)];
+  if (!parser) {
+    return index;
+  }
+
+  const content = await readUtf8(sourceManifest.filePath, workspaceFolder);
+  for (const dependency of parser(content)) {
+    const name = normalizePackageName(dependency.name, ecosystem);
+    if (!name || index.has(name)) {
+      continue;
+    }
+    index.set(name, dependency.declaredConstraint != null
+      ? String(dependency.declaredConstraint).trim()
+      : String(dependency.version || "").trim());
+  }
+  return index;
+}
+
+function adaptLegacyDependency(dependency, tree, sources, declaredConstraints) {
+  const ecosystem = dependency.ecosystem || tree.ecosystem;
+  const format = dependency.format || canonicalFormat(ecosystem);
+  const name = String(dependency.name || "").trim();
+  const declaredConstraint = dependency.isDirect
+    ? declaredConstraints.get(normalizePackageName(name, format)) || null
+    : null;
+  const hasUncertainMavenDirectResolution = ecosystem === "maven"
+    && dependency.isDirect
+    && sources.resolution
+    && sources.resolution.kind === RESOLUTION_SOURCE_KINDS.PACKAGE_MANAGER
+    && declaredConstraint;
+  const resolvedVersion = sources.resolution && dependency.version && !hasUncertainMavenDirectResolution
+    ? String(dependency.version).trim()
+    : null;
+  let versionState = classifyDeclaredConstraint(declaredConstraint);
+  if (hasUncertainMavenDirectResolution) {
+    versionState = DEPENDENCY_VERSION_STATES.INCOMPLETE;
+  } else if (resolvedVersion) {
+    versionState = DEPENDENCY_VERSION_STATES.RESOLVED;
+  }
+  const transitives = Array.isArray(dependency.transitives)
+    ? dependency.transitives.map((child) => adaptLegacyDependency(child, tree, sources, declaredConstraints))
+    : [];
+
+  return createDependencyRecord({
+    ecosystem,
+    format,
+    name,
+    declaredConstraint,
+    resolvedVersion,
+    versionState,
+    resolutionSource: resolvedVersion ? sources.resolution : null,
+    sourceManifest: dependency.isDirect ? sources.manifest : null,
+    isDirect: dependency.isDirect,
+    isDevelopmentDependency: dependency.isDevelopmentDependency || dependency.devDependency,
+    parent: dependency.parent,
+    parentChain: dependency.parentChain,
+    transitives,
+    legacyVersion: dependency.version,
+  });
+}
+
+function adaptLegacyManifestDependency(dependency, ecosystem, sourceManifest) {
+  const declaredConstraint = dependency.declaredConstraint != null
+    ? String(dependency.declaredConstraint).trim()
+    : String(dependency.version || "").trim() || null;
+  return createDependencyRecord({
+    ecosystem,
+    format: dependency.format || canonicalFormat(ecosystem),
+    name: dependency.name,
+    declaredConstraint,
+    resolvedVersion: null,
+    versionState: classifyDeclaredConstraint(declaredConstraint),
+    resolutionSource: null,
+    sourceManifest,
+    isDirect: true,
+    isDevelopmentDependency: dependency.isDevelopmentDependency || dependency.devDependency,
+    parent: null,
+    parentChain: [],
+    transitives: [],
+    legacyVersion: dependency.version,
+  });
+}
+
+function classifyDeclaredConstraint(constraint) {
+  const value = String(constraint || "").trim();
+  if (!value) {
+    return DEPENDENCY_VERSION_STATES.UNRESOLVED;
+  }
+  if (value.includes("${") || /^(?:workspace|file|git|path|link):/i.test(value)) {
+    return DEPENDENCY_VERSION_STATES.INCOMPLETE;
+  }
+  if (/^v?\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$/.test(value)) {
+    return DEPENDENCY_VERSION_STATES.EXACT_DECLARATION;
+  }
+  if (/[~^<>=!*,|]/.test(value) || /\s+-\s+/.test(value)) {
+    return DEPENDENCY_VERSION_STATES.RANGE;
+  }
+  return DEPENDENCY_VERSION_STATES.INCOMPLETE;
+}
+
+function createAdapterResult(values) {
+  const error = values.error
+    ? Object.freeze({
+      code: String(values.error.code || "unknown-error"),
+      message: String(values.error.message || "Dependency adapter failed."),
+    })
+    : null;
+  return Object.freeze({
+    status: values.status,
+    adapterId: values.adapterId || null,
+    ecosystem: values.ecosystem || null,
+    sourceFile: values.sourceFile || null,
+    source: values.source || null,
+    dependencies: Object.freeze(Array.isArray(values.dependencies) ? values.dependencies.slice() : []),
+    warnings: Object.freeze(Array.isArray(values.warnings) ? values.warnings.slice() : []),
+    error,
+    resolutionAvailability: values.resolutionAvailability || RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
+  });
+}
+
+function missingResolutionAvailability(adapterId) {
+  return ["goParser", "dockerParser"].includes(adapterId)
+    ? RESOLUTION_AVAILABILITY.NOT_APPLICABLE
+    : RESOLUTION_AVAILABILITY.MISSING;
+}
+
+function normalizeManifestType(manifestType) {
+  return String(manifestType || "").trim().toLowerCase();
+}
+
+module.exports = {
+  ADAPTER_RESULT_STATUSES,
+  DependencyAdapterRegistry,
+  RESOLUTION_AVAILABILITY,
+  createDefaultDependencyAdapterRegistry,
+};

--- a/util/dependencyAdapterRegistry.js
+++ b/util/dependencyAdapterRegistry.js
@@ -24,6 +24,7 @@ const ADAPTER_RESULT_STATUSES = Object.freeze({
   ERROR: "error",
   UNSUPPORTED: "unsupported",
 });
+const ADAPTER_RESULT_STATUS_VALUES = new Set(Object.values(ADAPTER_RESULT_STATUSES));
 
 const RESOLUTION_AVAILABILITY = Object.freeze({
   AVAILABLE: "available",
@@ -135,7 +136,10 @@ class DependencyAdapterRegistry {
     const workspaceRoot = getWorkspacePath(workspaceFolder);
     const detections = [];
     for (const adapter of this._adapters.values()) {
-      const adapterDetections = await adapter.detect(workspaceFolder);
+      const adapterDetections = validateDetectionResult(
+        adapter,
+        await adapter.detect(workspaceFolder)
+      );
       for (const detection of adapterDetections) {
         detections.push({
           ...detection,
@@ -178,7 +182,7 @@ class DependencyAdapterRegistry {
       });
     }
 
-    return adapter.parse(detection, options);
+    return validateAdapterResult(adapter, "parse", await adapter.parse(detection, options));
   }
 
   async parseManifest(manifest) {
@@ -198,7 +202,7 @@ class DependencyAdapterRegistry {
       });
     }
 
-    return adapter.parseManifest(manifest);
+    return validateAdapterResult(adapter, "parseManifest", await adapter.parseManifest(manifest));
   }
 }
 
@@ -225,7 +229,7 @@ function createResolverAdapter(resolver) {
       const detections = typeof resolver.detect === "function"
         ? await resolver.detect(rootPath)
         : [];
-      return Array.isArray(detections) ? detections : [];
+      return detections;
     },
     async parse(detection, options) {
       try {
@@ -534,6 +538,17 @@ function classifyDeclaredConstraint(constraint) {
 }
 
 function createAdapterResult(values) {
+  const adapterId = values.adapterId || "<unknown>";
+  if (!ADAPTER_RESULT_STATUS_VALUES.has(values.status)) {
+    throw new TypeError(`Dependency adapter "${adapterId}" result must use a supported status.`);
+  }
+  if (values.dependencies != null && !Array.isArray(values.dependencies)) {
+    throw new TypeError(`Dependency adapter "${adapterId}" result dependencies must be an array.`);
+  }
+  if (values.warnings != null && !Array.isArray(values.warnings)) {
+    throw new TypeError(`Dependency adapter "${adapterId}" result warnings must be an array.`);
+  }
+
   const error = values.error
     ? Object.freeze({
       code: String(values.error.code || "unknown-error"),
@@ -551,6 +566,30 @@ function createAdapterResult(values) {
     error,
     resolutionAvailability: values.resolutionAvailability || RESOLUTION_AVAILABILITY.NOT_APPLICABLE,
   });
+}
+
+function validateDetectionResult(adapter, detections) {
+  if (!Array.isArray(detections)) {
+    throw new TypeError(`Dependency adapter "${adapter.id}" detect() must return an array.`);
+  }
+  return detections;
+}
+
+function validateAdapterResult(adapter, methodName, result) {
+  const methodLabel = `Dependency adapter "${adapter.id}" ${methodName}()`;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    throw new TypeError(`${methodLabel} must return an adapter result object.`);
+  }
+  if (!ADAPTER_RESULT_STATUS_VALUES.has(result.status)) {
+    throw new TypeError(`${methodLabel} result must use a supported status.`);
+  }
+  if (!Array.isArray(result.dependencies)) {
+    throw new TypeError(`${methodLabel} result dependencies must be an array.`);
+  }
+  if (!Array.isArray(result.warnings)) {
+    throw new TypeError(`${methodLabel} result warnings must be an array.`);
+  }
+  return result;
 }
 
 function missingResolutionAvailability(adapterId) {

--- a/util/dependencyRecord.js
+++ b/util/dependencyRecord.js
@@ -1,0 +1,240 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const path = require("path");
+const { pathToFileURL } = require("url");
+const {
+  canonicalFormat,
+  normalizePackageName,
+  sanitizePackageNameInput,
+} = require("./packageNameNormalizer");
+
+const DEPENDENCY_VERSION_STATES = Object.freeze({
+  RESOLVED: "resolved",
+  EXACT_DECLARATION: "exact-declaration",
+  RANGE: "range",
+  UNRESOLVED: "unresolved",
+  INCOMPLETE: "incomplete",
+});
+
+const RESOLUTION_SOURCE_KINDS = Object.freeze({
+  MANIFEST: "manifest",
+  LOCKFILE: "lockfile",
+  PACKAGE_MANAGER: "package-manager",
+});
+
+const VERSION_STATE_VALUES = new Set(Object.values(DEPENDENCY_VERSION_STATES));
+const SOURCE_KIND_VALUES = new Set(Object.values(RESOLUTION_SOURCE_KINDS));
+
+/**
+ * @typedef {{line: number, character: number}} DependencySourcePosition
+ * @typedef {{start: DependencySourcePosition, end: DependencySourcePosition}} DependencySourceRange
+ * @typedef {{
+ *   kind: "manifest"|"lockfile"|"package-manager",
+ *   filePath: string,
+ *   uri: string,
+ *   type: string,
+ *   range: DependencySourceRange|null,
+ * }} DependencySource
+ * @typedef {{
+ *   ecosystem: string,
+ *   format: string,
+ *   name: string,
+ *   normalizedName: string,
+ *   declaredConstraint: string|null,
+ *   resolvedVersion: string|null,
+ *   versionState: "resolved"|"exact-declaration"|"range"|"unresolved"|"incomplete",
+ *   resolutionSource: DependencySource|null,
+ *   sourceManifest: DependencySource|null,
+ *   isDirect: boolean,
+ *   isDevelopmentDependency: boolean,
+ *   parent: string|null,
+ *   parentChain: string[],
+ *   transitives: DependencyRecord[],
+ *   legacyVersion: string,
+ * }} DependencyRecord
+ */
+
+/**
+ * Create plain, immutable file provenance without introducing a VS Code API
+ * dependency into the dependency domain.
+ *
+ * @param {{kind: string, filePath: string, type?: string, range?: object|null}} values
+ * @returns {DependencySource}
+ */
+function createDependencySource(values) {
+  const kind = String(values && values.kind || "").trim();
+  if (!SOURCE_KIND_VALUES.has(kind)) {
+    throw new TypeError(`Unsupported dependency source kind: ${kind || "<empty>"}`);
+  }
+
+  const filePath = String(values && values.filePath || "").trim();
+  if (!filePath || !path.isAbsolute(filePath)) {
+    throw new TypeError("Dependency source paths must be absolute.");
+  }
+
+  const normalizedPath = path.normalize(filePath);
+  const type = String(values && values.type || path.basename(normalizedPath)).trim();
+  if (!type) {
+    throw new TypeError("Dependency sources must have a type.");
+  }
+
+  return Object.freeze({
+    kind,
+    filePath: normalizedPath,
+    uri: pathToFileURL(normalizedPath).toString(),
+    type,
+    range: copySourceRange(values && values.range),
+  });
+}
+
+/**
+ * Create the canonical dependency-domain record. Cloudsmith scan state is
+ * deliberately applied later so parser output cannot be mistaken for trusted
+ * remote package data.
+ *
+ * @param {object} values
+ * @returns {DependencyRecord}
+ */
+function createDependencyRecord(values) {
+  const ecosystem = sanitizePackageNameInput(values && values.ecosystem).toLowerCase();
+  const format = canonicalFormat(values && (values.format || ecosystem));
+  const name = sanitizePackageNameInput(values && values.name);
+  if (!ecosystem || !format || !name) {
+    throw new TypeError("Dependency records require an ecosystem, format, and package name.");
+  }
+
+  const declaredConstraint = optionalString(values && values.declaredConstraint);
+  const resolvedVersion = optionalString(values && values.resolvedVersion);
+  const versionState = String(
+    values && values.versionState
+      || (resolvedVersion ? DEPENDENCY_VERSION_STATES.RESOLVED : DEPENDENCY_VERSION_STATES.UNRESOLVED)
+  ).trim();
+  if (!VERSION_STATE_VALUES.has(versionState)) {
+    throw new TypeError(`Unsupported dependency version state: ${versionState || "<empty>"}`);
+  }
+  if (versionState === DEPENDENCY_VERSION_STATES.RESOLVED && !resolvedVersion) {
+    throw new TypeError("Resolved dependency records require a resolved version.");
+  }
+  if (resolvedVersion && versionState !== DEPENDENCY_VERSION_STATES.RESOLVED) {
+    throw new TypeError("Dependencies with a resolved version must use the resolved version state.");
+  }
+
+  const sourceManifest = copyDependencySource(values && values.sourceManifest);
+  if (sourceManifest && sourceManifest.kind !== RESOLUTION_SOURCE_KINDS.MANIFEST) {
+    throw new TypeError("sourceManifest must use the manifest source kind.");
+  }
+
+  const parentChain = Object.freeze(copyStringArray(values && values.parentChain));
+  // Children are canonical records and are therefore already immutable. Copy
+  // the collection so callers cannot later add or remove graph entries.
+  const transitives = Object.freeze(Array.isArray(values && values.transitives)
+    ? values.transitives.slice()
+    : []);
+
+  return Object.freeze({
+    ecosystem,
+    format,
+    name,
+    normalizedName: normalizePackageName(name, format),
+    declaredConstraint,
+    resolvedVersion,
+    versionState,
+    resolutionSource: copyDependencySource(values && values.resolutionSource),
+    sourceManifest,
+    isDirect: Boolean(values && values.isDirect),
+    isDevelopmentDependency: Boolean(values && values.isDevelopmentDependency),
+    parent: optionalString(values && values.parent),
+    parentChain,
+    transitives,
+    legacyVersion: String(values && values.legacyVersion || "").trim(),
+  });
+}
+
+/**
+ * Build occurrence identity without collapsing distinct resolved versions,
+ * manifests, or graph paths into package-name identity.
+ *
+ * @param {DependencyRecord} dependency
+ * @returns {string}
+ */
+function getDependencyOccurrenceKey(dependency) {
+  return JSON.stringify([
+    String(dependency && dependency.ecosystem || "").toLowerCase(),
+    String(dependency && dependency.normalizedName || "").toLowerCase(),
+    String(dependency && dependency.resolvedVersion || ""),
+    String(dependency && dependency.declaredConstraint || ""),
+    String(dependency && dependency.legacyVersion || ""),
+    sourceIdentity(dependency && dependency.sourceManifest),
+    sourceIdentity(dependency && dependency.resolutionSource),
+    dependency && dependency.isDirect ? "direct" : "transitive",
+    dependency && dependency.isDevelopmentDependency ? "development" : "runtime",
+    String(dependency && dependency.parent || ""),
+    Array.isArray(dependency && dependency.parentChain) ? dependency.parentChain : [],
+  ]);
+}
+
+function sourceIdentity(source) {
+  if (!source) {
+    return null;
+  }
+  return [source.kind, source.uri, source.range];
+}
+
+function copyDependencySource(source) {
+  if (!source) {
+    return null;
+  }
+
+  return createDependencySource({
+    kind: source.kind,
+    filePath: source.filePath,
+    type: source.type,
+    range: source.range,
+  });
+}
+
+function copySourceRange(range) {
+  if (range == null) {
+    return null;
+  }
+
+  const start = copySourcePosition(range.start, "start");
+  const end = copySourcePosition(range.end, "end");
+  if (end.line < start.line || (end.line === start.line && end.character < start.character)) {
+    throw new TypeError("Dependency source ranges must end after they start.");
+  }
+
+  return Object.freeze({ start, end });
+}
+
+function copySourcePosition(position, label) {
+  const line = position && position.line;
+  const character = position && position.character;
+  if (!Number.isInteger(line) || line < 0 || !Number.isInteger(character) || character < 0) {
+    throw new TypeError(`Dependency source ${label} positions must use non-negative integers.`);
+  }
+
+  return Object.freeze({ line, character });
+}
+
+function copyStringArray(values) {
+  return Array.isArray(values)
+    ? values.map((value) => String(value || "").trim()).filter(Boolean)
+    : [];
+}
+
+function optionalString(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+module.exports = {
+  DEPENDENCY_VERSION_STATES,
+  RESOLUTION_SOURCE_KINDS,
+  createDependencyRecord,
+  createDependencySource,
+  getDependencyOccurrenceKey,
+};

--- a/util/dependencyRecord.js
+++ b/util/dependencyRecord.js
@@ -23,6 +23,7 @@ const RESOLUTION_SOURCE_KINDS = Object.freeze({
 
 const VERSION_STATE_VALUES = new Set(Object.values(DEPENDENCY_VERSION_STATES));
 const SOURCE_KIND_VALUES = new Set(Object.values(RESOLUTION_SOURCE_KINDS));
+const CANONICAL_DEPENDENCY_RECORDS = new WeakSet();
 
 /**
  * @typedef {{line: number, character: number}} DependencySourcePosition
@@ -95,58 +96,73 @@ function createDependencySource(values) {
  * @returns {DependencyRecord}
  */
 function createDependencyRecord(values) {
-  const ecosystem = sanitizePackageNameInput(values && values.ecosystem).toLowerCase();
-  const format = canonicalFormat(values && (values.format || ecosystem));
-  const name = sanitizePackageNameInput(values && values.name);
-  if (!ecosystem || !format || !name) {
-    throw new TypeError("Dependency records require an ecosystem, format, and package name.");
+  return createDependencyRecordInternal(values, new WeakSet());
+}
+
+function createDependencyRecordInternal(values, ancestors) {
+  const input = values && typeof values === "object" && !Array.isArray(values)
+    ? values
+    : null;
+  if (input && ancestors.has(input)) {
+    throw new TypeError("Dependency transitive graphs must not contain cycles.");
+  }
+  if (input) {
+    ancestors.add(input);
   }
 
-  const declaredConstraint = optionalString(values && values.declaredConstraint);
-  const resolvedVersion = optionalString(values && values.resolvedVersion);
-  const versionState = String(
-    values && values.versionState
-      || (resolvedVersion ? DEPENDENCY_VERSION_STATES.RESOLVED : DEPENDENCY_VERSION_STATES.UNRESOLVED)
-  ).trim();
-  if (!VERSION_STATE_VALUES.has(versionState)) {
-    throw new TypeError(`Unsupported dependency version state: ${versionState || "<empty>"}`);
-  }
-  if (versionState === DEPENDENCY_VERSION_STATES.RESOLVED && !resolvedVersion) {
-    throw new TypeError("Resolved dependency records require a resolved version.");
-  }
-  if (resolvedVersion && versionState !== DEPENDENCY_VERSION_STATES.RESOLVED) {
-    throw new TypeError("Dependencies with a resolved version must use the resolved version state.");
-  }
+  try {
+    const ecosystem = sanitizePackageNameInput(values && values.ecosystem).toLowerCase();
+    const format = canonicalFormat(values && (values.format || ecosystem));
+    const name = sanitizePackageNameInput(values && values.name);
+    if (!ecosystem || !format || !name) {
+      throw new TypeError("Dependency records require an ecosystem, format, and package name.");
+    }
 
-  const sourceManifest = copyDependencySource(values && values.sourceManifest);
-  if (sourceManifest && sourceManifest.kind !== RESOLUTION_SOURCE_KINDS.MANIFEST) {
-    throw new TypeError("sourceManifest must use the manifest source kind.");
+    const declaredConstraint = optionalString(values && values.declaredConstraint);
+    const resolvedVersion = optionalString(values && values.resolvedVersion);
+    const versionState = String(
+      values && values.versionState
+        || (resolvedVersion ? DEPENDENCY_VERSION_STATES.RESOLVED : DEPENDENCY_VERSION_STATES.UNRESOLVED)
+    ).trim();
+    if (!VERSION_STATE_VALUES.has(versionState)) {
+      throw new TypeError(`Unsupported dependency version state: ${versionState || "<empty>"}`);
+    }
+    if (versionState === DEPENDENCY_VERSION_STATES.RESOLVED && !resolvedVersion) {
+      throw new TypeError("Resolved dependency records require a resolved version.");
+    }
+    if (resolvedVersion && versionState !== DEPENDENCY_VERSION_STATES.RESOLVED) {
+      throw new TypeError("Dependencies with a resolved version must use the resolved version state.");
+    }
+
+    const sourceManifest = copyDependencySource(values && values.sourceManifest);
+    if (sourceManifest && sourceManifest.kind !== RESOLUTION_SOURCE_KINDS.MANIFEST) {
+      throw new TypeError("sourceManifest must use the manifest source kind.");
+    }
+
+    const record = Object.freeze({
+      ecosystem,
+      format,
+      name,
+      normalizedName: normalizePackageName(name, format),
+      declaredConstraint,
+      resolvedVersion,
+      versionState,
+      resolutionSource: copyDependencySource(values && values.resolutionSource),
+      sourceManifest,
+      isDirect: Boolean(values && values.isDirect),
+      isDevelopmentDependency: Boolean(values && values.isDevelopmentDependency),
+      parent: optionalString(values && values.parent),
+      parentChain: Object.freeze(copyStringArray(values && values.parentChain)),
+      transitives: copyTransitives(values && values.transitives, ancestors),
+      legacyVersion: String(values && values.legacyVersion || "").trim(),
+    });
+    CANONICAL_DEPENDENCY_RECORDS.add(record);
+    return record;
+  } finally {
+    if (input) {
+      ancestors.delete(input);
+    }
   }
-
-  const parentChain = Object.freeze(copyStringArray(values && values.parentChain));
-  // Children are canonical records and are therefore already immutable. Copy
-  // the collection so callers cannot later add or remove graph entries.
-  const transitives = Object.freeze(Array.isArray(values && values.transitives)
-    ? values.transitives.slice()
-    : []);
-
-  return Object.freeze({
-    ecosystem,
-    format,
-    name,
-    normalizedName: normalizePackageName(name, format),
-    declaredConstraint,
-    resolvedVersion,
-    versionState,
-    resolutionSource: copyDependencySource(values && values.resolutionSource),
-    sourceManifest,
-    isDirect: Boolean(values && values.isDirect),
-    isDevelopmentDependency: Boolean(values && values.isDevelopmentDependency),
-    parent: optionalString(values && values.parent),
-    parentChain,
-    transitives,
-    legacyVersion: String(values && values.legacyVersion || "").trim(),
-  });
 }
 
 /**
@@ -190,6 +206,25 @@ function copyDependencySource(source) {
     type: source.type,
     range: source.range,
   });
+}
+
+function copyTransitives(transitives, ancestors) {
+  if (transitives == null) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(transitives)) {
+    throw new TypeError("Dependency record transitives must be an array.");
+  }
+
+  return Object.freeze(transitives.map((child) => {
+    if (CANONICAL_DEPENDENCY_RECORDS.has(child)) {
+      return child;
+    }
+    if (!child || typeof child !== "object" || Array.isArray(child)) {
+      throw new TypeError("Dependency transitives must contain dependency record objects.");
+    }
+    return createDependencyRecordInternal(child, ancestors);
+  }));
 }
 
 function copySourceRange(range) {

--- a/util/lockfileParsers/manifestHelpers.js
+++ b/util/lockfileParsers/manifestHelpers.js
@@ -35,6 +35,7 @@ function parsePackageJsonManifest(content) {
       dependencies.push({
         name,
         version: normalizeVersion(version),
+        declaredConstraint: String(version || "").trim() || null,
         isDevelopmentDependency,
       });
       if (isDevelopmentDependency) {
@@ -142,14 +143,16 @@ function parsePyprojectManifest(content) {
       }
 
       const rawValue = parts.value;
-      const version = rawValue.startsWith("{")
-        ? normalizeVersion(parseInlineTomlValue(rawValue, "version"))
-        : normalizeVersion(unquote(rawValue));
+      const declaredConstraint = rawValue.startsWith("{")
+        ? parseInlineTomlValue(rawValue, "version")
+        : unquote(rawValue);
+      const version = normalizeVersion(declaredConstraint);
       const isDevelopmentDependency = section !== "[tool.poetry.dependencies]";
 
       dependencies.push({
         name,
         version: version === "*" ? "" : version,
+        declaredConstraint: declaredConstraint === "*" ? null : declaredConstraint || null,
         isDevelopmentDependency,
       });
 
@@ -184,6 +187,7 @@ function parseRequirementSpec(spec) {
   return {
     name: match[1],
     version: normalizeVersion(match[2] || ""),
+    declaredConstraint: String(match[2] || "").trim() || null,
   };
 }
 

--- a/util/manifestParser.js
+++ b/util/manifestParser.js
@@ -91,6 +91,7 @@ class ManifestParser {
           deps.push({
             name: name,
             version: ManifestParser._stripVersionPrefix(version),
+            declaredConstraint: String(version || "").trim() || null,
             devDependency: false,
             format: format || "npm",
           });
@@ -102,6 +103,7 @@ class ManifestParser {
           deps.push({
             name: name,
             version: ManifestParser._stripVersionPrefix(version),
+            declaredConstraint: String(version || "").trim() || null,
             devDependency: true,
             format: format || "npm",
           });
@@ -138,6 +140,7 @@ class ManifestParser {
         deps.push({
           name: match[1],
           version: match[3].trim().split(/[,;]/)[0].trim(),
+          declaredConstraint: `${match[2]}${match[3].trim().split(";")[0].trim()}`,
           devDependency: false,
           format: format || "python",
         });
@@ -148,6 +151,7 @@ class ManifestParser {
           deps.push({
             name: bareMatch[1],
             version: "",
+            declaredConstraint: null,
             devDependency: false,
             format: format || "python",
           });
@@ -166,6 +170,7 @@ class ManifestParser {
     return parsed.dependencies.map((dependency) => ({
       name: dependency.name,
       version: dependency.version,
+      declaredConstraint: dependency.declaredConstraint || null,
       devDependency: dependency.isDevelopmentDependency,
       format: format || "python",
     }));
@@ -208,6 +213,7 @@ class ManifestParser {
       deps.push({
         name: `${groupId[1].trim()}:${artifactId[1].trim()}`,
         version: versionStr,
+        declaredConstraint: versionStr || null,
         devDependency: isTest,
         format: format || "maven",
       });
@@ -235,6 +241,7 @@ class ManifestParser {
           deps.push({
             name: match[1],
             version: match[2],
+            declaredConstraint: match[2] || null,
             devDependency: false,
             format: format || "go",
           });
@@ -264,6 +271,7 @@ class ManifestParser {
           deps.push({
             name: match[1],
             version: match[2],
+            declaredConstraint: match[2] || null,
             devDependency: isIndirect,
             format: format || "go",
           });
@@ -313,6 +321,7 @@ class ManifestParser {
         deps.push({
           name: simpleMatch[1],
           version: ManifestParser._stripVersionPrefix(simpleMatch[2]),
+          declaredConstraint: simpleMatch[2] || null,
           devDependency: isDev,
           format: format || "cargo",
         });
@@ -325,6 +334,7 @@ class ManifestParser {
         deps.push({
           name: complexMatch[1],
           version: ManifestParser._stripVersionPrefix(complexMatch[2]),
+          declaredConstraint: complexMatch[2] || null,
           devDependency: isDev,
           format: format || "cargo",
         });

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -2,8 +2,10 @@
 const path = require("path");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
-const { LockfileResolver } = require("../util/lockfileResolver");
-const { ManifestParser } = require("../util/manifestParser");
+const {
+  ADAPTER_RESULT_STATUSES,
+  createDefaultDependencyAdapterRegistry,
+} = require("../util/dependencyAdapterRegistry");
 const { PaginatedFetch } = require("../util/paginatedFetch");
 const { SearchQueryBuilder } = require("../util/searchQueryBuilder");
 const { LicenseClassifier } = require("../util/licenseClassifier");
@@ -80,6 +82,7 @@ class DependencyHealthProvider {
       fetchRepositories: options.fetchRepositories || null,
       upstreamPullService: options.upstreamPullService || new UpstreamPullService(context),
     };
+    this._dependencyAdapters = options.dependencyAdapters || createDefaultDependencyAdapterRegistry();
     this._reportDateFactory = typeof options.reportDateFactory === "function"
       ? options.reportDateFactory
       : () => new Date();
@@ -561,7 +564,7 @@ class DependencyHealthProvider {
 
   async _performScan(cloudsmithWorkspace, cloudsmithRepo, folderPath, progress, token) {
     progress.report({ message: "Parsing lockfiles..." });
-    this._lastManifests = await ManifestParser.detectManifests(folderPath);
+    this._lastManifests = await this._dependencyAdapters.detectManifests(folderPath);
     if (token.isCancellationRequested) {
       return { canceled: true };
     }
@@ -571,7 +574,7 @@ class DependencyHealthProvider {
     const warnings = [];
 
     if (resolveTransitives) {
-      const detections = await LockfileResolver.detectResolvers(folderPath);
+      const detections = await this._dependencyAdapters.detect(folderPath);
       if (token.isCancellationRequested) {
         return { canceled: true };
       }
@@ -579,24 +582,31 @@ class DependencyHealthProvider {
         if (token.isCancellationRequested) {
           return { canceled: true };
         }
-        try {
-          const tree = await LockfileResolver.resolve(
-            detection.resolverName,
-            detection.lockfilePath,
-            detection.manifestPath,
-            {
-              workspaceFolder: folderPath,
-              maxDependenciesToScan: this._getMaxDependenciesToScan(),
-            }
-          );
-          if (tree) {
-            trees.push(tree);
-            if (Array.isArray(tree.warnings) && tree.warnings.length > 0) {
-              warnings.push(...tree.warnings);
-            }
+        const result = await this._dependencyAdapters.parse(detection, {
+          workspaceFolder: folderPath,
+          maxDependenciesToScan: this._getMaxDependenciesToScan(),
+        });
+        if (result.status === ADAPTER_RESULT_STATUSES.ERROR) {
+          warnings.push(result.error && result.error.message
+            ? result.error.message
+            : "A dependency adapter failed.");
+          continue;
+        }
+        if (
+          result.status === ADAPTER_RESULT_STATUSES.SUCCESS
+          || result.status === ADAPTER_RESULT_STATUSES.PARTIAL
+        ) {
+          trees.push({
+            adapterId: result.adapterId,
+            ecosystem: result.ecosystem,
+            sourceFile: result.sourceFile,
+            source: result.source,
+            dependencies: result.dependencies,
+            warnings: result.warnings,
+          });
+          if (result.warnings.length > 0) {
+            warnings.push(...result.warnings);
           }
-        } catch (error) {
-          warnings.push(error && error.message ? error.message : "A lockfile parser failed.");
         }
       }
     }
@@ -685,28 +695,23 @@ class DependencyHealthProvider {
   async _buildManifestFallbackTrees(manifests) {
     const trees = [];
     for (const manifest of manifests) {
-      const parsed = await ManifestParser.parseManifest(manifest);
-      if (!Array.isArray(parsed) || parsed.length === 0) {
+      const result = await this._dependencyAdapters.parseManifest(manifest);
+      if (
+        ![
+          ADAPTER_RESULT_STATUSES.SUCCESS,
+          ADAPTER_RESULT_STATUSES.PARTIAL,
+        ].includes(result.status)
+        || result.dependencies.length === 0
+      ) {
         continue;
       }
       trees.push({
-        ecosystem: manifest.format,
-        sourceFile: path.basename(manifest.filePath),
-        dependencies: parsed.map((dependency) => ({
-          name: dependency.name,
-          version: dependency.version,
-          ecosystem: manifest.format,
-          format: canonicalFormat(manifest.format),
-          isDirect: true,
-          parent: null,
-          parentChain: [],
-          transitives: [],
-          cloudsmithStatus: "CHECKING",
-          cloudsmithPackage: null,
-          sourceFile: path.basename(manifest.filePath),
-          devDependency: Boolean(dependency.devDependency),
-          isDevelopmentDependency: Boolean(dependency.devDependency),
-        })),
+        adapterId: result.adapterId,
+        ecosystem: result.ecosystem,
+        sourceFile: result.sourceFile || path.basename(manifest.filePath),
+        source: result.source,
+        dependencies: result.dependencies,
+        warnings: result.warnings,
       });
     }
     return trees;
@@ -1808,21 +1813,27 @@ function setCachedPackageIndexValue(cacheKey, value) {
 
 function normalizeTree(tree) {
   return {
+    ...tree,
     ecosystem: tree.ecosystem,
     sourceFile: tree.sourceFile,
     dependencies: deduplicateDependenciesWithStatus(
       (tree.dependencies || []).map((dependency) => normalizeDependency(dependency, tree))
     ),
+    warnings: Array.isArray(tree.warnings) ? tree.warnings.slice() : [],
   };
 }
 
 function normalizeDependency(dependency, tree) {
   const ecosystem = dependency.ecosystem || tree.ecosystem;
   const format = dependency.format || canonicalFormat(ecosystem);
+  const compatibilityVersion = Object.prototype.hasOwnProperty.call(dependency, "legacyVersion")
+    ? dependency.legacyVersion
+    : dependency.version;
   return {
     ...dependency,
     ecosystem,
     format,
+    version: String(compatibilityVersion || ""),
     sourceFile: dependency.sourceFile || tree.sourceFile,
     parent: dependency.parent || null,
     parentChain: Array.isArray(dependency.parentChain) ? dependency.parentChain.slice() : [],


### PR DESCRIPTION
### Summary

* Added a canonical dependency model that preserves declared constraints, resolved versions, version state, and source provenance.
* Introduced an explicit adapter registry over the existing dependency resolvers with distinct parse and resolution outcomes.
* Preserved current dependency-health matching and display behavior through a named legacy version projection.
* Added regression coverage for provenance, multiple versions, workspace path boundaries, and adapter error states.

### Validation

* `npm run lint` - passed
* `npm test` - passed
* `git diff --check` - passed
