### PR TITLE
refactor: introduce bounded Cloudsmith API transport

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const { CloudsmithProvider } = require("./views/cloudsmithProvider");
 const { helpProvider } = require("./views/helpProvider");
 const { SearchProvider } = require("./views/searchProvider");
 const { CloudsmithAPI } = require("./util/cloudsmithAPI");
+const { apiEndpoint } = require("./util/apiEndpoint");
 const { CredentialManager } = require("./util/credentialManager");
 const { RecentSearches } = require("./util/recentSearches");
 const { RemediationHelper } = require("./util/remediationHelper");
@@ -26,6 +27,7 @@ const { UpstreamDetailProvider } = require("./views/upstreamDetailProvider");
 const { PromotionProvider } = require("./views/promotionProvider");
 const { SearchQueryBuilder } = require("./util/searchQueryBuilder");
 const { formatApiError } = require("./util/errorFormatter");
+const { buildExactPackageQuery, packageMatchesExactIdentity } = require("./util/packageQuery");
 const { LicenseClassifier } = require("./util/licenseClassifier");
 const { fetchRepositoryUpstreams, generateTerraformConfig } = require("./util/terraformExporter");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("./util/upstreamFormats");
@@ -74,6 +76,42 @@ function extractPackageInfo(item) {
     slugPerm: unwrapValue(item.slug_perm),
     slug: unwrapValue(item.slug),
   };
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(isRecord);
+}
+
+function isWorkspaceArray(value) {
+  return isRecordArray(value) && value.every(workspace => (
+    typeof workspace.slug === "string" && workspace.slug.length > 0
+  ));
+}
+
+function isRepositoryArray(value) {
+  return isRecordArray(value) && value.every(repo => (
+    typeof repo.slug === "string"
+    && repo.slug.length > 0
+    && typeof repo.name === "string"
+    && repo.name.length > 0
+  ));
+}
+
+function isPackageLocationArray(value) {
+  return isRecordArray(value) && value.every(pkg => (
+    typeof pkg.name === "string"
+    && pkg.name.length > 0
+    && (typeof pkg.version === "string" || typeof pkg.version === "number")
+    && String(pkg.version).length > 0
+    && typeof pkg.format === "string"
+    && pkg.format.length > 0
+    && typeof pkg.repository === "string"
+    && pkg.repository.length > 0
+  ));
 }
 
 function getNestedInstallField(item, fieldName) {
@@ -313,18 +351,28 @@ async function getWorkspaces(context) {
         }
     }
     const cloudsmithAPI = new CloudsmithAPI(context);
-    const result = await cloudsmithAPI.get("namespaces/?sort=slug");
-    if (typeof result === 'string') {
+    const result = await cloudsmithAPI.get("namespaces/?sort=slug", {
+        responseType: "array",
+        validate: isWorkspaceArray,
+        retry: "safe-read",
+    });
+    if (!result.ok) {
         await setHasMultipleWorkspacesContext(false);
-        vscode.window.showErrorMessage("Failed to load workspaces: " + result);
+        vscode.window.showErrorMessage(`Failed to load workspaces: ${formatApiError(result.error)}`);
         return null;
     }
-    if (!result || result.length === 0) {
+    if (result.data.length === 0) {
         await setHasMultipleWorkspacesContext(false);
         return [];
     }
-    await setHasMultipleWorkspacesContext(result.length > 1);
-    return result;
+    const workspaces = result.data.map(workspace => ({
+        ...workspace,
+        name: typeof workspace.name === "string" && workspace.name.length > 0
+            ? workspace.name
+            : workspace.slug,
+    }));
+    await setHasMultipleWorkspacesContext(workspaces.length > 1);
+    return workspaces;
 }
 
 async function getPreferredTextDocumentLanguage() {
@@ -422,10 +470,24 @@ async function resolveDependencyScanTarget(context, options = {}) {
 
   if (!selectedScope._all) {
     const cloudsmithAPI = new CloudsmithAPI(context);
-    const repos = await cloudsmithAPI.get(`repos/${scanWorkspace}/?sort=name`);
-    if (typeof repos !== "string" && Array.isArray(repos) && repos.length > 0) {
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["repos", scanWorkspace], { query: { sort: "name" } });
+    } catch {
+      return null;
+    }
+    const repos = await cloudsmithAPI.get(endpoint, {
+      responseType: "array",
+      validate: isRepositoryArray,
+      retry: "safe-read",
+    });
+    if (!repos.ok) {
+      vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
+      return null;
+    }
+    if (repos.ok && repos.data.length > 0) {
       const selectedRepo = await vscode.window.showQuickPick(
-        repos.map((repository) => ({
+        repos.data.map((repository) => ({
           label: repository.name,
           description: repository.slug,
         })),
@@ -437,6 +499,9 @@ async function resolveDependencyScanTarget(context, options = {}) {
       if (selectedRepo) {
         scanRepo = selectedRepo.description;
       }
+    } else {
+      vscode.window.showInformationMessage("No repositories were found in this workspace.");
+      return null;
     }
   }
 
@@ -908,14 +973,23 @@ async function activate(context) {
 
 
         if (identifier) {
-          const result = await cloudsmithAPI.get(
-            `packages/${workspace}/${repo}/${identifier}`
-          );
-          if (typeof result === "string") {
-            vscode.window.showErrorMessage(formatApiError(result));
+          let endpoint;
+          try {
+            endpoint = apiEndpoint(["packages", workspace, repo, identifier]);
+          } catch {
+            vscode.window.showErrorMessage("Could not inspect the package because its identifier was invalid.");
             return;
           }
-          const jsonContent = JSON.stringify(result, null, 2);
+          const result = await cloudsmithAPI.get(endpoint, {
+            responseType: "object",
+            validate: isRecord,
+            retry: "safe-read",
+          });
+          if (!result.ok) {
+            vscode.window.showErrorMessage(formatApiError(result.error));
+            return;
+          }
+          const jsonContent = JSON.stringify(result.data, null, 2);
 
           const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
           const inspectOutput = await config.get("inspectOutput");
@@ -957,14 +1031,24 @@ async function activate(context) {
         const repo = typeof item === "string" ? item : item.repo;
 
         if (name) {
-          const result = await cloudsmithAPI.get(
-            `packages/${workspace}/${repo}/?query=name:"${name}"`
-          );
-          if (typeof result === "string") {
-            vscode.window.showErrorMessage(formatApiError(result));
+          let endpoint;
+          try {
+            const query = new SearchQueryBuilder().name(name).build();
+            endpoint = apiEndpoint(["packages", workspace, repo], { query: { query } });
+          } catch {
+            vscode.window.showErrorMessage("Could not inspect the package group because its identity was invalid.");
             return;
           }
-          const jsonContent = JSON.stringify(result, null, 2);
+          const result = await cloudsmithAPI.get(endpoint, {
+            responseType: "array",
+            validate: isRecordArray,
+            retry: "safe-read",
+          });
+          if (!result.ok) {
+            vscode.window.showErrorMessage(formatApiError(result.error));
+            return;
+          }
+          const jsonContent = JSON.stringify(result.data, null, 2);
 
           const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
           const inspectOutput = await config.get("inspectOutput");
@@ -1232,12 +1316,27 @@ async function activate(context) {
       let selectedRepos = null;
       if (selectedScope.label === "Select specific repositories") {
         const cloudsmithAPI = new CloudsmithAPI(context);
-        const repos = await cloudsmithAPI.get(`repos/${workspaceSlug}/?sort=name`);
-        if (typeof repos === 'string' || !repos || repos.length === 0) {
+        let endpoint;
+        try {
+          endpoint = apiEndpoint(["repos", workspaceSlug], { query: { sort: "name" } });
+        } catch {
+          vscode.window.showErrorMessage("The selected workspace identifier was invalid.");
+          return;
+        }
+        const repos = await cloudsmithAPI.get(endpoint, {
+          responseType: "array",
+          validate: isRepositoryArray,
+          retry: "safe-read",
+        });
+        if (!repos.ok) {
+          vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
+          return;
+        }
+        if (repos.data.length === 0) {
           vscode.window.showErrorMessage("No repositories found in this workspace.");
           return;
         }
-        const repoItems = repos.map(r => ({ label: r.name, description: r.slug }));
+        const repoItems = repos.data.map(r => ({ label: r.name, description: r.slug }));
         const picked = await vscode.window.showQuickPick(repoItems, {
           placeHolder: "Select repositories to search",
           canPickMany: true,
@@ -2005,17 +2104,41 @@ async function activate(context) {
       const abortController = new AbortController();
       exportTerraformAbortController = abortController;
       const cloudsmithAPI = new CloudsmithAPI(context);
+      let repoEndpoint;
+      let retentionEndpoint;
+      try {
+        repoEndpoint = apiEndpoint(["repos", workspace, repoSlug]);
+        retentionEndpoint = apiEndpoint(["repos", workspace, repoSlug, "retention"]);
+      } catch {
+        if (exportTerraformAbortController === abortController) {
+          exportTerraformAbortController = null;
+        }
+        vscode.window.showErrorMessage("Could not export the repository because its identity was invalid.");
+        return;
+      }
 
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
           title: "Generating Terraform configuration...",
+          cancellable: true,
         },
-        async () => {
+        async (_progress, token) => {
+          const cancellationSubscription = token.onCancellationRequested(() => abortController.abort());
           try {
             const [repoResult, retentionResult, upstreamResult] = await Promise.all([
-              cloudsmithAPI.get(`repos/${workspace}/${repoSlug}`),
-              cloudsmithAPI.get(`repos/${workspace}/${repoSlug}/retention`),
+              cloudsmithAPI.get(repoEndpoint, {
+                responseType: "object",
+                validate: isRecord,
+                retry: "safe-read",
+                signal: abortController.signal,
+              }),
+              cloudsmithAPI.get(retentionEndpoint, {
+                responseType: "object",
+                validate: isRecord,
+                retry: "safe-read",
+                signal: abortController.signal,
+              }),
               fetchRepositoryUpstreams(context, workspace, repoSlug, {
                 signal: abortController.signal,
               }),
@@ -2025,24 +2148,21 @@ async function activate(context) {
               return;
             }
 
-            if (typeof repoResult === "string") {
+            if (!repoResult.ok) {
+              if (repoResult.error.kind === "cancelled") {
+                return;
+              }
               vscode.window.showErrorMessage(
-                `Could not export repository. ${formatApiError(repoResult)}`
+                `Could not export repository. ${formatApiError(repoResult.error)}`
               );
               return;
             }
 
             const upstreamLoadFailed = Boolean(upstreamResult && upstreamResult.error);
-            const retentionRules = (
-              typeof retentionResult === "string" ||
-              !retentionResult ||
-              typeof retentionResult !== "object"
-            )
-              ? null
-              : retentionResult;
+            const retentionRules = retentionResult.ok ? retentionResult.data : null;
 
             const hclContent = generateTerraformConfig({
-              repo: repoResult,
+              repo: repoResult.data,
               workspace,
               upstreams: upstreamLoadFailed ? [] : upstreamResult.data,
               retention: retentionRules,
@@ -2070,6 +2190,7 @@ async function activate(context) {
               `Could not export repository. ${formatApiError(message)}`
             );
           } finally {
+            cancellationSubscription.dispose();
             if (exportTerraformAbortController === abortController) {
               exportTerraformAbortController = null;
             }
@@ -2124,13 +2245,28 @@ async function activate(context) {
 
       // Select repo
       const cloudsmithAPI = new CloudsmithAPI(context);
-      const repos = await cloudsmithAPI.get(`repos/${wsSlug}/?sort=name`);
-      if (typeof repos === "string" || !repos || repos.length === 0) {
+      let reposEndpoint;
+      try {
+        reposEndpoint = apiEndpoint(["repos", wsSlug], { query: { sort: "name" } });
+      } catch {
+        vscode.window.showErrorMessage("The workspace identifier was invalid.");
+        return;
+      }
+      const repos = await cloudsmithAPI.get(reposEndpoint, {
+        responseType: "array",
+        validate: isRepositoryArray,
+        retry: "safe-read",
+      });
+      if (!repos.ok) {
+        vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
+        return;
+      }
+      if (repos.data.length === 0) {
         vscode.window.showErrorMessage("No repositories found.");
         return;
       }
       const repoPick = await vscode.window.showQuickPick(
-        repos.map(r => ({ label: r.name, description: r.slug })),
+        repos.data.map(r => ({ label: r.name, description: r.slug })),
         { placeHolder: "Select target repository" }
       );
       if (!repoPick) return;
@@ -2153,7 +2289,7 @@ async function activate(context) {
       recentPackages.add(item);
 
       const info = extractPackageInfo(item);
-      if (!info.workspace || !info.name || !info.version) {
+      if (!info.workspace || !info.name || !info.version || !info.format) {
         vscode.window.showWarningMessage("Could not determine package details.");
         return;
       }
@@ -2161,9 +2297,17 @@ async function activate(context) {
       const pipeline = promotionProvider.getPipeline();
       if (pipeline.length > 0) {
         // Pipeline mode: show status across configured repos
-        const status = await promotionProvider.getPromotionStatus(
+        const statusResult = await promotionProvider.getPromotionStatus(
           info.workspace, info.name, info.version, info.format
         );
+
+        if (statusResult.error) {
+          vscode.window.showErrorMessage(
+            `Could not load promotion status. ${formatApiError(statusResult.error)}`
+          );
+          return;
+        }
+        const status = statusResult.items;
 
         if (status.length === 0) {
           vscode.window.showInformationMessage("No pipeline repositories found.");
@@ -2180,17 +2324,37 @@ async function activate(context) {
       } else {
         // No pipeline: search workspace-wide for this package name+version
         const cloudsmithAPI = new CloudsmithAPI(context);
-        const query = encodeURIComponent(`name:^${info.name}$ AND version:${info.version}`);
-        const results = await cloudsmithAPI.get(
-          `packages/${info.workspace}/?query=${query}&page_size=100`
-        );
+        let endpoint;
+        try {
+          endpoint = apiEndpoint(["packages", info.workspace], {
+            query: {
+              query: buildExactPackageQuery(info.name, info.version, info.format),
+              page_size: 100,
+            },
+          });
+        } catch {
+          vscode.window.showErrorMessage("The package search parameters were invalid.");
+          return;
+        }
+        const results = await cloudsmithAPI.get(endpoint, {
+          responseType: "array",
+          validate: isPackageLocationArray,
+          retry: "never",
+        });
 
-        if (typeof results === "string" || !Array.isArray(results) || results.length === 0) {
+        if (!results.ok) {
+          vscode.window.showErrorMessage(
+            `Could not load package locations. ${formatApiError(results.error)}`
+          );
+          return;
+        }
+        const exactPackages = results.data.filter(pkg => packageMatchesExactIdentity(pkg, info));
+        if (exactPackages.length === 0) {
           vscode.window.showInformationMessage(`${info.name} ${info.version} was not found in any other repository.`);
           return;
         }
 
-        const lines = results.map(pkg => {
+        const lines = exactPackages.map(pkg => {
           const icon = pkg.status_str === "Quarantined" ? "\u274C" : (pkg.policy_violated ? "\u26A0\uFE0F" : "\u2705");
           return `${icon} ${pkg.repository}: ${pkg.status_str || "Unknown"}`;
         });
@@ -2209,7 +2373,14 @@ async function activate(context) {
       recentPackages.add(item);
 
       const info = extractPackageInfo(item);
-      if (!info.workspace || !info.repo || !info.slugPerm) {
+      if (
+        !info.workspace
+        || !info.repo
+        || !info.slugPerm
+        || !info.name
+        || !info.version
+        || !info.format
+      ) {
         vscode.window.showWarningMessage("Could not determine package details.");
         return;
       }
@@ -2241,13 +2412,30 @@ async function activate(context) {
         targetItems = eligibleTargets.map(r => ({ label: r, description: r, _slug: r }));
       } else {
         // No pipeline: show all workspace repos except the source
-        const repos = await cloudsmithAPI.get(`repos/${info.workspace}/?sort=name`);
-        if (typeof repos === "string" || !Array.isArray(repos) || repos.length === 0) {
-          vscode.window.showErrorMessage("Could not fetch workspace repositories.");
+        let reposEndpoint;
+        try {
+          reposEndpoint = apiEndpoint(["repos", info.workspace], { query: { sort: "name" } });
+        } catch {
+          vscode.window.showErrorMessage("The workspace identifier was invalid.");
+          return;
+        }
+        const repos = await cloudsmithAPI.get(reposEndpoint, {
+          responseType: "array",
+          validate: isRepositoryArray,
+          retry: "safe-read",
+        });
+        if (!repos.ok) {
+          vscode.window.showErrorMessage(
+            `Could not fetch workspace repositories. ${formatApiError(repos.error)}`
+          );
+          return;
+        }
+        if (repos.data.length === 0) {
+          vscode.window.showErrorMessage("No target repositories were found.");
           return;
         }
 
-        targetItems = repos
+        targetItems = repos.data
           .filter(r => r.slug !== info.repo)
           .map(r => ({ label: r.name, description: r.slug, _slug: r.slug }));
       }
@@ -2258,22 +2446,39 @@ async function activate(context) {
       const recentTargets = (history[info.repo] || []).slice(0, 5);
 
       // Check where this package already exists (workspace-wide search)
-      let existingRepoMap = {};
+      const existingRepoMap = new Map();
       if (info.name && info.version) {
-        const query = encodeURIComponent(`name:^${info.name}$ AND version:${info.version}`);
-        const existingResults = await cloudsmithAPI.get(
-          `packages/${info.workspace}/?query=${query}&page_size=100`
-        );
-        if (Array.isArray(existingResults)) {
-          for (const pkg of existingResults) {
-            existingRepoMap[pkg.repository] = pkg.status_str || "Unknown";
-          }
+        let existingEndpoint;
+        try {
+          existingEndpoint = apiEndpoint(["packages", info.workspace], {
+            query: {
+              query: buildExactPackageQuery(info.name, info.version, info.format),
+              page_size: 100,
+            },
+          });
+        } catch {
+          vscode.window.showErrorMessage("The package search parameters were invalid.");
+          return;
+        }
+        const existingResults = await cloudsmithAPI.get(existingEndpoint, {
+          responseType: "array",
+          validate: isPackageLocationArray,
+          retry: "never",
+        });
+        if (!existingResults.ok) {
+          vscode.window.showErrorMessage(
+            `Could not check existing package locations. ${formatApiError(existingResults.error)}`
+          );
+          return;
+        }
+        for (const pkg of existingResults.data.filter(pkg => packageMatchesExactIdentity(pkg, info))) {
+            existingRepoMap.set(pkg.repository, pkg.status_str || "Unknown");
         }
       }
 
       // Annotate target items with existence status
       for (const ti of targetItems) {
-        const existingStatus = existingRepoMap[ti._slug];
+        const existingStatus = existingRepoMap.get(ti._slug);
         if (existingStatus) {
           ti.description = `${ti._slug} — already exists (${existingStatus})`;
         } else {

--- a/models/repositoryNode.js
+++ b/models/repositoryNode.js
@@ -2,6 +2,7 @@
 
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
 const upstreamChecker = require("../util/upstreamChecker");
 const {
   normalizeUpstreamFormat,
@@ -118,29 +119,43 @@ class RepositoryNode {
 
     const activeFilter = this._getActiveFilter();
     const filterQuery = activeFilter ? (activeFilter.query || activeFilter) : null;
-    const filterParam = filterQuery ? `&query=${encodeURIComponent(filterQuery)}` : '';
-
-
     let apiFailed = false;
-    if (!groupByPackageGroup) {
-      const apiUrl = "packages/" + workspace + "/" + repo + "/?sort=-date&page_size=" + maxPackages + filterParam;
-      packages = await cloudsmithAPI.get(apiUrl);
-      // Guard against error string from API
-      if (typeof packages === 'string' || !Array.isArray(packages)) {
-        apiFailed = true;
-        packages = [];
-      }
-    } else {
-      const groups = await cloudsmithAPI.get(
-        "packages/" + workspace + "/" + repo + "/groups/?sort=-last_push&page_size=" + maxPackages + filterParam
-      );
-      // Guard against error string from API
-      if (typeof groups === 'string' || !groups || !groups.results) {
-        apiFailed = true;
-        packages = [];
+    try {
+      const query = {
+        sort: groupByPackageGroup ? "-last_push" : "-date",
+        page_size: maxPackages,
+        ...(filterQuery ? { query: filterQuery } : {}),
+      };
+      if (!groupByPackageGroup) {
+        const result = await cloudsmithAPI.get(
+          apiEndpoint(["packages", workspace, repo], { query }),
+          { responseType: "array", validate: isPackageArray, retry: "safe-read" }
+        );
+        if (result.ok) {
+          packages = result.data;
+        } else {
+          apiFailed = true;
+          packages = [];
+        }
       } else {
-        packages = groups.results;
+        const result = await cloudsmithAPI.get(
+          apiEndpoint(["packages", workspace, repo, "groups"], { query }),
+          {
+            responseType: "object",
+            validate: value => isPackageGroupArray(value.results),
+            retry: "safe-read",
+          }
+        );
+        if (result.ok) {
+          packages = result.data.results;
+        } else {
+          apiFailed = true;
+          packages = [];
+        }
       }
+    } catch {
+      apiFailed = true;
+      packages = [];
     }
     this._lastApiFailed = apiFailed;
 
@@ -238,13 +253,23 @@ class RepositoryNode {
    */
   async getEntitlements() {
     const cloudsmithAPI = new CloudsmithAPI(this.context);
-    const result = await cloudsmithAPI.get(
-      `entitlements/${this.workspace}/${this.slug}/?page_size=50`
-    );
-    if (typeof result === "string" || !Array.isArray(result)) {
-      return [];
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["entitlements", this.workspace, this.slug], {
+        query: { page_size: 50 },
+      });
+    } catch {
+      throw new Error("The entitlement endpoint was invalid.");
     }
-    return result;
+    const result = await cloudsmithAPI.get(endpoint, {
+      responseType: "array",
+      validate: isEntitlementArray,
+      retry: "safe-read",
+    });
+    if (!result.ok) {
+      throw result.error;
+    }
+    return result.data;
   }
 
   async getChildren() {
@@ -341,6 +366,50 @@ class RepositoryNode {
 
     return children;
   }
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(item => (
+    Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  ));
+}
+
+function unwrapIdentifier(value) {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
+    ? value.value
+    : null;
+}
+
+function isPackageArray(value) {
+  return isRecordArray(value) && value.every(pkg => (
+    typeof pkg.name === "string" && pkg.name.length > 0
+    && typeof pkg.format === "string" && pkg.format.length > 0
+    && (typeof pkg.version === "string" || typeof pkg.version === "number")
+    && String(pkg.version).length > 0
+    && typeof pkg.repository === "string" && pkg.repository.length > 0
+    && typeof pkg.namespace === "string" && pkg.namespace.length > 0
+    && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+  ));
+}
+
+function isPackageGroupArray(value) {
+  return isRecordArray(value) && value.every(group => (
+    typeof group.name === "string"
+    && group.name.length > 0
+    && [group.format, group.package_format, group.packageFormat]
+      .some(format => typeof format === "string" && format.length > 0)
+  ));
+}
+
+function isEntitlementArray(value) {
+  return isRecordArray(value) && value.every(entitlement => (
+    typeof entitlement.name === "string"
+    && entitlement.name.trim().length > 0
+    && (entitlement.is_active === undefined || typeof entitlement.is_active === "boolean")
+  ));
 }
 
 module.exports = RepositoryNode;

--- a/models/vulnerabilitySummaryNode.js
+++ b/models/vulnerabilitySummaryNode.js
@@ -10,6 +10,7 @@
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { fetchPackageVulnerabilities } = require("../util/packageVulnerabilities");
+const { formatApiError } = require("../util/errorFormatter");
 const VulnerabilityNode = require("./vulnerabilityNode");
 const InfoNode = require("./infoNode");
 
@@ -110,7 +111,7 @@ class VulnerabilitySummaryNode {
     this.maxSeverity = data.maxSeverity;
 
     if (data.error) {
-      throw new Error(data.error);
+      throw new Error(formatApiError(data.error));
     }
 
     return data.results;

--- a/models/workspaceNode.js
+++ b/models/workspaceNode.js
@@ -3,6 +3,8 @@
 const vscode = require("vscode");
 const path = require("path");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
+const { formatApiError } = require("../util/errorFormatter");
 const InfoNode = require("./infoNode");
 const repositoryNode = require("./repositoryNode");
 const { WorkspaceInfoNode } = require("./workspaceInfoNode");
@@ -43,7 +45,7 @@ class WorkspaceNode {
       return [new InfoNode(
         "Failed to load repositories",
         "Check your connection and try refreshing",
-        `Failed to load repositories for ${workspace}: ${result.error}`,
+        `Failed to load repositories for ${workspace}: ${formatApiError(result.error)}`,
         "warning"
       )];
     }
@@ -73,10 +75,13 @@ class WorkspaceNode {
 
     try {
       const cloudsmithAPI = new CloudsmithAPI(this.context);
-      const result = await cloudsmithAPI.get(`quota/${this.workspace}/`);
+      const result = await cloudsmithAPI.get(apiEndpoint(["quota", this.workspace]), {
+        responseType: "object",
+        retry: "safe-read",
+      });
 
-      if (typeof result !== "string" && result && result.usage) {
-        quotaData = result;
+      if (result.ok && result.data.usage && typeof result.data.usage === "object") {
+        quotaData = result.data;
       }
     } catch {
       // Quota access is optional for this node.

--- a/test/apiEndpoint.test.js
+++ b/test/apiEndpoint.test.js
@@ -1,0 +1,73 @@
+const assert = require("assert");
+const {
+  apiEndpoint,
+  appendApiQuery,
+  encodeApiPathSegment,
+} = require("../util/apiEndpoint");
+
+suite("Cloudsmith API endpoint construction", () => {
+  test("encodes dynamic path and query values without changing their structure", () => {
+    assert.strictEqual(
+      apiEndpoint(["packages", "workspace & team", "repo"], {
+        query: { query: "name:widget & version:1.0", page_size: 100 },
+      }),
+      "packages/workspace%20%26%20team/repo/?query=name%3Awidget+%26+version%3A1.0&page_size=100"
+    );
+  });
+
+  test("rejects direct and repeatedly encoded separators, traversal, controls, and query delimiters", () => {
+    const unsafeValues = [
+      ".",
+      "..",
+      "../outside",
+      "repo/name",
+      "repo\\name",
+      "repo?admin=true",
+      "repo#fragment",
+      "%2foutside",
+      "%252foutside",
+      "%252e%252e",
+      "repo\nname",
+    ];
+
+    for (const value of unsafeValues) {
+      assert.throws(() => encodeApiPathSegment(value), /unsafe|unsupported|invalid/i, value);
+    }
+  });
+
+  test("rejects secret query names and non-scalar values", () => {
+    for (const name of [
+      "api_key",
+      "ApiKey",
+      "access-token",
+      "Authorization",
+      "token",
+      "x-api-key",
+      "x_api_key",
+      "client_secret",
+      "refresh-token",
+      "id_token",
+      "password",
+      "private_key",
+    ]) {
+      assert.throws(() => apiEndpoint(["packages"], { query: { [name]: "secret" } }), /credentials/i);
+    }
+    assert.throws(
+      () => appendApiQuery("packages/?client%255fsecret=old-secret", { page: 1 }),
+      /credentials/i
+    );
+    assert.throws(
+      () => apiEndpoint(["packages"], { query: { filter: { name: "artifact" } } }),
+      /invalid/i
+    );
+  });
+
+  test("appends pagination without allowing endpoint root or secret-query escape", () => {
+    assert.strictEqual(
+      appendApiQuery("packages/workspace/", { page: 2, page_size: 100 }),
+      "packages/workspace/?page=2&page_size=100"
+    );
+    assert.throws(() => appendApiQuery("https://evil.test/", { page: 1 }), /escaped/i);
+    assert.throws(() => appendApiQuery("packages/?token=secret", { page: 1 }), /credentials/i);
+  });
+});

--- a/test/apiResultHelpers.js
+++ b/test/apiResultHelpers.js
@@ -1,0 +1,40 @@
+function apiSuccess(data, options = {}) {
+  return {
+    ok: true,
+    data,
+    status: options.status || 200,
+    headers: options.headers || {},
+    requestId: options.requestId || "test-request-id",
+    serverRequestId: null,
+    attempts: options.attempts || 1,
+    redirectCount: 0,
+  };
+}
+
+function apiFailure(kind, options = {}) {
+  const status = Object.prototype.hasOwnProperty.call(options, "status")
+    ? options.status
+    : null;
+  const message = options.message || `Test ${kind} failure.`;
+  const error = {
+    kind,
+    status,
+    retryable: Boolean(options.retryable),
+    message,
+    requestId: options.requestId || "test-request-id",
+    retryAfterMs: options.retryAfterMs || null,
+    outcomeUnknown: Boolean(options.outcomeUnknown),
+    diagnostic: {},
+  };
+  return {
+    ok: false,
+    status,
+    headers: options.headers || {},
+    requestId: error.requestId,
+    serverRequestId: null,
+    attempts: options.attempts || 1,
+    error,
+  };
+}
+
+module.exports = { apiFailure, apiSuccess };

--- a/test/cloudsmithAPI.test.js
+++ b/test/cloudsmithAPI.test.js
@@ -1,0 +1,625 @@
+const assert = require("assert");
+const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+
+const API_KEY = "csa_test_transport_secret_value";
+
+function jsonResponse(data, status = 200, headers = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function textResponse(body, status = 200, headers = {}) {
+  return new Response(body, { status, headers });
+}
+
+function createApi(fetchImpl, options = {}) {
+  return new CloudsmithAPI({}, {
+    fetchImpl,
+    credentialManager: options.credentialManager || {
+      async getApiKey() {
+        return API_KEY;
+      },
+    },
+    randomUUID: () => "logical-request-id",
+    ...(options.setTimeout ? { setTimeout: options.setTimeout } : {}),
+    ...(options.clearTimeout ? { clearTimeout: options.clearTimeout } : {}),
+    ...(options.now ? { now: options.now } : {}),
+  });
+}
+
+function nextTurn() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+suite("CloudsmithAPI typed transport", () => {
+  test("returns typed JSON success metadata and a frozen allowlisted header snapshot", async () => {
+    const api = createApi(async (_url, request) => {
+      assert.strictEqual(request.headers["X-Api-Key"], API_KEY);
+      assert.strictEqual(request.redirect, "manual");
+      return jsonResponse([{ slug: "workspace" }], 200, {
+        "x-request-id": "server-request-id",
+        "x-pagination-page": "1",
+        "set-cookie": "sensitive=true",
+      });
+    });
+
+    const result = await api.get("namespaces/", {
+      responseType: "array",
+      validate: value => value.every(item => typeof item.slug === "string"),
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.data, [{ slug: "workspace" }]);
+    assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.requestId, "logical-request-id");
+    assert.strictEqual(result.serverRequestId, "server-request-id");
+    assert.strictEqual(result.headers["x-pagination-page"], "1");
+    assert.strictEqual(result.headers["set-cookie"], undefined);
+    assert.strictEqual(Object.isFrozen(result), true);
+    assert.strictEqual(Object.isFrozen(result.headers), true);
+    assert.strictEqual(Reflect.set(result.headers, "x-pagination-page", "2"), false);
+  });
+
+  test("supports 201 JSON, explicit 204 empty, and explicitly expected primitive JSON", async () => {
+    const responses = [
+      jsonResponse({ copied: true }, 201),
+      new Response(null, { status: 204 }),
+      jsonResponse("primitive-value"),
+    ];
+    const api = createApi(async () => responses.shift());
+
+    const created = await api.post("packages/workspace/repo/pkg/copy/", {}, {
+      responseType: "object",
+    });
+    const empty = await api.request("packages/workspace/repo/pkg/tag/", {
+      method: "POST",
+      apiVersion: "v1",
+      json: {},
+      responseType: "empty",
+    });
+    const primitive = await api.get("user/self", { responseType: "json" });
+
+    assert.strictEqual(created.ok, true);
+    assert.strictEqual(created.status, 201);
+    assert.strictEqual(empty.ok, true);
+    assert.strictEqual(empty.data, null);
+    assert.strictEqual(primitive.ok, true);
+    assert.strictEqual(primitive.data, "primitive-value");
+  });
+
+  test("maps invalid JSON, content type, response shape, and validator failures", async () => {
+    const responses = [
+      textResponse("{bad", 200, { "content-type": "application/json" }),
+      textResponse("{}", 200, { "content-type": "text/html" }),
+      jsonResponse({ results: [] }),
+      jsonResponse([{ slug: "workspace" }]),
+    ];
+    const api = createApi(async () => responses.shift());
+
+    const invalidJson = await api.get("namespaces/", { responseType: "array" });
+    const wrongType = await api.get("namespaces/", { responseType: "object" });
+    const wrongShape = await api.get("namespaces/", { responseType: "array" });
+    const throwingValidator = await api.get("namespaces/", {
+      responseType: "array",
+      validate() {
+        throw new Error("validator failed");
+      },
+    });
+
+    for (const result of [invalidJson, wrongType, wrongShape, throwingValidator]) {
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.error.kind, "invalid_response");
+    }
+  });
+
+  test("maps representative HTTP failures without retaining response bodies", async () => {
+    const cases = [
+      [400, "http_error"],
+      [401, "unauthorized"],
+      [403, "forbidden"],
+      [404, "not_found"],
+      [429, "rate_limited"],
+      [500, "server_error"],
+      [502, "server_error"],
+      [503, "server_error"],
+    ];
+
+    for (const [status, kind] of cases) {
+      const api = createApi(async () => textResponse(
+        `private response ${API_KEY} Authorization: bearer-secret`,
+        status,
+        { "content-type": "text/plain" }
+      ));
+      const result = await api.get("packages/workspace/");
+      const serialized = JSON.stringify(result);
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.status, status);
+      assert.strictEqual(result.error.kind, kind);
+      assert.doesNotMatch(serialized, /private response|bearer-secret/);
+      assert.doesNotMatch(serialized, new RegExp(API_KEY));
+    }
+  });
+
+  test("classifies a network failure without serializing exception secrets", async () => {
+    const api = createApi(async () => {
+      const error = new Error(`fetch failed for https://api.cloudsmith.io/?token=${API_KEY}`);
+      error.code = "ENOTFOUND";
+      throw error;
+    });
+
+    const result = await api.get("packages/workspace/");
+
+    assert.strictEqual(result.error.kind, "network_error");
+    assert.strictEqual(result.error.diagnostic.causeCode, "ENOTFOUND");
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(API_KEY));
+    assert.doesNotMatch(JSON.stringify(result), /token=/);
+  });
+
+  test("aborts the actual fetch on timeout and clears the deadline timer", async () => {
+    let fetchWasAborted = false;
+    let clearedTimers = 0;
+    const api = createApi((_url, request) => new Promise((_resolve, reject) => {
+      request.signal.addEventListener("abort", () => {
+        fetchWasAborted = true;
+        reject(new DOMException("aborted", "AbortError"));
+      }, { once: true });
+    }), {
+      clearTimeout(handle) {
+        clearedTimers += 1;
+        clearTimeout(handle);
+      },
+    });
+
+    const result = await api.get("packages/workspace/", { timeoutMs: 10 });
+
+    assert.strictEqual(result.error.kind, "timeout");
+    assert.strictEqual(fetchWasAborted, true);
+    assert.strictEqual(clearedTimers, 1);
+  });
+
+  test("timeout settles hanging credential lookup and ignored late fetch success", async () => {
+    let credentialTimeout;
+    let fetchCalls = 0;
+    const credentialApi = createApi(async () => {
+      fetchCalls += 1;
+      return jsonResponse({ authenticated: true });
+    }, {
+      credentialManager: { getApiKey() { return new Promise(() => {}); } },
+      setTimeout(callback) { credentialTimeout = callback; return {}; },
+      clearTimeout() {},
+    });
+    const credentialPending = credentialApi.get("user/self", { responseType: "object" });
+    await nextTurn();
+    credentialTimeout();
+    const credentialResult = await credentialPending;
+    assert.strictEqual(credentialResult.error.kind, "timeout");
+    assert.strictEqual(fetchCalls, 0);
+
+    let fetchTimeout;
+    let lateResolve;
+    let lateCancelCalled = false;
+    const lateApi = createApi(async () => new Promise(resolve => { lateResolve = resolve; }), {
+      setTimeout(callback) { fetchTimeout = callback; return {}; },
+      clearTimeout() {},
+    });
+    const latePending = lateApi.get("user/self", { responseType: "object" });
+    await nextTurn();
+    fetchTimeout();
+    const lateResult = await latePending;
+    assert.strictEqual(lateResult.error.kind, "timeout");
+    lateResolve({
+      status: 200,
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: { cancel() { lateCancelCalled = true; return new Promise(() => {}); } },
+    });
+    await nextTurn();
+    assert.strictEqual(lateCancelCalled, true);
+  });
+
+  test("elapsed absolute deadline wins even when the timeout callback is delayed", async () => {
+    let now = 1_000;
+    const api = createApi(async () => {
+      now = 1_011;
+      return jsonResponse({ authenticated: true });
+    }, {
+      now: () => now,
+      setTimeout() { return {}; },
+      clearTimeout() {},
+    });
+
+    const result = await api.get("user/self", { responseType: "object", timeoutMs: 10 });
+
+    assert.strictEqual(result.error.kind, "timeout");
+  });
+
+  test("pre-cancellation makes no fetch and disposes the cancellation listener", async () => {
+    let fetchCalls = 0;
+    let listeners = 0;
+    let disposals = 0;
+    const token = {
+      isCancellationRequested: true,
+      onCancellationRequested() {
+        listeners += 1;
+        return { dispose() { disposals += 1; } };
+      },
+    };
+    const api = createApi(async () => {
+      fetchCalls += 1;
+      return jsonResponse({});
+    });
+
+    const result = await api.get("user/self", { cancellationToken: token });
+
+    assert.strictEqual(result.error.kind, "cancelled");
+    assert.strictEqual(fetchCalls, 0);
+    assert.strictEqual(listeners, 1);
+    assert.strictEqual(disposals, 1);
+  });
+
+  test("removes an external abort listener on successful completion", async () => {
+    let added = 0;
+    let removed = 0;
+    const signal = {
+      aborted: false,
+      addEventListener(event, listener) {
+        assert.strictEqual(event, "abort");
+        assert.strictEqual(typeof listener, "function");
+        added += 1;
+      },
+      removeEventListener(event, listener) {
+        assert.strictEqual(event, "abort");
+        assert.strictEqual(typeof listener, "function");
+        removed += 1;
+      },
+    };
+    const api = createApi(async () => jsonResponse({ authenticated: true }));
+
+    const result = await api.get("user/self", { signal, responseType: "object" });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(added, 1);
+    assert.strictEqual(removed, 1);
+  });
+
+  test("redacts secrets from allowlisted server correlation headers", async () => {
+    const api = createApi(async () => jsonResponse({}, 200, {
+      "x-request-id": `server-${API_KEY}`,
+    }));
+
+    const result = await api.get("user/self", { responseType: "object" });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.serverRequestId, "server-[REDACTED]");
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(API_KEY));
+  });
+
+  test("the first abort cause wins a timeout and user-cancel race", async () => {
+    let deadlineCallback;
+    const external = new AbortController();
+    const api = createApi((_url, request) => new Promise((_resolve, reject) => {
+      request.signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+    }), {
+      setTimeout(callback, delay) {
+        if (delay === 1000) deadlineCallback = callback;
+        return { delay };
+      },
+      clearTimeout() {},
+    });
+
+    const pending = api.get("user/self", { timeoutMs: 1000, signal: external.signal });
+    await nextTurn();
+    deadlineCallback();
+    external.abort();
+    const result = await pending;
+
+    assert.strictEqual(result.error.kind, "timeout");
+  });
+
+  test("retries an opted-in safe read and caps attempts at three", async () => {
+    let successCalls = 0;
+    const successApi = createApi(async () => {
+      successCalls += 1;
+      return successCalls === 1
+        ? textResponse("busy", 503, { "retry-after": "0" })
+        : jsonResponse({ authenticated: true });
+    });
+    const eventual = await successApi.get("user/self", {
+      responseType: "object",
+      retry: "safe-read",
+    });
+
+    let cappedCalls = 0;
+    const cappedApi = createApi(async () => {
+      cappedCalls += 1;
+      return textResponse("busy", 503, { "retry-after": "0" });
+    });
+    const capped = await cappedApi.get("user/self", { retry: "safe-read" });
+
+    assert.strictEqual(eventual.ok, true);
+    assert.strictEqual(eventual.attempts, 2);
+    assert.strictEqual(successCalls, 2);
+    assert.strictEqual(capped.ok, false);
+    assert.strictEqual(capped.attempts, 3);
+    assert.strictEqual(cappedCalls, 3);
+  });
+
+  test("honors Retry-After seconds and HTTP-date but rejects excessive delays", async () => {
+    const now = Date.parse("2026-08-09T12:00:00.000Z");
+    for (const [retryAfter, expectedDelay] of [
+      ["1", 1000],
+      [new Date(now + 2000).toUTCString(), 2000],
+    ]) {
+      const delays = [];
+      let calls = 0;
+      const api = createApi(async () => {
+        calls += 1;
+        return calls === 1
+          ? textResponse("limited", 429, { "retry-after": retryAfter })
+          : jsonResponse({ authenticated: true });
+      }, {
+        now: () => now,
+        setTimeout(callback, delay) {
+          if (delay !== 30000) {
+            delays.push(delay);
+            queueMicrotask(callback);
+          }
+          return { delay };
+        },
+        clearTimeout() {},
+      });
+
+      const result = await api.get("user/self", { retry: "safe-read" });
+      assert.strictEqual(result.ok, true);
+      assert.deepStrictEqual(delays, [expectedDelay]);
+    }
+
+    let calls = 0;
+    const excessiveApi = createApi(async () => {
+      calls += 1;
+      return textResponse("limited", 429, { "retry-after": "60" });
+    });
+    const excessive = await excessiveApi.get("user/self", { retry: "safe-read" });
+    assert.strictEqual(excessive.error.kind, "rate_limited");
+    assert.strictEqual(excessive.error.retryAfterMs, 60000);
+    assert.strictEqual(calls, 1);
+  });
+
+  test("cancellation during retry backoff clears the delay and stops requests", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    let retryTimerCleared = false;
+    let retryTimerHandle;
+    const api = createApi(async () => {
+      calls += 1;
+      return textResponse("limited", 429, { "retry-after": "1" });
+    }, {
+      setTimeout(callback, delay) {
+        const handle = { callback, delay };
+        if (delay === 1000) retryTimerHandle = handle;
+        return handle;
+      },
+      clearTimeout(handle) {
+        if (handle === retryTimerHandle) retryTimerCleared = true;
+      },
+    });
+
+    const pending = api.get("user/self", { retry: "safe-read", signal: controller.signal });
+    while (!retryTimerHandle) await nextTurn();
+    controller.abort();
+    const result = await pending;
+
+    assert.strictEqual(result.error.kind, "cancelled");
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(retryTimerCleared, true);
+  });
+
+  test("follows one same-origin GET redirect and retains credentials only on the validated hop", async () => {
+    const calls = [];
+    const api = createApi(async (url, request) => {
+      calls.push({ url: String(url), key: request.headers["X-Api-Key"] });
+      if (calls.length === 1) {
+        return textResponse("", 302, { location: "/v1/namespaces/?sort=slug" });
+      }
+      return jsonResponse([]);
+    });
+
+    const result = await api.get("packages/workspace/", { responseType: "array" });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.redirectCount, 1);
+    assert.strictEqual(calls.length, 2);
+    assert.ok(calls[1].url.startsWith("https://api.cloudsmith.io/v1/namespaces/"));
+    assert.deepStrictEqual(calls.map(call => call.key), [API_KEY, API_KEY]);
+  });
+
+  test("rejects hostile, confused, downgraded, credentialed, and root-escaping redirects", async () => {
+    const locations = [
+      "https://evil.test/v1/packages/",
+      "https://evil.api.cloudsmith.io/v1/packages/",
+      "https://api.cloudsmith.io.evil.test/v1/packages/",
+      "http://api.cloudsmith.io/v1/packages/",
+      "https://user@api.cloudsmith.io/v1/packages/",
+      "https://api.cloudsmith.io:444/v1/packages/",
+      "https://api.cloudsmith.io/v2/packages/",
+      "../../../outside/",
+      "https://api.cloudsmith.io./v1/packages/",
+    ];
+
+    for (const location of locations) {
+      let calls = 0;
+      const api = createApi(async () => {
+        calls += 1;
+        return textResponse("", 302, { location });
+      });
+      const result = await api.get("packages/workspace/");
+      assert.strictEqual(result.error.kind, "redirect_rejected", location);
+      assert.strictEqual(calls, 1, location);
+    }
+  });
+
+  test("rejects redirect loops, extra redirects, and every write redirect without replay", async () => {
+    let loopCalls = 0;
+    const loopApi = createApi(async () => {
+      loopCalls += 1;
+      return textResponse("", 302, { location: "/v1/packages/workspace/" });
+    });
+    const loop = await loopApi.get("packages/workspace/");
+    assert.strictEqual(loop.error.kind, "redirect_rejected");
+    assert.strictEqual(loopCalls, 1);
+
+    let chainCalls = 0;
+    const chainApi = createApi(async () => {
+      chainCalls += 1;
+      return textResponse("", 302, { location: `packages/workspace/page-${chainCalls}/` });
+    });
+    const chain = await chainApi.get("packages/workspace/");
+    assert.strictEqual(chain.error.kind, "redirect_rejected");
+    assert.strictEqual(chainCalls, 2);
+
+    for (const status of [301, 302, 303, 307, 308]) {
+      let calls = 0;
+      const writeApi = createApi(async () => {
+        calls += 1;
+        return textResponse("", status, { location: "packages/workspace/repo/pkg/copied/" });
+      });
+      const result = await writeApi.post("packages/workspace/repo/pkg/copy/", {}, {
+        responseType: "object",
+      });
+      assert.strictEqual(result.error.kind, "redirect_rejected");
+      assert.strictEqual(calls, 1);
+    }
+  });
+
+  test("never retries writes and marks post-dispatch uncertainty", async () => {
+    let serverCalls = 0;
+    const serverApi = createApi(async () => {
+      serverCalls += 1;
+      return textResponse("failed", 503);
+    });
+    const serverResult = await serverApi.post("packages/workspace/repo/pkg/copy/", {}, {
+      responseType: "object",
+    });
+
+    let malformedCalls = 0;
+    const malformedApi = createApi(async () => {
+      malformedCalls += 1;
+      return textResponse("not-json", 200, { "content-type": "application/json" });
+    });
+    const malformed = await malformedApi.post("packages/workspace/repo/pkg/tag/", {}, {
+      responseType: "object",
+    });
+
+    assert.strictEqual(serverCalls, 1);
+    assert.strictEqual(serverResult.error.outcomeUnknown, true);
+    assert.match(serverResult.error.message, /may have completed/);
+    assert.strictEqual(malformedCalls, 1);
+    assert.strictEqual(malformed.error.kind, "invalid_response");
+    assert.strictEqual(malformed.error.outcomeUnknown, true);
+  });
+
+  test("rejects credential-bearing endpoints, empty candidate keys, and oversized success bodies before unsafe use", async () => {
+    let calls = 0;
+    const api = createApi(async () => {
+      calls += 1;
+      return jsonResponse({});
+    });
+    const secretEndpoint = await api.get(`packages/workspace/?token=${API_KEY}`);
+    const secretValue = await api.get(`packages/workspace/?query=${API_KEY}`);
+    const oldSecretName = await api.get("packages/workspace/?x-api-key=old-secret-value");
+    const encodedSecretName = await api.get("packages/workspace/?client%255fsecret=old-secret-value");
+    const emptyCandidate = await api.get("user/self", { apiKey: "" });
+
+    assert.strictEqual(secretEndpoint.error.kind, "invalid_request");
+    assert.strictEqual(secretValue.error.kind, "invalid_request");
+    assert.strictEqual(oldSecretName.error.kind, "invalid_request");
+    assert.strictEqual(encodedSecretName.error.kind, "invalid_request");
+    assert.strictEqual(emptyCandidate.error.kind, "unauthorized");
+    assert.strictEqual(calls, 0);
+    assert.doesNotMatch(JSON.stringify(secretEndpoint), new RegExp(API_KEY));
+    assert.doesNotMatch(JSON.stringify(secretValue), new RegExp(API_KEY));
+
+    const oversizedApi = createApi(async () => textResponse("{}", 200, {
+      "content-type": "application/json",
+      "content-length": String(6 * 1024 * 1024),
+    }));
+    const oversized = await oversizedApi.get("user/self", { responseType: "object" });
+    assert.strictEqual(oversized.error.kind, "invalid_response");
+  });
+
+  test("rejects stored and candidate keys found at intermediate URL decode layers", async () => {
+    let storedCalls = 0;
+    const storedApi = createApi(async () => {
+      storedCalls += 1;
+      return jsonResponse({});
+    }, {
+      credentialManager: {
+        async getApiKey() {
+          return "stored%41";
+        },
+      },
+    });
+    const storedResult = await storedApi.get("packages/stored%2541/");
+
+    let candidateCalls = 0;
+    const candidateApi = createApi(async () => {
+      candidateCalls += 1;
+      return jsonResponse({});
+    });
+    const candidateResult = await candidateApi.get("packages/candidate%2541/", {
+      apiKey: "candidate%41",
+    });
+
+    assert.strictEqual(storedResult.error.kind, "invalid_request");
+    assert.strictEqual(candidateResult.error.kind, "invalid_request");
+    assert.strictEqual(storedCalls, 0);
+    assert.strictEqual(candidateCalls, 0);
+    assert.doesNotMatch(JSON.stringify(storedResult), /stored%41/i);
+    assert.doesNotMatch(JSON.stringify(candidateResult), /candidate%41/i);
+  });
+
+  test("never falls back to unbounded text reads and bounds unknown-length streamed bodies", async () => {
+    let textRead = false;
+    let bodyCanceled = false;
+    const nonStreamingApi = createApi(async () => ({
+      status: 200,
+      statusText: "OK",
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: { async cancel() { bodyCanceled = true; } },
+      async text() { textRead = true; return JSON.stringify({ authenticated: true }); },
+    }));
+    const nonStreaming = await nonStreamingApi.get("user/self", { responseType: "object" });
+    assert.strictEqual(nonStreaming.error.kind, "invalid_response");
+    assert.strictEqual(textRead, false);
+    assert.strictEqual(bodyCanceled, true);
+
+    let streamCanceled = false;
+    let streamReads = 0;
+    const oversizedStreamApi = createApi(async () => ({
+      status: 200,
+      statusText: "OK",
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: {
+        getReader() {
+          return {
+            async read() {
+              streamReads += 1;
+              return { done: false, value: new Uint8Array((5 * 1024 * 1024) + 1) };
+            },
+            async cancel() { streamCanceled = true; },
+            releaseLock() {},
+          };
+        },
+      },
+    }));
+    const oversizedStream = await oversizedStreamApi.get("user/self", { responseType: "object" });
+    assert.strictEqual(oversizedStream.error.kind, "invalid_response");
+    assert.strictEqual(streamReads, 1);
+    assert.strictEqual(streamCanceled, true);
+  });
+});

--- a/test/cloudsmithProvider.test.js
+++ b/test/cloudsmithProvider.test.js
@@ -1,6 +1,9 @@
 const assert = require("assert");
 const vscode = require("vscode");
 const { CloudsmithProvider } = require("../views/cloudsmithProvider");
+const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { ConnectionManager } = require("../util/connectionManager");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("CloudsmithProvider Test Suite", () => {
   let originalExecuteCommand;
@@ -11,6 +14,8 @@ suite("CloudsmithProvider Test Suite", () => {
   let defaultWorkspace;
   let treeView;
   let provider;
+  let originalApiGet;
+  let originalConnect;
 
   const context = {
     secrets: {
@@ -42,6 +47,8 @@ suite("CloudsmithProvider Test Suite", () => {
     originalExecuteCommand = vscode.commands.executeCommand;
     originalGetConfiguration = vscode.workspace.getConfiguration;
     originalShowWarningMessage = vscode.window.showWarningMessage;
+    originalApiGet = CloudsmithAPI.prototype.get;
+    originalConnect = ConnectionManager.prototype.connect;
 
     vscode.commands.executeCommand = async (...args) => {
       commandCalls.push(args);
@@ -64,6 +71,8 @@ suite("CloudsmithProvider Test Suite", () => {
     vscode.commands.executeCommand = originalExecuteCommand;
     vscode.workspace.getConfiguration = originalGetConfiguration;
     vscode.window.showWarningMessage = originalShowWarningMessage;
+    CloudsmithAPI.prototype.get = originalApiGet;
+    ConnectionManager.prototype.connect = originalConnect;
   });
 
   test("silent refresh shows the signed-out root state without warning after credentials are cleared", async () => {
@@ -93,5 +102,41 @@ suite("CloudsmithProvider Test Suite", () => {
     assert.strictEqual(warningCalls.length, 0);
     assert.strictEqual(nodes.length, 1);
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
+  });
+
+  test("a malformed workspace payload is an explicit load failure, not an empty workspace list", async () => {
+    ConnectionManager.prototype.connect = async () => "true";
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      const malformed = [{ name: "Missing stable slug" }];
+      assert.strictEqual(options.validate(malformed), false);
+      return apiFailure("invalid_response", {
+        status: 200,
+        message: "Cloudsmith returned an unexpected response.",
+      });
+    };
+
+    const nodes = await provider.getWorkspaces();
+
+    assert.strictEqual(nodes.length, 1);
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
+    assert.ok(commandCalls.some(call => (
+      call[0] === "setContext"
+      && call[1] === "cloudsmith.hasMultipleWorkspaces"
+      && call[2] === false
+    )));
+  });
+
+  test("a validated workspace array produces workspace nodes", async () => {
+    ConnectionManager.prototype.connect = async () => "true";
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      const payload = [{ slug: "workspace-a", name: "Workspace A" }];
+      assert.strictEqual(options.validate(payload), true);
+      return apiSuccess(payload);
+    };
+
+    const nodes = await provider.getWorkspaces();
+
+    assert.strictEqual(nodes.length, 1);
+    assert.strictEqual(nodes[0].workspace, "workspace-a");
   });
 });

--- a/test/connectionManager.test.js
+++ b/test/connectionManager.test.js
@@ -1,12 +1,15 @@
 const assert = require("assert");
 const vscode = require("vscode");
 const { ConnectionManager } = require("../util/connectionManager");
+const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("ConnectionManager Test Suite", () => {
   let originalShowWarningMessage;
   let originalExecuteCommand;
   let warningCalls;
   let commandCalls;
+  let originalApiGet;
 
   const context = {
     secrets: {
@@ -23,6 +26,7 @@ suite("ConnectionManager Test Suite", () => {
 
     originalShowWarningMessage = vscode.window.showWarningMessage;
     originalExecuteCommand = vscode.commands.executeCommand;
+    originalApiGet = CloudsmithAPI.prototype.get;
 
     vscode.window.showWarningMessage = async (...args) => {
       warningCalls.push(args);
@@ -36,6 +40,7 @@ suite("ConnectionManager Test Suite", () => {
   teardown(() => {
     vscode.window.showWarningMessage = originalShowWarningMessage;
     vscode.commands.executeCommand = originalExecuteCommand;
+    CloudsmithAPI.prototype.get = originalApiGet;
   });
 
   test("connect() warns for missing credentials in interactive flows", async () => {
@@ -61,5 +66,40 @@ suite("ConnectionManager Test Suite", () => {
     assert.deepStrictEqual(commandCalls, [
       ["setContext", "cloudsmith.connected", false],
     ]);
+  });
+
+  test("checkConnectivity handles authenticated, negative, and typed failure responses", async () => {
+    const stored = [];
+    const connectivityContext = {
+      secrets: {
+        async get() { return null; },
+        async store(key, value) { stored.push([key, value]); },
+      },
+    };
+    const manager = new ConnectionManager(connectivityContext);
+
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      assert.strictEqual(options.apiKey, "candidate-key");
+      return apiSuccess({ authenticated: true });
+    };
+    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "true");
+
+    CloudsmithAPI.prototype.get = async () => apiSuccess({ authenticated: false });
+    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "false");
+
+    CloudsmithAPI.prototype.get = async () => apiFailure("unauthorized", {
+      status: 401,
+      message: "Authentication failed. Check the API key.",
+    });
+    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "error");
+    assert.strictEqual(manager._lastError.kind, "unauthorized");
+
+    CloudsmithAPI.prototype.get = async () => apiFailure("invalid_response", {
+      status: 200,
+      message: "Cloudsmith returned an unexpected response.",
+    });
+    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "error");
+    assert.strictEqual(manager._lastError.kind, "invalid_response");
+    assert.deepStrictEqual(stored.map(([, value]) => value), ["true", "false", "error", "error"]);
   });
 });

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -21,6 +21,7 @@ const {
   createDependencyRecord,
   createDependencySource,
 } = require("../util/dependencyRecord");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("DependencyHealthProvider Test Suite", () => {
   let originalWithProgress;
@@ -194,10 +195,28 @@ suite("DependencyHealthProvider Test Suite", () => {
   function createLookupApi(handler) {
     return {
       calls: [],
-      async getWithHeaders(endpoint) {
+      callOptions: [],
+      async get(endpoint, options) {
         this.calls.push(endpoint);
-        return handler(endpoint, this.calls.length);
+        this.callOptions.push(options);
+        const response = await handler(endpoint, this.calls.length);
+        if (response && typeof response === "object" && typeof response.ok === "boolean") {
+          return response;
+        }
+        if (response && typeof response === "object" && Array.isArray(response.data)) {
+          return apiSuccess(response.data, { headers: normalizeTestLookupHeaders(response.headers) });
+        }
+        return apiSuccess(response);
       },
+    };
+  }
+
+  function normalizeTestLookupHeaders(headers = {}) {
+    return {
+      ...(headers.page === undefined ? {} : { "x-pagination-page": headers.page }),
+      ...(headers.pageTotal === undefined ? {} : { "x-pagination-pagetotal": headers.pageTotal }),
+      ...(headers.count === undefined ? {} : { "x-pagination-count": headers.count }),
+      ...(headers.pageSize === undefined ? {} : { "x-pagination-pagesize": headers.pageSize }),
     };
   }
 
@@ -582,6 +601,109 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(diagnostics.current, priorDiagnostics);
     assert.strictEqual(diagnostics.replacements.length, 1);
     assert.strictEqual(provider.isScanRunning(), false);
+  });
+
+  test("12/12 upstream progress waits for vulnerability enrichment and cancellation preserves the prior scan", async () => {
+    const diagnostics = createDiagnosticsPublisher();
+    const upstreamComplete = deferred();
+    const vulnerabilityStarted = deferred();
+    const progressMessages = [];
+    let cancelProgress;
+    let vulnerabilityCancellationDisposed = false;
+    let scanNumber = 0;
+
+    vscode.window.withProgress = async (_options, task) => {
+      const progressToken = {
+        onCancellationRequested(listener) {
+          cancelProgress = listener;
+          return { dispose() {} };
+        },
+      };
+      return task({
+        report(update) {
+          if (update && update.message) progressMessages.push(update.message);
+        },
+      }, progressToken);
+    };
+
+    const provider = new DependencyHealthProvider(createContext(), diagnostics, {
+      async enrichVulnerabilities(_dependencies, _workspace, { cancellationToken }) {
+        vulnerabilityStarted.resolve();
+        if (cancellationToken.isCancellationRequested) return;
+        await new Promise((resolve) => {
+          const subscription = cancellationToken.onCancellationRequested(() => {
+            subscription.dispose();
+            vulnerabilityCancellationDisposed = true;
+            resolve();
+          });
+        });
+      },
+      async enrichLicenses() {},
+      async enrichPolicies() {},
+      async analyzeUpstreamGaps(_dependencies, _workspace, _repositories, { onProgress }) {
+        onProgress(new Map(), { completed: 12, total: 12 });
+        upstreamComplete.resolve();
+      },
+    });
+
+    provider._performScan = async function (workspace, repository, _folder, progress, token) {
+      scanNumber += 1;
+      const name = scanNumber === 1 ? "known-good" : "partial-replacement";
+      const dependency = createProblemDependency(name, "1.0.0", `/${name}.json`);
+      this._lastManifests = [{ filePath: `/${name}.json`, format: "npm" }];
+      this._fullTrees = [{ ecosystem: "npm", sourceFile: `${name}.json`, dependencies: [dependency] }];
+      this._displayTrees = cloneTrees(this._fullTrees);
+      this._warnings = [];
+      this._rebuildSummary();
+
+      if (scanNumber > 1) {
+        await DependencyHealthProvider.prototype._runEnrichmentPasses.call(
+          this,
+          workspace,
+          repository,
+          progress,
+          token
+        );
+        if (token.isCancellationRequested) return { canceled: true };
+      }
+
+      await this._storeReportData(new Date("2026-08-09T12:00:00.000Z"));
+      return { canceled: false };
+    };
+
+    assert.strictEqual(
+      (await provider.scan("workspace-a", "repo-a", "/project-a")).status,
+      SCAN_STATES.SUCCEEDED
+    );
+    const priorDependencies = provider.dependencies;
+    const priorReport = provider.getReportData();
+    const priorDiagnostics = diagnostics.current;
+
+    let rescanSettled = false;
+    const rescanPromise = provider.rescan().then((result) => {
+      rescanSettled = true;
+      return result;
+    });
+    await Promise.all([upstreamComplete.promise, vulnerabilityStarted.promise]);
+    await waitForTurn();
+
+    assert.ok(progressMessages.includes("Checking upstream coverage... 12/12"));
+    assert.strictEqual(rescanSettled, false);
+    assert.strictEqual(provider.dependencies, priorDependencies);
+    assert.strictEqual(provider.getReportData(), priorReport);
+    assert.strictEqual(diagnostics.current, priorDiagnostics);
+    assert.strictEqual(diagnostics.replacements.length, 1);
+
+    cancelProgress();
+    const result = await rescanPromise;
+
+    assert.strictEqual(result.status, SCAN_STATES.CANCELLED);
+    assert.strictEqual(vulnerabilityCancellationDisposed, true);
+    assert.strictEqual(provider.dependencies, priorDependencies);
+    assert.strictEqual(provider.dependencies[0].name, "known-good");
+    assert.strictEqual(provider.getReportData(), priorReport);
+    assert.strictEqual(diagnostics.current, priorDiagnostics);
+    assert.strictEqual(diagnostics.replacements.length, 1);
   });
 
   test("successful retry clears the failed operation state", async () => {
@@ -1329,7 +1451,7 @@ suite("DependencyHealthProvider Test Suite", () => {
 
   test("lookup failure and partial failure remain distinct from package absence", async () => {
     const failed = await lookupExactDependency({
-      api: createLookupApi(() => "Response status: 503 - Service Unavailable"),
+      api: createLookupApi(() => apiFailure("server_error", { status: 503 })),
       cloudsmithWorkspace: "workspace",
       cloudsmithRepo: "repo",
       dependency: createDependency("left-pad", "1.0.0"),
@@ -1338,7 +1460,7 @@ suite("DependencyHealthProvider Test Suite", () => {
     const partialApi = createLookupApi((_endpoint, callCount) => (
       callCount === 1
         ? lookupPage([{ name: "other", version: "1.0.0" }], 1, 2, 2, 1)
-        : "Response status: 503 - Service Unavailable"
+        : apiFailure("server_error", { status: 503 })
     ));
     const incomplete = await lookupExactDependency({
       api: partialApi,
@@ -1352,9 +1474,21 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(incomplete.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
   });
 
-  test("rejected lookup requests remain explicit failures", async () => {
+  test("network lookup failures remain explicit failures", async () => {
     const result = await lookupExactDependency({
-      api: createLookupApi(() => Promise.reject(new Error("network unavailable"))),
+      api: createLookupApi(() => apiFailure("network_error", { retryable: true })),
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency("left-pad", "1.0.0"),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED);
+  });
+
+  test("a malformed dependency lookup payload cannot prove package absence", async () => {
+    const result = await lookupExactDependency({
+      api: createLookupApi(() => apiFailure("invalid_response", { status: 200 })),
       cloudsmithWorkspace: "workspace",
       cloudsmithRepo: "repo",
       dependency: createDependency("left-pad", "1.0.0"),
@@ -1455,7 +1589,7 @@ suite("DependencyHealthProvider Test Suite", () => {
 
   test("rate limiting is explicit and is not converted to absence", async () => {
     const result = await lookupExactDependency({
-      api: createLookupApi(() => "Response status: 429 - Too Many Requests"),
+      api: createLookupApi(() => apiFailure("rate_limited", { status: 429 })),
       cloudsmithWorkspace: "workspace",
       cloudsmithRepo: "repo",
       dependency: createDependency("left-pad", "1.0.0"),
@@ -1897,7 +2031,7 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(dependency.declaredConstraint, ">=2.0,<3.0");
     assert.strictEqual(dependency.resolvedVersion, null);
     const lookup = await lookupExactDependency({
-      api: { async getWithHeaders() { throw new Error("range-only dependency must not be queried"); } },
+      api: { async get() { throw new Error("range-only dependency must not be queried"); } },
       cloudsmithWorkspace: "workspace",
       cloudsmithRepo: "repository",
       dependency,

--- a/test/dependencyVulnEnricher.test.js
+++ b/test/dependencyVulnEnricher.test.js
@@ -4,6 +4,8 @@ const {
   enrichVulnerabilities,
   getVulnerabilityCacheSize,
 } = require("../util/dependencyVulnEnricher");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 
 suite("dependencyVulnEnricher", () => {
   function createFoundDependency(slug, count = 1) {
@@ -36,7 +38,7 @@ suite("dependencyVulnEnricher", () => {
       cloudsmithAPI: {
         async getV2(endpoint) {
           calls.push(endpoint);
-          return {
+          return apiSuccess({
             results: [
               {
                 vulnerability_id: "CVE-2024-1234",
@@ -48,7 +50,7 @@ suite("dependencyVulnEnricher", () => {
                 severity: "Medium",
               },
             ],
-          };
+          });
         },
       },
     });
@@ -85,13 +87,29 @@ suite("dependencyVulnEnricher", () => {
       cloudsmithAPI: {
         async getV2() {
           calls += 1;
-          return { results: [] };
+          return apiSuccess({ results: [] });
         },
       },
     });
 
     assert.strictEqual(calls, 0);
     assert.strictEqual(enriched[0].vulnerabilities, undefined);
+  });
+
+  test("malformed nested vulnerability entries are rejected and never cached as clean", async () => {
+    const enriched = await enrichVulnerabilities([createFoundDependency("pkg-malformed")], "workspace-a", {
+      cloudsmithAPI: {
+        async getV2(_endpoint, options) {
+          const payload = { results: [null] };
+          assert.strictEqual(options.validate(payload), false);
+          return apiFailure("invalid_response", { status: 200 });
+        },
+      },
+    });
+
+    assert.strictEqual(enriched[0].vulnerabilities.detailsLoaded, false);
+    assert.strictEqual(enriched[0].vulnerabilities.count, 1);
+    assert.strictEqual(getVulnerabilityCacheSize(), 0);
   });
 
   test("deletes expired cache entries on read when the refresh does not replace them", async () => {
@@ -107,12 +125,12 @@ suite("dependencyVulnEnricher", () => {
       ], "workspace-a", {
         cloudsmithAPI: {
           async getV2() {
-            return {
+            return apiSuccess({
               results: [{
                 vulnerability_id: "CVE-2024-1234",
                 severity: "High",
               }],
-            };
+            });
           },
         },
       });
@@ -124,7 +142,7 @@ suite("dependencyVulnEnricher", () => {
       const enriched = await enrichVulnerabilities([createFoundDependency("pkg-1")], "workspace-a", {
         cloudsmithAPI: {
           async getV2() {
-            return "temporarily unavailable";
+            return apiFailure("network_error", { retryable: true });
           },
         },
       });
@@ -148,12 +166,12 @@ suite("dependencyVulnEnricher", () => {
       await enrichVulnerabilities(dependencies, "workspace-a", {
         cloudsmithAPI: {
           async getV2() {
-            return {
+            return apiSuccess({
               results: [{
                 vulnerability_id: "CVE-2024-1234",
                 severity: "High",
               }],
-            };
+            });
           },
         },
       });
@@ -165,12 +183,12 @@ suite("dependencyVulnEnricher", () => {
       await enrichVulnerabilities([createFoundDependency("pkg-fresh")], "workspace-a", {
         cloudsmithAPI: {
           async getV2() {
-            return {
+            return apiSuccess({
               results: [{
                 vulnerability_id: "CVE-2024-5678",
                 severity: "Medium",
               }],
-            };
+            });
           },
         },
       });
@@ -179,5 +197,45 @@ suite("dependencyVulnEnricher", () => {
     } finally {
       Date.now = originalNow;
     }
+  });
+
+  test("scan cancellation aborts a hanging vulnerability fetch and does not cache a clean result", async () => {
+    let cancellationListener;
+    let disposedListeners = 0;
+    let fetchSignal;
+    const cancellationToken = {
+      isCancellationRequested: false,
+      onCancellationRequested(listener) {
+        cancellationListener = listener;
+        return { dispose() { disposedListeners += 1; } };
+      },
+    };
+    const api = new CloudsmithAPI({}, {
+      credentialManager: { async getApiKey() { return "test-key"; } },
+      fetchImpl: async (_url, options) => {
+        fetchSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+      },
+    });
+
+    const pending = enrichVulnerabilities([createFoundDependency("pkg-hanging")], "workspace-a", {
+      cloudsmithAPI: api,
+      cancellationToken,
+    });
+    while (!fetchSignal) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    cancellationToken.isCancellationRequested = true;
+    cancellationListener();
+    const enriched = await pending;
+
+    assert.strictEqual(fetchSignal.aborted, true);
+    assert.strictEqual(disposedListeners, 1);
+    assert.strictEqual(enriched[0].vulnerabilities.detailsLoaded, false);
+    assert.strictEqual(getVulnerabilityCacheSize(), 0);
   });
 });

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { apiKey, workspace, testRepo, createAPI, skipIfNoKey } = require('./setup');
+const { apiEndpoint } = require('../../util/apiEndpoint');
 
 suite('Integration: Search', function () {
   this.timeout(15000);
@@ -12,40 +13,31 @@ suite('Integration: Search', function () {
   });
 
   test('searching for "spotipy" returns results', async function () {
-    const results = await api.get(
-      `packages/${workspace}/${testRepo}/?query=name:spotipy&page_size=10`,
-      apiKey
-    );
-    assert.ok(Array.isArray(results), 'Expected array response');
-    assert.ok(results.length > 0, 'Expected at least one result');
-    assert.strictEqual(results[0].name, 'spotipy');
+    const result = await api.get(apiEndpoint(['packages', workspace, testRepo], {
+      query: { query: 'name:spotipy', page_size: 10 },
+    }), { apiKey, responseType: 'array' });
+    assert.strictEqual(result.ok, true, result.error && result.error.message);
+    assert.ok(result.data.length > 0, 'Expected at least one result');
+    assert.strictEqual(result.data[0].name, 'spotipy');
   });
 
   test('search results include a quarantined or policy-violated package', async function () {
-    const results = await api.get(
-      `packages/${workspace}/${testRepo}/?query=name:spotipy&page_size=10`,
-      apiKey
-    );
-    assert.ok(Array.isArray(results), 'Expected array response');
-    const flagged = results.find(
+    const result = await api.get(apiEndpoint(['packages', workspace, testRepo], {
+      query: { query: 'name:spotipy', page_size: 10 },
+    }), { apiKey, responseType: 'array' });
+    assert.strictEqual(result.ok, true, result.error && result.error.message);
+    const flagged = result.data.find(
       (pkg) => pkg.status_str === 'Quarantined' || pkg.policy_violated === true
     );
     assert.ok(flagged, 'Expected at least one quarantined or policy-violated package');
   });
 
   test('status:quarantined filter returns only quarantined packages', async function () {
-    const results = await api.get(
-      `packages/${workspace}/${testRepo}/?query=status:quarantined&page_size=10`,
-      apiKey
-    );
-    // If no quarantined packages exist, the response may be an empty array — that's valid
-    if (typeof results === 'string') {
-      // API returned an error string — skip rather than fail
-      this.skip();
-      return;
-    }
-    assert.ok(Array.isArray(results), 'Expected array response');
-    for (const pkg of results) {
+    const result = await api.get(apiEndpoint(['packages', workspace, testRepo], {
+      query: { query: 'status:quarantined', page_size: 10 },
+    }), { apiKey, responseType: 'array' });
+    assert.strictEqual(result.ok, true, result.error && result.error.message);
+    for (const pkg of result.data) {
       assert.strictEqual(pkg.status_str, 'Quarantined',
         `Expected all results to be Quarantined, got: ${pkg.status_str}`);
     }

--- a/test/integration/vulnerabilities.test.js
+++ b/test/integration/vulnerabilities.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { apiKey, workspace, testRepo, testPackageSlug, createAPI, skipIfNoKey } = require('./setup');
 const { extractVulnerabilityResults } = require('../../util/packageVulnerabilities');
+const { apiEndpoint } = require('../../util/apiEndpoint');
 
 suite('Integration: Vulnerabilities', function () {
   this.timeout(15000);
@@ -15,11 +16,12 @@ suite('Integration: Vulnerabilities', function () {
   });
 
   test('step 1: list scans for a package returns scan entries', async function () {
-    const scans = await api.get(
-      `vulnerabilities/${workspace}/${testRepo}/${testPackageSlug}/`,
-      apiKey
+    const result = await api.get(
+      apiEndpoint(['vulnerabilities', workspace, testRepo, testPackageSlug]),
+      { apiKey, responseType: 'array' }
     );
-    assert.ok(Array.isArray(scans), `Expected array, got: ${typeof scans}`);
+    assert.strictEqual(result.ok, true, result.error && result.error.message);
+    const scans = result.data;
     assert.ok(scans.length > 0, 'Expected at least one scan result');
 
     const scan = scans.find((s) => s.has_vulnerabilities) || scans[0];
@@ -36,12 +38,13 @@ suite('Integration: Vulnerabilities', function () {
       return;
     }
 
-    scanDetail = await api.get(
-      `vulnerabilities/${workspace}/${testRepo}/${testPackageSlug}/${scanId}/`,
-      apiKey
+    const result = await api.get(
+      apiEndpoint(['vulnerabilities', workspace, testRepo, testPackageSlug, scanId]),
+      { apiKey, responseType: 'object' }
     );
+    assert.strictEqual(result.ok, true, result.error && result.error.message);
+    scanDetail = result.data;
     assert.ok(scanDetail, 'Expected scan detail response');
-    assert.ok(typeof scanDetail !== 'string', `API returned error: ${scanDetail}`);
     assert.ok(scanDetail.scan && typeof scanDetail.scan === 'object', 'Expected scan object in response');
     assert.ok(Array.isArray(scanDetail.scan.results), 'Expected results array in scan response');
     assert.ok(scanDetail.scan.results.length > 0, 'Expected at least one CVE result');

--- a/test/packageQuery.test.js
+++ b/test/packageQuery.test.js
@@ -1,0 +1,41 @@
+const assert = require("assert");
+const {
+  buildExactPackageQuery,
+  packageMatchesExactIdentity,
+} = require("../util/packageQuery");
+
+suite("Cloudsmith exact package query", () => {
+  test("escapes query operators, quotes, and backslashes without widening identity", () => {
+    const query = buildExactPackageQuery(
+      'widget" OR status:quarantined',
+      "1.0\\beta && *",
+      "npm"
+    );
+
+    assert.strictEqual(
+      query,
+      'name:"widget\\" OR status\\:quarantined" AND version:"1.0\\\\beta \\&\\& \\*" AND format:"npm"'
+    );
+    assert.strictEqual(
+      packageMatchesExactIdentity(
+        { name: 'widget" OR status:quarantined', version: "1.0\\beta && *", format: "npm" },
+        { name: 'widget" OR status:quarantined', version: "1.0\\beta && *", format: "npm" }
+      ),
+      true
+    );
+    assert.strictEqual(
+      packageMatchesExactIdentity(
+        { name: "unrelated", version: "1.0\\beta && *", format: "npm" },
+        { name: 'widget" OR status:quarantined', version: "1.0\\beta && *", format: "npm" }
+      ),
+      false
+    );
+  });
+
+  test("rejects controls and incomplete identities", () => {
+    for (const value of ["", "bad\nvalue", "bad\u0000value"]) {
+      assert.throws(() => buildExactPackageQuery(value, "1.0.0", "npm"), /invalid/i);
+    }
+    assert.throws(() => buildExactPackageQuery("widget", {}, "npm"), /invalid/i);
+  });
+});

--- a/test/paginatedFetch.test.js
+++ b/test/paginatedFetch.test.js
@@ -1,0 +1,93 @@
+const assert = require("assert");
+const { PaginatedFetch } = require("../util/paginatedFetch");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+suite("PaginatedFetch typed API boundary", () => {
+  test("returns validated data and normalized pagination metadata", async () => {
+    let requestOptions;
+    const token = { isCancellationRequested: false };
+    const paginated = new PaginatedFetch({
+      async get(endpoint, options) {
+        requestOptions = options;
+        assert.strictEqual(endpoint, "packages/workspace/?page=2&page_size=2&query=name%3Aartifact");
+        return apiSuccess([{ name: "artifact" }], {
+          headers: {
+            "x-pagination-page": "2",
+            "x-pagination-pagetotal": "2",
+            "x-pagination-count": "3",
+            "x-pagination-pagesize": "2",
+          },
+        });
+      },
+    });
+
+    const result = await paginated.fetchPage(
+      "packages/workspace/",
+      2,
+      2,
+      "name:artifact",
+      { cancellationToken: token, retry: "never" }
+    );
+
+    assert.strictEqual(result.error, null);
+    assert.deepStrictEqual(result.pagination, { page: 2, pageTotal: 2, count: 3, pageSize: 2 });
+    assert.strictEqual(requestOptions.cancellationToken, token);
+    assert.strictEqual(requestOptions.retry, "never");
+  });
+
+  test("keeps typed transport failures distinct from empty pages", async () => {
+    const failure = apiFailure("rate_limited", { status: 429 }).error;
+    const paginated = new PaginatedFetch({
+      async get() {
+        return { ...apiFailure("rate_limited", { status: 429 }), error: failure };
+      },
+    });
+
+    const result = await paginated.fetchPage("packages/workspace/", 1, 100);
+
+    assert.strictEqual(result.error, failure);
+    assert.deepStrictEqual(result.data, []);
+  });
+
+  test("rejects malformed arrays and incomplete or contradictory pagination metadata", async () => {
+    const responses = [
+      apiFailure("invalid_response", { status: 200 }),
+      apiSuccess([], { headers: {} }),
+      apiSuccess([{ name: "artifact" }], {
+        headers: {
+          "x-pagination-page": "2",
+          "x-pagination-pagetotal": "1",
+          "x-pagination-count": "1",
+          "x-pagination-pagesize": "100",
+        },
+      }),
+    ];
+    const paginated = new PaginatedFetch({ async get() { return responses.shift(); } });
+
+    for (let index = 0; index < 3; index += 1) {
+      const result = await paginated.fetchPage("packages/workspace/", index === 2 ? 2 : 1, 100);
+      assert.strictEqual(result.error.kind, "invalid_response");
+    }
+  });
+
+  test("forwards a domain validator so blank records cannot cross pagination", async () => {
+    let capturedValidator;
+    const paginated = new PaginatedFetch({
+      async get(_endpoint, options) {
+        capturedValidator = options.validate;
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    });
+    const repositoryValidator = value => Array.isArray(value) && value.every(repository => (
+      typeof repository.slug === "string" && repository.slug.length > 0
+    ));
+
+    await paginated.fetchPage("repos/workspace/", 1, 100, null, {
+      validate: repositoryValidator,
+    });
+
+    assert.strictEqual(capturedValidator, repositoryValidator);
+    assert.strictEqual(capturedValidator([{}]), false);
+    assert.strictEqual(capturedValidator([{ slug: "repo" }]), true);
+  });
+});

--- a/test/promotionProvider.test.js
+++ b/test/promotionProvider.test.js
@@ -1,0 +1,186 @@
+const assert = require("assert");
+const { PromotionProvider } = require("../views/promotionProvider");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+suite("PromotionProvider typed transport", () => {
+  function createProvider() {
+    const provider = new PromotionProvider({
+      secrets: {
+        async get() {
+          return "candidate-key";
+        },
+      },
+    });
+    provider.getTagTemplates = () => ({ onPromote: [], onReceive: [] });
+    return provider;
+  }
+
+  test("copy write is dispatched once and preserves ambiguous-outcome errors", async () => {
+    const provider = createProvider();
+    let postCalls = 0;
+    provider.api = {
+      async get() {
+        return apiSuccess({
+          name: "artifact",
+          version: "1.0.0",
+          format: "npm",
+          slug_perm: "artifact-id",
+        });
+      },
+      async post(_endpoint, _json, options) {
+        postCalls += 1;
+        assert.strictEqual(options.responseType, "object");
+        return apiFailure("server_error", {
+          status: 503,
+          outcomeUnknown: true,
+          message: "The request may have completed in Cloudsmith. Check the remote state before trying again.",
+        });
+      },
+    };
+
+    const result = await provider.promote(
+      "workspace",
+      "source",
+      "artifact-id",
+      "target"
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error.outcomeUnknown, true);
+    assert.strictEqual(postCalls, 1);
+  });
+
+  test("malformed successful write responses cannot be reported as promotion success", async () => {
+    const provider = createProvider();
+    let postCalls = 0;
+    provider.api = {
+      async get() {
+        return apiSuccess({ name: "artifact", version: "1.0.0", format: "npm" });
+      },
+      async post() {
+        postCalls += 1;
+        return apiFailure("invalid_response", {
+          status: 200,
+          outcomeUnknown: true,
+          message: "The request may have completed in Cloudsmith. Check the remote state before trying again.",
+        });
+      },
+    };
+
+    const result = await provider.promote(
+      "workspace",
+      "source",
+      "artifact-id",
+      "target"
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error.kind, "invalid_response");
+    assert.strictEqual(result.error.outcomeUnknown, true);
+    assert.strictEqual(postCalls, 1);
+  });
+
+  test("promotion status keeps transport failure distinct from package absence", async () => {
+    const provider = createProvider();
+    provider.getPipeline = () => ["dev", "production"];
+    provider.api = {
+      async get() {
+        return apiFailure("rate_limited", { status: 429, retryable: true });
+      },
+    };
+
+    const result = await provider.getPromotionStatus(
+      "workspace",
+      "artifact",
+      "1.0.0",
+      "npm"
+    );
+
+    assert.deepStrictEqual(result.items, []);
+    assert.strictEqual(result.error.kind, "rate_limited");
+  });
+
+  test("promotion status filters same-name versions by exact format", async () => {
+    const provider = createProvider();
+    provider.getPipeline = () => ["dev"];
+    provider.api = {
+      async get() {
+        return apiSuccess([
+          { name: "artifact", version: "1.0.0", format: "python", repository: "dev", status_str: "Quarantined" },
+          { name: "artifact", version: "1.0.0", format: "npm", repository: "dev", status_str: "Completed" },
+        ]);
+      },
+    };
+
+    const result = await provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");
+
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.items[0].found, true);
+    assert.strictEqual(result.items[0].status, "Completed");
+  });
+
+  test("a validated copy response completes without retrying or tagging", async () => {
+    const provider = createProvider();
+    let postCalls = 0;
+    provider.api = {
+      async get() {
+        return apiSuccess({ name: "artifact", version: "1.0.0", format: "npm" });
+      },
+      async post() {
+        postCalls += 1;
+        return apiSuccess({
+          name: "artifact",
+          version: "1.0.0",
+          format: "npm",
+          repository: "target",
+          slug_perm: "copied-id",
+        });
+      },
+    };
+
+    const result = await provider.promote(
+      "workspace",
+      "source",
+      "artifact-id",
+      "target"
+    );
+
+    assert.deepStrictEqual(result, { success: true, error: null });
+    assert.strictEqual(postCalls, 1);
+  });
+
+  test("copy and tag validators require usable package identities and identifiers", async () => {
+    const provider = createProvider();
+    const validPackage = {
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+      repository: "target",
+      slug_perm: "copied-id",
+    };
+    let copyValidated = false;
+    let tagValidated = false;
+    provider.api = {
+      async get() {
+        return apiSuccess(validPackage);
+      },
+      async post(endpoint, _json, options) {
+        assert.strictEqual(options.validate({}), false);
+        assert.strictEqual(options.validate(validPackage), true);
+        if (endpoint.endsWith("/copy/")) {
+          copyValidated = true;
+          return apiSuccess(validPackage);
+        }
+        tagValidated = true;
+        return apiSuccess(validPackage);
+      },
+    };
+    provider.getTagTemplates = () => ({ onPromote: ["promoted"], onReceive: [] });
+
+    const result = await provider.promote("workspace", "source", "artifact-id", "target");
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(copyValidated, true);
+    assert.strictEqual(tagValidated, true);
+  });
+});

--- a/test/remediationHelper.test.js
+++ b/test/remediationHelper.test.js
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const { RemediationHelper } = require("../util/remediationHelper");
+const { apiFailure } = require("./apiResultHelpers");
+
+suite("RemediationHelper response validation", () => {
+  test("blank package records cannot be offered as safe versions", async () => {
+    const helper = new RemediationHelper({
+      async get(_endpoint, options) {
+        assert.strictEqual(options.validate([{}]), false);
+        assert.strictEqual(options.validate([{
+          name: "artifact",
+          version: "1.0.0",
+          format: "npm",
+          repository: "repo",
+          namespace: "workspace",
+          slug_perm: "artifact-id",
+        }]), true);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    });
+
+    const result = await helper.findSafeVersions("workspace", "repo", "artifact", "npm");
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error.kind, "invalid_response");
+    assert.deepStrictEqual(result.versions, []);
+  });
+});

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -3,6 +3,7 @@ const vscode = require("vscode");
 const UpstreamIndicatorNode = require("../models/upstreamIndicatorNode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("RepositoryNode Test Suite", () => {
   const repositoryNodePath = require.resolve("../models/repositoryNode");
@@ -204,7 +205,7 @@ suite("RepositoryNode Test Suite", () => {
       uploaded_at: "2026-08-07T00:00:00Z",
     };
 
-    CloudsmithAPI.prototype.get = async () => ([
+    CloudsmithAPI.prototype.get = async () => apiSuccess([
       {
         ...packageBase,
         name: "clean-npm",
@@ -247,5 +248,56 @@ suite("RepositoryNode Test Suite", () => {
         false
       );
     }
+  });
+
+  test("a malformed package array cannot be published as an empty successful repository", async () => {
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      const malformed = [{ name: "artifact" }, null];
+      assert.strictEqual(options.validate(malformed), false);
+      return apiFailure("invalid_response", { status: 200 });
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context
+    );
+
+    const packages = await repositoryNode.getPackages();
+
+    assert.deepStrictEqual(packages, []);
+    assert.strictEqual(repositoryNode._lastApiFailed, true);
+  });
+
+  test("group and entitlement validators reject blank records", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) {
+        if (key === "groupByPackageGroups") return true;
+        if (key === "showMaxPackages") return 10;
+        return false;
+      },
+    });
+    let requestCount = 0;
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        assert.strictEqual(options.validate({ results: [{}] }), false);
+        assert.strictEqual(options.validate({ results: [{ name: "artifact", format: "npm" }] }), true);
+      } else {
+        assert.strictEqual(options.validate([{}]), false);
+        assert.strictEqual(options.validate([{ name: "token", is_active: false }]), true);
+      }
+      return apiFailure("invalid_response", { status: 200 });
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context
+    );
+
+    assert.deepStrictEqual(await repositoryNode.getPackages(), []);
+    await assert.rejects(
+      () => repositoryNode.getEntitlements(),
+      error => error && error.kind === "invalid_response"
+    );
   });
 });

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -82,6 +82,37 @@ suite("SearchProvider Test Suite", () => {
     assert.strictEqual(provider.currentRepo, null);
   });
 
+  test("search cancellation reaches pagination and preserves the prior result snapshot", async () => {
+    const priorResults = [{ marker: "prior" }];
+    const token = { isCancellationRequested: true };
+    let progressOptions;
+    let requestOptions;
+    provider.searchResults = priorResults;
+    provider.currentWorkspace = "workspace-before";
+    provider.currentQuery = "before";
+
+    vscode.window.withProgress = async (options, task) => {
+      progressOptions = options;
+      return task({ report() {} }, token);
+    };
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, _page, _pageSize, _query, options) => {
+      requestOptions = options;
+      return {
+        data: [],
+        pagination: null,
+        error: { kind: "cancelled", message: "The request was canceled." },
+      };
+    };
+
+    await provider.search("workspace-a", "name:artifact");
+
+    assert.strictEqual(progressOptions.cancellable, true);
+    assert.strictEqual(requestOptions.cancellationToken, token);
+    assert.strictEqual(provider.searchResults, priorResults);
+    assert.strictEqual(provider.currentWorkspace, "workspace-before");
+    assert.strictEqual(provider.currentQuery, "before");
+  });
+
   test("getChildren() shows the signed-out state when disconnected and idle", async () => {
     provider = new SearchProvider({
       secrets: {

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -9,9 +9,20 @@ const {
 const {
   SUPPORTED_UPSTREAM_FORMATS: SHARED_SUPPORTED_UPSTREAM_FORMATS,
 } = require("../util/upstreamFormats");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+function toApiResult(response) {
+  if (response && typeof response === "object" && typeof response.ok === "boolean") {
+    return response;
+  }
+  if (response instanceof Error) {
+    return apiFailure("server_error", { status: 503, message: response.message });
+  }
+  return apiSuccess(response === undefined ? [] : response);
+}
 
 suite("UpstreamChecker repository upstream cache", () => {
-  let originalMakeRequest;
+  let originalGet;
   let originalGetApiKey;
   let formatResponses;
   let requestCount;
@@ -19,7 +30,7 @@ suite("UpstreamChecker repository upstream cache", () => {
   let context;
 
   setup(() => {
-    originalMakeRequest = CloudsmithAPI.prototype.makeRequest;
+    originalGet = CloudsmithAPI.prototype.get;
     originalGetApiKey = CredentialManager.prototype.getApiKey;
     formatResponses = {};
     requestCount = 0;
@@ -40,30 +51,35 @@ suite("UpstreamChecker repository upstream cache", () => {
     };
 
     CredentialManager.prototype.getApiKey = async () => "test-api-key";
-    CloudsmithAPI.prototype.makeRequest = async function(endpoint) {
+    CloudsmithAPI.prototype.get = async function(endpoint, options = {}) {
       requestCount += 1;
       const match = endpoint.match(/upstream\/([^/]+)\/$/);
       const format = match ? match[1] : null;
       const response = formatResponses[format];
 
-      if (response instanceof Error) {
-        throw response;
+      try {
+        if (typeof response === "function") {
+          const result = toApiResult(response());
+          return result.ok && typeof options.validate === "function" && options.validate(result.data) !== true
+            ? apiFailure("invalid_response", { status: 200 })
+            : result;
+        }
+        if (response !== undefined) {
+          const result = toApiResult(response);
+          return result.ok && typeof options.validate === "function" && options.validate(result.data) !== true
+            ? apiFailure("invalid_response", { status: 200 })
+            : result;
+        }
+      } catch {
+        return apiFailure("server_error", { status: 503 });
       }
 
-      if (typeof response === "function") {
-        return response();
-      }
-
-      if (response !== undefined) {
-        return response;
-      }
-
-      return [];
+      return apiSuccess([]);
     };
   });
 
   teardown(() => {
-    CloudsmithAPI.prototype.makeRequest = originalMakeRequest;
+    CloudsmithAPI.prototype.get = originalGet;
     CredentialManager.prototype.getApiKey = originalGetApiKey;
   });
 
@@ -107,7 +123,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       docker: [
         { name: "Docker Hub", upstream_url: "https://registry-1.docker.io/" },
       ],
-      conda: "Response status: 404 - Not Found - ",
+      conda: apiFailure("not_found", { status: 404 }),
     };
 
     const checker = new UpstreamChecker(context);
@@ -137,7 +153,7 @@ suite("UpstreamChecker repository upstream cache", () => {
         { name: "PyPI", upstream_url: "https://pypi.org/simple/" },
       ],
       npm: () => {
-        throw new Error("Response status: 503 - Service Unavailable - ");
+        return apiFailure("server_error", { status: 503 });
       },
     };
 
@@ -152,6 +168,18 @@ suite("UpstreamChecker repository upstream cache", () => {
     await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.strictEqual(requestCount, SUPPORTED_UPSTREAM_FORMATS.length * 2);
+    assert.strictEqual(store.size, 0);
+  });
+
+  test("rejects blank upstream records instead of reporting false active reachability", async () => {
+    formatResponses = { python: [{}] };
+
+    const checker = new UpstreamChecker(context);
+    const state = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
+
+    assert.strictEqual(state.active, 0);
+    assert.strictEqual(state.total, 0);
+    assert.ok(state.failedFormats.includes("python"));
     assert.strictEqual(store.size, 0);
   });
 
@@ -177,6 +205,10 @@ suite("UpstreamChecker repository upstream cache", () => {
 
   test("treats non-object groupedUpstreams as an invalid cached repository upstream state", async () => {
     await assertInvalidCachedEntry(createCachedEntry({ groupedUpstreams: [] }));
+  });
+
+  test("treats unnamed cached upstream records as invalid", async () => {
+    await assertInvalidCachedEntry(createCachedEntry({ groupedUpstreams: { python: [{}] } }));
   });
 
   test("treats expired cached repository upstream state as invalid", () => {
@@ -293,25 +325,24 @@ suite("UpstreamChecker shared helper and format handling", () => {
     let requestCount = 0;
     const checker = new UpstreamChecker(context);
 
-    checker.api.makeRequest = async (endpoint) => {
+    checker.api.get = async (endpoint) => {
       requestCount += 1;
       const match = endpoint.match(/upstream\/([^/]+)\/$/);
       const format = match ? match[1] : null;
       const response = formatResponses[format];
 
-      if (response instanceof Error) {
-        throw response;
+      try {
+        if (typeof response === "function") {
+          return toApiResult(response());
+        }
+        if (response !== undefined) {
+          return toApiResult(response);
+        }
+      } catch {
+        return apiFailure("server_error", { status: 503 });
       }
 
-      if (typeof response === "function") {
-        return response();
-      }
-
-      if (response !== undefined) {
-        return response;
-      }
-
-      return [];
+      return apiSuccess([]);
     };
 
     return {
@@ -357,7 +388,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
   [400, 404, 405, 422].forEach((statusCode) => {
     test(`${statusCode} is classified as a benign upstream format error`, () => {
       assert.strictEqual(
-        isBenignUpstreamFormatError(`Response status: ${statusCode}`),
+        isBenignUpstreamFormatError({ status: statusCode }),
         true
       );
     });
@@ -366,7 +397,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
   [401, 403, 407, 408, 429].forEach((statusCode) => {
     test(`${statusCode} is classified as a non-benign upstream format error`, () => {
       assert.strictEqual(
-        isBenignUpstreamFormatError(`Response status: ${statusCode}`),
+        isBenignUpstreamFormatError({ status: statusCode }),
         false
       );
     });
@@ -387,7 +418,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
       docker: [
         { name: "Docker Hub", upstream_url: "https://registry-1.docker.io/" },
       ],
-      conda: "Response status: 404 - Not Found - ",
+      conda: apiFailure("not_found", { status: 404 }),
     });
 
     const firstState = await checker.getAllUpstreamData("workspace-a", "repo-a");
@@ -421,7 +452,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
         { name: "PyPI", upstream_url: "https://pypi.org/simple/" },
       ],
       npm: () => {
-        throw new Error("Response status: 503 - Service Unavailable - ");
+        return apiFailure("server_error", { status: 503 });
       },
     });
 
@@ -544,7 +575,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
     const { context, updates } = createContext();
     const checker = new UpstreamChecker(context);
 
-    checker.api.makeRequest = async () => "Response status: 401";
+    checker.api.get = async () => apiFailure("unauthorized", { status: 401 });
 
     const result = await checker.getUpstreamDataForFormats("acme", "example-repo", ["python"]);
 

--- a/test/upstreamPreviewProvider.test.js
+++ b/test/upstreamPreviewProvider.test.js
@@ -64,7 +64,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           active: 0,
           configs: [],
         },
-        error: "Response status: 503 - Service Unavailable",
+        error: "Upstream availability could not be determined.",
       },
       canResolveViaUpstream: false,
     });

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -1,24 +1,14 @@
 const assert = require("assert");
 const {
   buildRegistryTriggerPlan,
+  findPythonDistributionUrl,
 } = require("../util/registryEndpoints");
 const {
   UpstreamPullService,
 } = require("../util/upstreamPullService");
 
 function createResponse(status, body, headers = {}) {
-  return {
-    status,
-    headers: {
-      get(name) {
-        const lowerName = String(name || "").toLowerCase();
-        return headers[lowerName] || headers[name] || null;
-      },
-    },
-    async text() {
-      return body;
-    },
-  };
+  return new Response(body, { status, headers });
 }
 
 suite("UpstreamPullService", () => {
@@ -62,6 +52,55 @@ suite("UpstreamPullService", () => {
       cargoPlan.request.url,
       "https://cargo.cloudsmith.io/workspace/repo/se/rd/serde"
     );
+  });
+
+  test("rejects registry path traversal and query injection across ecosystems", () => {
+    const hostileDependencies = [
+      { format: "docker", name: "../../other/image", version: "1.0.0" },
+      { format: "npm", name: "..", version: "1.0.0" },
+      { format: "cargo", name: "..", version: "1.0.0" },
+      { format: "swift", name: "../secret", version: "1.0.0" },
+      { format: "go", name: "../../other/repo/pkg?admin=true", version: "v1.0.0" },
+      { format: "composer", name: "../secret", version: "1.0.0" },
+      { format: "maven", name: "com.example:..", version: "1.0.0" },
+      { format: "ruby", name: "bad\\name", version: "1.0.0" },
+      { format: "nuget", name: "bad\nname", version: "1.0.0" },
+      { format: "python", name: "requests", version: "../other" },
+      { format: "npm", name: "%ZZ", version: "1.0.0" },
+      { format: "python", name: "a/b", version: "1.0.0" },
+      { format: "cargo", name: "a/b", version: "1.0.0" },
+      { format: "maven", name: "a.b:foo/bar", version: "1.0.0" },
+    ];
+
+    for (const dependency of hostileDependencies) {
+      assert.strictEqual(
+        buildRegistryTriggerPlan("workspace", "repo", dependency),
+        null,
+        `${dependency.format}:${dependency.name}`
+      );
+    }
+    assert.strictEqual(
+      buildRegistryTriggerPlan("..", "repo", { format: "npm", name: "safe", version: "1.0.0" }),
+      null
+    );
+    assert.strictEqual(
+      buildRegistryTriggerPlan("workspace", "repo?admin=true", { format: "npm", name: "safe", version: "1.0.0" }),
+      null
+    );
+  });
+
+  test("Python artifact discovery stays bounded on repeated incomplete anchors", () => {
+    const hostileHtml = "<a ".repeat(150000);
+    const startedAt = Date.now();
+    const result = findPythonDistributionUrl(
+      hostileHtml,
+      "1.0.0",
+      "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/"
+    );
+    const elapsed = Date.now() - startedAt;
+
+    assert.strictEqual(result, null);
+    assert.ok(elapsed < 1000, `hostile anchor scan took ${elapsed}ms`);
   });
 
   test("prepare builds a mixed-ecosystem confirmation with skipped formats", async () => {
@@ -259,6 +298,211 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(result.pullResult.errors, 1);
     assert.strictEqual(calls.length, 1);
     assert.match(result.pullResult.details[0].errorMessage, /redirect target was rejected/i);
+  });
+
+  test("registry requests ignore caller authorization overrides and drain artifact bodies", async () => {
+    let capturedRequest;
+    let bodyCanceled = false;
+    let textRead = false;
+    let bodyReads = 0;
+    const service = new UpstreamPullService({}, {
+      fetchImpl: async (_url, options) => {
+        capturedRequest = options;
+        return {
+          status: 200,
+          headers: { get() { return null; } },
+          body: {
+            getReader() {
+              return {
+                async read() {
+                  bodyReads += 1;
+                  return bodyReads === 1
+                    ? { done: false, value: new Uint8Array([1, 2, 3]) }
+                    : { done: true, value: undefined };
+                },
+                async cancel() { bodyCanceled = true; },
+                releaseLock() {},
+              };
+            },
+          },
+          async text() { textRead = true; return "large artifact"; },
+        };
+      },
+    });
+
+    const result = await service._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/raw/file.bin",
+      headers: { Authorization: "Bearer hostile", Accept: "application/octet-stream" },
+    }, "api-key", null, { captureBody: false });
+
+    assert.strictEqual(result.statusCode, 200);
+    assert.strictEqual(
+      capturedRequest.headers.Authorization,
+      `Basic ${Buffer.from("token:api-key").toString("base64")}`
+    );
+    assert.strictEqual(capturedRequest.headers.Accept, "application/octet-stream");
+    assert.strictEqual(bodyReads, 2);
+    assert.strictEqual(bodyCanceled, false);
+    assert.strictEqual(textRead, false);
+  });
+
+  test("registry metadata bodies are bounded before retention", async () => {
+    let bodyCanceled = false;
+    const service = new UpstreamPullService({}, {
+      fetchImpl: async () => ({
+        status: 200,
+        headers: {
+          get(name) {
+            return String(name).toLowerCase() === "content-length"
+              ? String(2 * 1024 * 1024)
+              : null;
+          },
+        },
+        body: { async cancel() { bodyCanceled = true; } },
+      }),
+    });
+
+    const result = await service._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/",
+      headers: {},
+    }, "api-key", null, { captureBody: true });
+
+    assert.strictEqual(result.statusCode, 0);
+    assert.match(result.errorMessage, /size limit/i);
+    assert.strictEqual(bodyCanceled, true);
+  });
+
+  test("registry readers reject non-streaming bodies and unknown-length oversized chunks", async () => {
+    let fallbackTextRead = false;
+    let fallbackCanceled = false;
+    const fallbackService = new UpstreamPullService({}, {
+      fetchImpl: async () => ({
+        status: 200,
+        headers: { get() { return null; } },
+        body: { async cancel() { fallbackCanceled = true; } },
+        async text() { fallbackTextRead = true; return "unbounded"; },
+      }),
+    });
+    const fallback = await fallbackService._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/",
+      headers: {},
+    }, "api-key", null, { captureBody: true });
+    assert.strictEqual(fallback.statusCode, 0);
+    assert.strictEqual(fallbackTextRead, false);
+    assert.strictEqual(fallbackCanceled, true);
+
+    let oversizedCanceled = false;
+    let reads = 0;
+    const oversizedService = new UpstreamPullService({}, {
+      fetchImpl: async () => ({
+        status: 200,
+        headers: { get() { return null; } },
+        body: {
+          getReader() {
+            return {
+              async read() {
+                reads += 1;
+                return { done: false, value: new Uint8Array((1024 * 1024) + 1) };
+              },
+              async cancel() { oversizedCanceled = true; },
+              releaseLock() {},
+            };
+          },
+        },
+      }),
+    });
+    const oversized = await oversizedService._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/",
+      headers: {},
+    }, "api-key", null, { captureBody: true });
+    assert.strictEqual(oversized.statusCode, 0);
+    assert.strictEqual(reads, 1);
+    assert.strictEqual(oversizedCanceled, true);
+  });
+
+  test("registry timeout settles ignored fetch and body reads without awaiting cancellation", async () => {
+    let timeoutCallback;
+    let lateResolve;
+    let lateCancelCalled = false;
+    const lateService = new UpstreamPullService({}, {
+      fetchImpl: async () => new Promise(resolve => { lateResolve = resolve; }),
+      setTimeout(callback) { timeoutCallback = callback; return {}; },
+      clearTimeout() {},
+    });
+    const latePending = lateService._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/raw/file.bin",
+      headers: {},
+    }, "api-key", null, { captureBody: false });
+    await new Promise(resolve => setImmediate(resolve));
+    timeoutCallback();
+    const lateResult = await latePending;
+    assert.strictEqual(lateResult.statusCode, 0);
+    assert.match(lateResult.errorMessage, /timed out/i);
+    lateResolve({
+      status: 200,
+      headers: { get() { return null; } },
+      body: { cancel() { lateCancelCalled = true; return new Promise(() => {}); } },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(lateCancelCalled, true);
+
+    let bodyTimeoutCallback;
+    let readerCancelCalled = false;
+    const bodyService = new UpstreamPullService({}, {
+      fetchImpl: async () => ({
+        status: 200,
+        headers: { get() { return null; } },
+        body: {
+          getReader() {
+            return {
+              read() { return new Promise(() => {}); },
+              cancel() { readerCancelCalled = true; return new Promise(() => {}); },
+              releaseLock() {},
+            };
+          },
+        },
+      }),
+      setTimeout(callback) { bodyTimeoutCallback = callback; return {}; },
+      clearTimeout() {},
+    });
+    const bodyPending = bodyService._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/raw/file.bin",
+      headers: {},
+    }, "api-key", null, { captureBody: false });
+    await new Promise(resolve => setImmediate(resolve));
+    bodyTimeoutCallback();
+    const bodyResult = await bodyPending;
+    assert.strictEqual(bodyResult.statusCode, 0);
+    assert.match(bodyResult.errorMessage, /timed out/i);
+    assert.strictEqual(readerCancelCalled, true);
+  });
+
+  test("registry redirects cannot move credentials between allowed Cloudsmith hosts", async () => {
+    let calls = 0;
+    const service = new UpstreamPullService({}, {
+      fetchImpl: async () => {
+        calls += 1;
+        return createResponse(302, "", {
+          location: "https://npm.cloudsmith.io/workspace/repo/package.tgz",
+        });
+      },
+    });
+
+    const result = await service._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/",
+      headers: {},
+    }, "api-key", null, { captureBody: true });
+
+    assert.strictEqual(result.statusCode, 0);
+    assert.match(result.errorMessage, /redirect target was rejected/i);
+    assert.strictEqual(calls, 1);
   });
 
   test("stops after three authentication failures before expanding concurrency", async () => {

--- a/test/vulnerabilityProvider.test.js
+++ b/test/vulnerabilityProvider.test.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const { VulnerabilityProvider } = require("../views/vulnerabilityProvider");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("VulnerabilityProvider Test Suite", () => {
   test("webview fetch preserves multiple records from the canonical scan response", async () => {
@@ -9,21 +10,21 @@ suite("VulnerabilityProvider Test Suite", () => {
       async get(endpoint) {
         calls.push(endpoint);
         if (calls.length === 1) {
-          return [{
+          return apiSuccess([{
             identifier: "scan-webview",
             has_vulnerabilities: true,
             num_vulnerabilities: 2,
             max_severity: "Critical",
-          }];
+          }]);
         }
-        return {
+        return apiSuccess({
           scan: {
             results: [
               { vulnerability_id: "CVE-2026-3001", severity: "Critical" },
               { vulnerability_id: "CVE-2026-3002", severity: "Low" },
             ],
           },
-        };
+        });
       },
     };
 
@@ -52,13 +53,17 @@ suite("VulnerabilityProvider Test Suite", () => {
     const api = {
       async get(endpoint) {
         if (endpoint.endsWith("immutable-package-id/")) {
-          return [{
+          return apiSuccess([{
             identifier: "scan-webview",
             has_vulnerabilities: true,
             max_severity: "High",
-          }];
+          }]);
         }
-        return "Response status: 503 - Service Unavailable";
+        return apiFailure("server_error", {
+          status: 503,
+          retryable: true,
+          message: "The Cloudsmith API returned an internal error.",
+        });
       },
     };
 
@@ -72,7 +77,7 @@ suite("VulnerabilityProvider Test Suite", () => {
     assert.deepStrictEqual(result.results, []);
     assert.strictEqual(result.numVulns, -1);
     assert.strictEqual(result.maxSeverity, "High");
-    assert.match(result.error, /503/);
+    assert.strictEqual(result.error.kind, "server_error");
 
     const html = provider._getHtmlContent(
       {},
@@ -92,5 +97,38 @@ suite("VulnerabilityProvider Test Suite", () => {
     );
     assert.match(html, /<strong>detected<\/strong> vulnerabilities/);
     assert.doesNotMatch(html, /<strong>0<\/strong> vulnerabilities/);
+  });
+
+  test("rejects unsafe scan identifiers and primitive nested vulnerability entries", async () => {
+    const provider = new VulnerabilityProvider({});
+    let unsafeCalls = 0;
+    const unsafe = await provider._fetchVulnerabilities({
+      async get(_endpoint, options) {
+        unsafeCalls += 1;
+        const payload = [{ identifier: "../unsafe", has_vulnerabilities: true }];
+        assert.strictEqual(options.validate(payload), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "repo-a", "package-id");
+    assert.strictEqual(unsafeCalls, 1);
+    assert.strictEqual(unsafe.error.kind, "invalid_response");
+
+    let detailCalls = 0;
+    const malformedDetail = await provider._fetchVulnerabilities({
+      async get(_endpoint, options) {
+        detailCalls += 1;
+        if (detailCalls === 1) {
+          const payload = [{ identifier: "scan-id", has_vulnerabilities: true }];
+          assert.strictEqual(options.validate(payload), true);
+          return apiSuccess(payload);
+        }
+        const payload = { results: [null] };
+        assert.strictEqual(options.validate(payload), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "repo-a", "package-id");
+    assert.strictEqual(detailCalls, 2);
+    assert.strictEqual(malformedDetail.error.kind, "invalid_response");
+    assert.deepStrictEqual(malformedDetail.results, []);
   });
 });

--- a/test/vulnerabilitySummaryNode.test.js
+++ b/test/vulnerabilitySummaryNode.test.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const VulnerabilitySummaryNode = require("../models/vulnerabilitySummaryNode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("VulnerabilitySummaryNode Test Suite", () => {
   const context = {};
@@ -105,14 +106,14 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
       calls.push(endpoint);
       if (calls.length === 1) {
-        return [{
+        return apiSuccess([{
           identifier: "scan-123",
           has_vulnerabilities: true,
           num_vulnerabilities: 2,
           max_severity: "High",
-        }];
+        }]);
       }
-      return {
+      return apiSuccess({
         identifier: "scan-123",
         scan: {
           results: [
@@ -133,7 +134,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
             },
           ],
         },
-      };
+      });
     };
 
     const node = new VulnerabilitySummaryNode({
@@ -165,14 +166,14 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
   test("shows a retryable error node when vulnerability details fail to load", async () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
       if (endpoint.endsWith("immutable-package-id/")) {
-        return [{
+        return apiSuccess([{
           identifier: "scan-123",
           has_vulnerabilities: true,
           num_vulnerabilities: 1,
           max_severity: "Critical",
-        }];
+        }]);
       }
-      return "Response status: 503 - Service Unavailable";
+      return apiFailure("server_error", { status: 503, retryable: true });
     };
 
     const node = new VulnerabilitySummaryNode({
@@ -194,20 +195,20 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
       if (endpoint.includes("vulnerable-package")) {
         if (endpoint.endsWith("vulnerable-package/")) {
-          return [{
+          return apiSuccess([{
             identifier: "scan-vulnerable",
             has_vulnerabilities: true,
             num_vulnerabilities: 1,
             max_severity: "High",
-          }];
+          }]);
         }
-        return {
+        return apiSuccess({
           scan: {
             results: [{ vulnerability_id: "CVE-2026-2001", severity: "High" }],
           },
-        };
+        });
       }
-      return "Response status: 500 - Internal Server Error";
+      return apiFailure("server_error", { status: 500, retryable: true });
     };
 
     const vulnerableNode = new VulnerabilitySummaryNode({

--- a/test/workspaceNode.test.js
+++ b/test/workspaceNode.test.js
@@ -2,6 +2,7 @@ const assert = require("assert");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
 const WorkspaceNode = require("../models/workspaceNode");
+const { apiFailure } = require("./apiResultHelpers");
 
 suite("WorkspaceNode Test Suite", () => {
   let originalGet;
@@ -22,7 +23,7 @@ suite("WorkspaceNode Test Suite", () => {
       },
     };
 
-    CloudsmithAPI.prototype.get = async () => "quota unavailable";
+    CloudsmithAPI.prototype.get = async () => apiFailure("forbidden", { status: 403 });
   });
 
   teardown(() => {
@@ -34,7 +35,7 @@ suite("WorkspaceNode Test Suite", () => {
   test("shows an error child when the first repository page fails", async () => {
     workspaceRepositoryFetcher.fetchWorkspaceRepositories = async () => ({
       repositories: [],
-      error: "Response status: 500",
+      error: apiFailure("server_error", { status: 500 }).error,
       warning: null,
       partial: false,
     });

--- a/test/workspaceRepositoryFetcher.test.js
+++ b/test/workspaceRepositoryFetcher.test.js
@@ -2,6 +2,7 @@ const assert = require("assert");
 const vscode = require("vscode");
 const { PaginatedFetch } = require("../util/paginatedFetch");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
+const { apiFailure } = require("./apiResultHelpers");
 
 suite("WorkspaceRepositoryFetcher Test Suite", () => {
   let originalConsole;
@@ -194,10 +195,14 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
   });
 
   test("returns an error when the first page fails", async () => {
+    const failure = apiFailure("server_error", {
+      status: 500,
+      message: "The Cloudsmith API returned an internal error.",
+    }).error;
     PaginatedFetch.prototype.fetchPage = async () => ({
       data: [],
       pagination: { page: 1, pageTotal: 1, count: 0, pageSize: 500 },
-      error: "Response status: 500",
+      error: failure,
     });
 
     const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
@@ -205,7 +210,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       "workspace-a"
     );
 
-    assert.strictEqual(result.error, "Response status: 500");
+    assert.strictEqual(result.error, failure);
     assert.strictEqual(result.partial, false);
     assert.deepStrictEqual(result.repositories, []);
   });
@@ -224,7 +229,10 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       return {
         data: [],
         pagination: { page: 2, pageTotal: 2, count: 600, pageSize },
-        error: "Response status: 502",
+        error: apiFailure("server_error", {
+          status: 502,
+          message: "The Cloudsmith API returned an internal error.",
+        }).error,
       };
     };
 
@@ -235,13 +243,13 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
 
     assert.strictEqual(result.error, null);
     assert.strictEqual(result.partial, true);
-    assert.strictEqual(result.warning, "Response status: 502");
+    assert.strictEqual(result.warning.kind, "server_error");
     assert.strictEqual(result.repositories.length, 500);
     assert.strictEqual(result.repositories[0].name, "repo-001");
     assert.strictEqual(result.repositories[499].name, "repo-500");
     assert.deepStrictEqual(warnCalls, [
       [
-        "[WorkspaceRepositories] Failed to load additional repositories for workspace-a on page 2: Response status: 502",
+        "[WorkspaceRepositories] Failed to load an additional repository page: The Cloudsmith API returned an internal error.",
       ],
     ]);
   });

--- a/util/apiEndpoint.js
+++ b/util/apiEndpoint.js
@@ -1,0 +1,156 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const API_ROOT = new URL("https://api.cloudsmith.io/v1/");
+const MAX_SEGMENT_LENGTH = 1024;
+const MAX_QUERY_VALUE_LENGTH = 8192;
+const SECRET_QUERY_NAMES = new Set([
+  "api-key",
+  "api_key",
+  "apikey",
+  "x-api-key",
+  "x_api_key",
+  "xapikey",
+  "access-token",
+  "access_token",
+  "accesstoken",
+  "authorization",
+  "bearer",
+  "client-secret",
+  "client_secret",
+  "clientsecret",
+  "credential",
+  "credentials",
+  "id-token",
+  "id_token",
+  "idtoken",
+  "password",
+  "passwd",
+  "private-key",
+  "private_key",
+  "refresh-token",
+  "refresh_token",
+  "refreshtoken",
+  "secret",
+  "token",
+]);
+
+function decodeRepeated(value) {
+  let decoded = value;
+  for (let depth = 0; depth < 3; depth += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new Error("API path segment contains invalid percent encoding.");
+    }
+    if (next === decoded) {
+      break;
+    }
+    decoded = next;
+  }
+  return decoded;
+}
+
+function encodeApiPathSegment(value) {
+  const segment = typeof value === "number" && Number.isFinite(value)
+    ? String(value)
+    : value;
+  if (typeof segment !== "string" || segment.length === 0 || segment.length > MAX_SEGMENT_LENGTH) {
+    throw new Error("API path segment is missing or too long.");
+  }
+  if (segment !== segment.trim() || /[\u0000-\u001f\u007f\\/?#]/.test(segment)) {
+    throw new Error("API path segment contains unsupported characters.");
+  }
+
+  const decoded = decodeRepeated(segment);
+  if (
+    decoded === "."
+    || decoded === ".."
+    || /[\u0000-\u001f\u007f\\/?#]/.test(decoded)
+  ) {
+    throw new Error("API path segment is unsafe.");
+  }
+
+  return encodeURIComponent(segment);
+}
+
+function isSecretQueryName(value) {
+  let decoded;
+  try {
+    decoded = decodeRepeated(String(value));
+  } catch {
+    return true;
+  }
+  return SECRET_QUERY_NAMES.has(decoded.trim().toLowerCase());
+}
+
+function appendQueryValues(searchParams, query) {
+  if (query == null) {
+    return;
+  }
+
+  const entries = query instanceof URLSearchParams
+    ? [...query.entries()]
+    : Object.entries(query);
+  for (const [rawName, rawValue] of entries) {
+    const name = String(rawName);
+    if (isSecretQueryName(name)) {
+      throw new Error("Credentials are not permitted in API query parameters.");
+    }
+    if (rawValue === undefined || rawValue === null) {
+      continue;
+    }
+    const value = typeof rawValue === "number"
+      ? (Number.isFinite(rawValue) ? String(rawValue) : null)
+      : typeof rawValue === "boolean" || typeof rawValue === "string"
+        ? String(rawValue)
+        : null;
+    if (value === null || value.length > MAX_QUERY_VALUE_LENGTH || /[\u0000-\u001f\u007f]/.test(value)) {
+      throw new Error("API query value is invalid or too long.");
+    }
+    searchParams.set(name, value);
+  }
+}
+
+function apiEndpoint(segments, options = {}) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    throw new Error("API endpoint requires at least one path segment.");
+  }
+  const trailingSlash = options.trailingSlash !== false;
+  const pathname = segments.map(encodeApiPathSegment).join("/") + (trailingSlash ? "/" : "");
+  const searchParams = new URLSearchParams();
+  appendQueryValues(searchParams, options.query);
+  const queryString = searchParams.toString();
+  return queryString ? `${pathname}?${queryString}` : pathname;
+}
+
+function appendApiQuery(endpoint, query) {
+  if (
+    typeof endpoint !== "string"
+    || !endpoint
+    || endpoint.length > MAX_QUERY_VALUE_LENGTH
+    || /[\u0000-\u001f\u007f\\#]/.test(endpoint)
+  ) {
+    throw new Error("API endpoint is invalid.");
+  }
+
+  const parsed = new URL(endpoint, API_ROOT);
+  if (parsed.origin !== API_ROOT.origin || !parsed.pathname.startsWith(API_ROOT.pathname)) {
+    throw new Error("API endpoint escaped the Cloudsmith API root.");
+  }
+  for (const name of parsed.searchParams.keys()) {
+    if (isSecretQueryName(name)) {
+      throw new Error("Credentials are not permitted in API query parameters.");
+    }
+  }
+  appendQueryValues(parsed.searchParams, query);
+  return `${parsed.pathname.slice(API_ROOT.pathname.length)}${parsed.search}`;
+}
+
+module.exports = {
+  apiEndpoint,
+  appendApiQuery,
+  encodeApiPathSegment,
+  isSecretQueryName,
+  SECRET_QUERY_NAMES,
+};

--- a/util/cloudsmithAPI.js
+++ b/util/cloudsmithAPI.js
@@ -1,271 +1,1041 @@
-// Class to handle Cloudsmith API requests. 
-// Utilises the public Cloudsmith v1 API - https://help.cloudsmith.io/reference/introduction
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
-const apiURL = 'https://api.cloudsmith.io/v1/';
-const apiV2URL = 'https://api.cloudsmith.io/v2/';
-const ALLOWED_API_HOST = "api.cloudsmith.io";
-const { CredentialManager } = require('./credentialManager');
-const extensionVersion = require('../package.json').version;
-const vscodeVersion = require('vscode').version;
+const crypto = require("crypto");
+const { CredentialManager } = require("./credentialManager");
+const { isSecretQueryName } = require("./apiEndpoint");
+const extensionVersion = require("../package.json").version;
+const vscodeVersion = require("vscode").version;
+
+const API_ROOTS = Object.freeze({
+  v1: new URL("https://api.cloudsmith.io/v1/"),
+  v2: new URL("https://api.cloudsmith.io/v2/"),
+});
+const API_ORIGIN = "https://api.cloudsmith.io";
+const DEFAULT_TIMEOUT_MS = 30 * 1000;
+const MAX_TIMEOUT_MS = 2 * 60 * 1000;
+const MAX_ENDPOINT_LENGTH = 16 * 1024;
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+const MAX_SUCCESS_BODY_BYTES = 5 * 1024 * 1024;
+const MAX_ERROR_BODY_BYTES = 8 * 1024;
+const MAX_HEADER_VALUE_LENGTH = 512;
+const MAX_REDIRECTS = 1;
+const MAX_READ_RETRIES = 2;
+const MAX_AUTO_RETRY_DELAY_MS = 5 * 1000;
+const MAX_REPORTED_RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const SUPPORTED_METHODS = new Set(["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"]);
+const ALLOWED_CAUSE_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+]);
+const ALLOWED_RESPONSE_HEADERS = Object.freeze([
+  "content-length",
+  "content-type",
+  "retry-after",
+  "x-correlation-id",
+  "x-pagination-count",
+  "x-pagination-page",
+  "x-pagination-pagesize",
+  "x-pagination-pagetotal",
+  "x-request-id",
+  "cf-ray",
+]);
+const EMPTY_HEADERS = Object.freeze(Object.create(null));
 const userAgent = `Cloudsmith-VSCode/${extensionVersion} (VS Code ${vscodeVersion})`;
 
-class CloudsmithAPI {
-    constructor(context){
-        this.context = context;
-    }
-
-    /**
-     * GET request to Cloudsmith API.
-     *
-     * @param   endpoint  for example 'repos' for v1/repos.
-     * @param.  api token *optional
-     * @returns json response.
-     */
-    //async function get(endpoint, apiKey) {
-    async get(endpoint, apiKey) {
-
-        const credentialManager = new CredentialManager(this.context)
-
-        if(!apiKey){
-            apiKey = await credentialManager.getApiKey();
-        }
-
-        const headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-        };
-        if (apiKey) {
-            headers['X-Api-Key'] = apiKey;
-        }
-
-        const requestOptions = {
-            method: 'GET',
-            headers: headers,
-        };
-
-        const response = this.makeRequest(endpoint, requestOptions);
-        return response;
-
-    }
-
-    /**
-     * POST request to Cloudsmith API.
-     *
-     * @param   endpoint  for example 'repos' for v1/repos.
-     * @param   payload  json string payload 
-     * @param   api token *optional
-     * @returns json response.
-     */
-
-    async post(endpoint, payload, apiKey) {
-        const credentialManager = new CredentialManager(this.context);
-
-        if (!apiKey) {
-            apiKey = await credentialManager.getApiKey();
-        }
-
-        const headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-        };
-        if (apiKey) {
-            headers['X-Api-Key'] = apiKey;
-        }
-
-        const requestOptions = {
-            method: 'POST',
-            headers: headers,
-            body: payload
-        };
-
-        const response = await this.makeRequest(endpoint, requestOptions);
-        return response;
-    }
-
-
-    /**
-     * Make the actual request to the API endpoint.
-     *
-     * @param   endpoint  for example 'repos' for v1/repos.
-     * @param   requestOptions Request options such as method, headers and body. 
-     * @returns json response.
-     */
-    /**
-     * GET request that returns both data and pagination headers.
-     *
-     * @param   endpoint  for example 'packages/owner/' with query params.
-     * @param   apiKey *optional
-     * @returns { data, headers } where headers contains pagination info.
-     */
-    async getWithHeaders(endpoint, apiKey) {
-
-        const credentialManager = new CredentialManager(this.context)
-
-        if(!apiKey){
-            apiKey = await credentialManager.getApiKey();
-        }
-
-        const headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-        };
-        if (apiKey) {
-            headers['X-Api-Key'] = apiKey;
-        }
-
-        const requestOptions = {
-            method: 'GET',
-            headers: headers,
-        };
-
-        const response = this.makeRequest(endpoint, requestOptions, true);
-        return response;
-
-    }
-
-    /**
-     * GET request to Cloudsmith v2 API.
-     *
-     * @param   endpoint  for example 'workspaces/my-org/policies/'
-     * @param   apiKey *optional
-     * @returns json response.
-     */
-    async getV2(endpoint, apiKey) {
-
-        const credentialManager = new CredentialManager(this.context)
-
-        if(!apiKey){
-            apiKey = await credentialManager.getApiKey();
-        }
-
-        const headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-        };
-        if (apiKey) {
-            headers['X-Api-Key'] = apiKey;
-        }
-
-        const requestOptions = {
-            method: 'GET',
-            headers: headers,
-        };
-
-        const response = this.makeRequest(endpoint, requestOptions, false, apiV2URL);
-        return response;
-
-    }
-
-    /**
-     * GET request to Cloudsmith v2 API that returns both data and pagination headers.
-     *
-     * @param   endpoint  for example 'workspaces/my-org/policies/'
-     * @param   apiKey *optional
-     * @returns { data, headers } where headers contains pagination info.
-     */
-    async getV2WithHeaders(endpoint, apiKey) {
-
-        const credentialManager = new CredentialManager(this.context)
-
-        if(!apiKey){
-            apiKey = await credentialManager.getApiKey();
-        }
-
-        const headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-        };
-        if (apiKey) {
-            headers['X-Api-Key'] = apiKey;
-        }
-
-        const requestOptions = {
-            method: 'GET',
-            headers: headers,
-        };
-
-        const response = this.makeRequest(endpoint, requestOptions, true, apiV2URL);
-        return response;
-
-    }
-
-    /**
-     * GET upstream configurations for a repository and format.
-     *
-     * @param   workspace  Workspace/owner slug.
-     * @param   repo       Repository slug.
-     * @param   format     Package format slug (e.g., 'python', 'npm', 'maven', 'docker').
-     * @returns Array of upstream config objects, or empty array on error.
-     */
-    async getUpstreams(workspace, repo, format) {
-        const result = await this.get(`repos/${workspace}/${repo}/upstream/${format}/`);
-        if (typeof result === 'string' || !Array.isArray(result)) {
-            return [];
-        }
-        return result;
-    }
-
-    /**
-     * Make the actual request to the API endpoint.
-     *
-     * @param   endpoint  for example 'repos' for v1/repos.
-     * @param   requestOptions Request options such as method, headers and body.
-     * @param   includeHeaders If true, return { data, headers } with pagination info.
-     * @returns json response.
-     */
-    async makeRequest(endpoint, requestOptions, includeHeaders = false, baseUrl = apiURL) {
-        try {
-            const requestUrl = new URL(endpoint, baseUrl);
-            if (requestUrl.protocol !== "https:" || requestUrl.hostname !== ALLOWED_API_HOST) {
-                return "Blocked non-Cloudsmith request target.";
-            }
-
-            // Add User-Agent header for usage attribution
-            if (requestOptions.headers) {
-                requestOptions.headers['User-Agent'] = userAgent;
-            }
-
-            // Prevent automatic redirect following to avoid leaking API key
-            requestOptions.redirect = 'manual';
-
-            let response = await fetch(requestUrl, requestOptions);
-
-            // Handle 3xx redirects manually with host validation
-            if (response.status >= 300 && response.status < 400) {
-                const location = response.headers.get('Location');
-                if (!location) {
-                    return "Received redirect with no Location header.";
-                }
-                const redirectUrl = new URL(location, requestUrl);
-                if (redirectUrl.protocol !== "https:" || redirectUrl.hostname !== ALLOWED_API_HOST) {
-                    return "Blocked redirect to untrusted host: " + redirectUrl.hostname;
-                }
-                response = await fetch(redirectUrl, requestOptions);
-            }
-
-            if (!response.ok) {
-                let errorBody = '';
-                try { errorBody = await response.text(); } catch (_) { /* ignore */ }
-                throw new Error(`Response status: ${response.status} - ${response.statusText} - ${errorBody}`);
-            }
-            const result = await response.json();
-            if (includeHeaders) {
-                return {
-                    data: result,
-                    headers: {
-                        page: response.headers.get('X-Pagination-Page'),
-                        pageTotal: response.headers.get('X-Pagination-PageTotal'),
-                        count: response.headers.get('X-Pagination-Count'),
-                        pageSize: response.headers.get('X-Pagination-PageSize'),
-                    }
-                };
-            }
-            return result;
-        } catch (error) {
-            return error.message
-
-        }
-    }
+function stripControls(value, maximum = MAX_HEADER_VALUE_LENGTH) {
+  return String(value == null ? "" : value)
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .slice(0, maximum);
 }
 
-module.exports = { CloudsmithAPI };
+function redactKnownSecrets(value, keys) {
+  let redacted = stripControls(value, 1024);
+  for (const key of keys) {
+    if (typeof key === "string" && key) {
+      redacted = redacted.split(key).join("[REDACTED]");
+      try {
+        redacted = redacted.split(encodeURIComponent(key)).join("[REDACTED]");
+      } catch {
+        // The raw value replacement above still applies.
+      }
+    }
+  }
+  return redacted;
+}
+
+function safeHeaderValue(headers, name) {
+  if (!headers || typeof headers.get !== "function") {
+    return null;
+  }
+  try {
+    const value = headers.get(name);
+    return value == null ? null : stripControls(value);
+  } catch {
+    return null;
+  }
+}
+
+function snapshotHeaders(headers, keys = []) {
+  if (!headers || typeof headers.get !== "function") {
+    return EMPTY_HEADERS;
+  }
+  const snapshot = Object.create(null);
+  for (const name of ALLOWED_RESPONSE_HEADERS) {
+    const value = safeHeaderValue(headers, name);
+    if (value !== null) {
+      snapshot[name] = redactKnownSecrets(value, keys);
+    }
+  }
+  return Object.freeze(snapshot);
+}
+
+function serverRequestIdFrom(headers) {
+  return headers["x-request-id"]
+    || headers["x-correlation-id"]
+    || headers["cf-ray"]
+    || null;
+}
+
+function decodingLayers(value) {
+  const layers = [String(value || "")];
+  for (let depth = 0; depth < 3; depth += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(layers[layers.length - 1]);
+    } catch {
+      return null;
+    }
+    if (next === layers[layers.length - 1]) {
+      break;
+    }
+    layers.push(next);
+  }
+  return layers;
+}
+
+function decodeRepeated(value) {
+  const layers = decodingLayers(value);
+  return layers === null ? null : layers[layers.length - 1];
+}
+
+function hasUnsafePathEncoding(rawPath) {
+  for (const segment of String(rawPath || "").split("/")) {
+    const decoded = decodeRepeated(segment);
+    if (
+      decoded === null
+      || decoded === "."
+      || decoded === ".."
+      || /[\\/?#\u0000-\u001f\u007f]/.test(decoded)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsKnownSecret(value, keys) {
+  const candidates = decodingLayers(value);
+  if (candidates === null) return true;
+  return [...keys].some((key) => (
+    typeof key === "string"
+    && key
+    && candidates.some((candidate) => candidate.includes(key))
+  ));
+}
+
+function validateApiUrl(candidate, apiVersion, keys, options = {}) {
+  const root = API_ROOTS[apiVersion];
+  if (!root || typeof candidate !== "string" || !candidate || candidate.length > MAX_ENDPOINT_LENGTH) {
+    return null;
+  }
+  if (candidate !== candidate.trim() || /[\\#\u0000-\u001f\u007f]/.test(candidate)) {
+    return null;
+  }
+  if (!options.allowAbsolute && (/^[a-z][a-z\d+.-]*:/i.test(candidate) || candidate.startsWith("/"))) {
+    return null;
+  }
+
+  const rawPath = candidate.split("?", 1)[0];
+  if (hasUnsafePathEncoding(rawPath) || containsKnownSecret(candidate, keys)) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = options.allowAbsolute ? new URL(candidate, options.baseUrl || root) : new URL(candidate, root);
+  } catch {
+    return null;
+  }
+  if (
+    url.origin !== API_ORIGIN
+    || url.protocol !== "https:"
+    || url.hostname !== "api.cloudsmith.io"
+    || url.port !== ""
+    || url.username !== ""
+    || url.password !== ""
+    || url.hash !== ""
+    || !url.pathname.startsWith(root.pathname)
+  ) {
+    return null;
+  }
+  if (hasUnsafePathEncoding(url.pathname.slice(root.pathname.length))) {
+    return null;
+  }
+  for (const [name, value] of url.searchParams.entries()) {
+    if (
+      /[\u0000-\u001f\u007f]/.test(name)
+      || /[\u0000-\u001f\u007f]/.test(value)
+      || isSecretQueryName(name)
+      || containsKnownSecret(value, keys)
+    ) {
+      return null;
+    }
+  }
+  if (containsKnownSecret(url.pathname, keys)) {
+    return null;
+  }
+  return url;
+}
+
+function responseTypeAcceptsEmpty(responseType) {
+  return responseType === "empty" || responseType === "json-or-empty";
+}
+
+function isJsonContentType(contentType) {
+  const mediaType = String(contentType || "").split(";", 1)[0].trim().toLowerCase();
+  return mediaType === "application/json" || mediaType.endsWith("+json");
+}
+
+function validateResponseShape(data, responseType) {
+  switch (responseType) {
+    case "array":
+      return Array.isArray(data);
+    case "object":
+      return Boolean(data) && typeof data === "object" && !Array.isArray(data);
+    case "json":
+    case "json-or-empty":
+      return true;
+    case "empty":
+      return data === null;
+    default:
+      return false;
+  }
+}
+
+function errorKindForStatus(status) {
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
+  if (status === 404) return "not_found";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "server_error";
+  return "http_error";
+}
+
+function messageForError(kind, outcomeUnknown = false) {
+  if (outcomeUnknown) {
+    return "The request may have completed in Cloudsmith. Check the remote state before trying again.";
+  }
+  switch (kind) {
+    case "unauthorized":
+      return "Authentication failed. Check the API key.";
+    case "forbidden":
+      return "Could not access this resource. Check permissions.";
+    case "not_found":
+      return "Could not find the requested Cloudsmith resource.";
+    case "rate_limited":
+      return "Rate limited by the Cloudsmith API. Wait a moment and try again.";
+    case "server_error":
+      return "The Cloudsmith API returned an internal error. Try again later.";
+    case "network_error":
+      return "Could not reach the Cloudsmith API. Check the network connection.";
+    case "timeout":
+      return "The Cloudsmith API request timed out.";
+    case "cancelled":
+      return "The Cloudsmith API request was canceled.";
+    case "invalid_response":
+      return "Cloudsmith returned an unexpected response.";
+    case "redirect_rejected":
+      return "Cloudsmith returned an unsafe redirect, so the request was stopped.";
+    case "invalid_request":
+      return "The Cloudsmith request could not be constructed safely.";
+    default:
+      return "The Cloudsmith API request failed.";
+  }
+}
+
+function parseRetryAfter(value, now) {
+  if (!value) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  if (/^\d+$/.test(normalized)) {
+    const milliseconds = Number(normalized) * 1000;
+    return Number.isSafeInteger(milliseconds) ? milliseconds : null;
+  }
+  const timestamp = Date.parse(normalized);
+  if (!Number.isFinite(timestamp)) {
+    return null;
+  }
+  return Math.max(0, timestamp - now);
+}
+
+function isReadMethod(method) {
+  return method === "GET" || method === "HEAD";
+}
+
+function safeCauseCode(error) {
+  try {
+    const code = error && (error.code || (error.cause && error.cause.code));
+    return ALLOWED_CAUSE_CODES.has(code) ? code : null;
+  } catch {
+    return null;
+  }
+}
+
+function cancelResponseBody(response) {
+  try {
+    if (response && response.body && typeof response.body.cancel === "function") {
+      Promise.resolve(response.body.cancel()).catch(() => {});
+    }
+  } catch {
+    // Body cancellation is best-effort after the request outcome is known.
+  }
+}
+
+async function readBoundedBody(response, limit, signal) {
+  const lengthHeader = safeHeaderValue(response && response.headers, "content-length");
+  const declaredLength = lengthHeader && /^\d+$/.test(lengthHeader) ? Number(lengthHeader) : null;
+  if (declaredLength !== null && declaredLength > limit) {
+    await cancelResponseBody(response);
+    return { oversized: true, text: "", bytes: 0 };
+  }
+
+  if (response && response.body && typeof response.body.getReader === "function") {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    let bytes = 0;
+    try {
+      while (true) {
+        if (signal.aborted) {
+          cancelResponseReader(reader);
+          return { aborted: true, text: "", bytes };
+        }
+        const chunkResult = await readStreamChunk(reader, signal);
+        if (chunkResult.aborted) {
+          return { aborted: true, text: "", bytes };
+        }
+        if (chunkResult.failed) {
+          cancelResponseReader(reader);
+          return { readFailed: true, text: "", bytes };
+        }
+        const chunk = chunkResult.value;
+        if (chunk.done) {
+          text += decoder.decode();
+          return { text, bytes };
+        }
+        bytes += chunk.value.byteLength;
+        if (bytes > limit) {
+          cancelResponseReader(reader);
+          return { oversized: true, text: "", bytes };
+        }
+        text += decoder.decode(chunk.value, { stream: true });
+      }
+    } catch {
+      cancelResponseReader(reader);
+      if (signal.aborted) {
+        return { aborted: true, text: "", bytes };
+      }
+      return { readFailed: true, text: "", bytes };
+    } finally {
+      try { reader.releaseLock(); } catch { /* no-op */ }
+    }
+  }
+
+  if (!response || !response.body) {
+    return { text: "", bytes: 0 };
+  }
+
+  await cancelResponseBody(response);
+  return { unsupported: true, text: "", bytes: 0 };
+}
+
+function cancelResponseReader(reader) {
+  if (!reader || typeof reader.cancel !== "function") {
+    return;
+  }
+  try {
+    Promise.resolve(reader.cancel()).catch(() => {});
+  } catch {
+    // The stream may already be closed or detached.
+  }
+}
+
+function readStreamChunk(reader, signal) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const onAbort = () => {
+      cancelResponseReader(reader);
+      finish({ aborted: true });
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    Promise.resolve()
+      .then(() => reader.read())
+      .then(value => finish({ value }), () => finish({ failed: true }));
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+}
+
+async function discardBoundedBody(response, limit, signal) {
+  const result = await readBoundedBody(response, limit, signal);
+  if (result.oversized) {
+    await cancelResponseBody(response);
+  }
+  return result;
+}
+
+class CloudsmithAPI {
+  constructor(context, options = {}) {
+    this.context = context;
+    this._fetch = options.fetchImpl || fetch;
+    this._setTimeout = options.setTimeout || setTimeout;
+    this._clearTimeout = options.clearTimeout || clearTimeout;
+    this._now = options.now || Date.now;
+    this._randomUUID = options.randomUUID || crypto.randomUUID;
+    this._credentialManager = options.credentialManager || new CredentialManager(context);
+  }
+
+  async get(endpoint, options = {}) {
+    return this.request(endpoint, { ...options, method: "GET", apiVersion: "v1" });
+  }
+
+  async getV2(endpoint, options = {}) {
+    return this.request(endpoint, { ...options, method: "GET", apiVersion: "v2" });
+  }
+
+  async post(endpoint, json, options = {}) {
+    return this.request(endpoint, {
+      ...options,
+      method: "POST",
+      apiVersion: options.apiVersion || "v1",
+      json,
+      retry: "never",
+    });
+  }
+
+  async request(endpoint, options = {}) {
+    const requestId = this._randomUUID();
+    const method = String(options.method || "GET").toUpperCase();
+    const apiVersion = options.apiVersion || "v1";
+    const responseType = options.responseType || "object";
+    const retry = options.retry || "never";
+    const timeoutMs = Number.isFinite(options.timeoutMs)
+      ? Math.max(1, Math.min(Math.floor(options.timeoutMs), MAX_TIMEOUT_MS))
+      : DEFAULT_TIMEOUT_MS;
+    const externalSignal = options.signal || null;
+    const cancellationToken = options.cancellationToken || null;
+    const controller = new AbortController();
+    let abortKind = null;
+    let externalAbortListener = null;
+    let cancellationDisposable = null;
+    let timeoutHandle = null;
+    let attempts = 0;
+    let selectedKey = null;
+    let storedKey = null;
+    const keys = new Set();
+    const deadline = this._now() + timeoutMs;
+
+    const abort = (kind) => {
+      if (abortKind !== null) {
+        return false;
+      }
+      abortKind = kind;
+      controller.abort();
+      return true;
+    };
+
+    const diagnosticPath = () => {
+      const root = API_ROOTS[apiVersion];
+      const validated = root ? validateApiUrl(endpoint, apiVersion, keys) : null;
+      if (!validated || !root) {
+        return "";
+      }
+      return stripControls(validated.pathname.slice(root.pathname.length), 512);
+    };
+
+    const buildDiagnostic = (status = null, headers = EMPTY_HEADERS, bodyBytes = 0, causeCode = null) => Object.freeze({
+      method,
+      apiVersion: API_ROOTS[apiVersion] ? apiVersion : null,
+      path: redactKnownSecrets(diagnosticPath(), keys),
+      status: Number.isInteger(status) ? status : null,
+      contentType: redactKnownSecrets(headers["content-type"] || "", keys),
+      bodyBytes: Number.isSafeInteger(bodyBytes) && bodyBytes >= 0 ? bodyBytes : 0,
+      causeCode: ALLOWED_CAUSE_CODES.has(causeCode) ? causeCode : null,
+    });
+
+    const failure = ({
+      kind,
+      status = null,
+      headers = EMPTY_HEADERS,
+      retryable = false,
+      retryAfterMs = null,
+      outcomeUnknown = false,
+      bodyBytes = 0,
+      causeCode = null,
+    }) => {
+      const serverRequestId = serverRequestIdFrom(headers);
+      const error = Object.freeze({
+        kind,
+        status: Number.isInteger(status) ? status : null,
+        retryable: Boolean(retryable),
+        message: messageForError(kind, outcomeUnknown),
+        requestId,
+        retryAfterMs: Number.isFinite(retryAfterMs)
+          ? Math.min(Math.max(0, retryAfterMs), MAX_REPORTED_RETRY_AFTER_MS)
+          : null,
+        outcomeUnknown: Boolean(outcomeUnknown),
+        diagnostic: buildDiagnostic(status, headers, bodyBytes, causeCode),
+      });
+      return Object.freeze({
+        ok: false,
+        status: Number.isInteger(status) ? status : null,
+        headers,
+        requestId,
+        serverRequestId,
+        attempts,
+        error,
+      });
+    };
+
+    const cancelledFailure = () => failure({
+      kind: abortKind === "timeout" ? "timeout" : "cancelled",
+      retryable: false,
+      outcomeUnknown: !isReadMethod(method) && attempts > 0,
+    });
+
+    try {
+      if (externalSignal && typeof externalSignal.addEventListener === "function") {
+        externalAbortListener = () => abort("cancelled");
+        externalSignal.addEventListener("abort", externalAbortListener, { once: true });
+        if (externalSignal.aborted) {
+          abort("cancelled");
+        }
+      }
+      if (cancellationToken && typeof cancellationToken.onCancellationRequested === "function") {
+        cancellationDisposable = cancellationToken.onCancellationRequested(() => abort("cancelled"));
+        if (cancellationToken.isCancellationRequested) {
+          abort("cancelled");
+        }
+      }
+      timeoutHandle = this._setTimeout(() => abort("timeout"), timeoutMs);
+      if (abortKind !== null) {
+        return cancelledFailure();
+      }
+
+      const credentialResult = await this._awaitAbortable(
+        Promise.resolve().then(() => this._credentialManager.getApiKey()),
+        controller.signal
+      );
+      if (credentialResult.aborted) {
+        return cancelledFailure();
+      }
+      if (!credentialResult.ok) {
+        return failure({ kind: "invalid_request" });
+      }
+      storedKey = credentialResult.value;
+      if (typeof storedKey === "string" && storedKey) {
+        keys.add(storedKey);
+      }
+      if (abortKind !== null || this._now() >= deadline) {
+        if (abortKind === null) abort("timeout");
+        return cancelledFailure();
+      }
+
+      const hasCandidateKey = Object.prototype.hasOwnProperty.call(options, "apiKey");
+      if (hasCandidateKey) {
+        if (typeof options.apiKey === "string" && options.apiKey) {
+          selectedKey = options.apiKey;
+          keys.add(selectedKey);
+        }
+      } else {
+        selectedKey = storedKey;
+      }
+      if (
+        typeof selectedKey !== "string"
+        || !selectedKey
+        || selectedKey.length > 4096
+        || /[\u0000-\u001f\u007f]/.test(selectedKey)
+      ) {
+        return failure({ kind: "unauthorized", status: 401 });
+      }
+
+      const requestUrl = validateApiUrl(endpoint, apiVersion, keys);
+      if (!requestUrl || !API_ROOTS[apiVersion]) {
+        return failure({ kind: "invalid_request" });
+      }
+      if (!SUPPORTED_METHODS.has(method)) {
+        return failure({ kind: "invalid_request" });
+      }
+      if (!["array", "empty", "json", "json-or-empty", "object"].includes(responseType)) {
+        return failure({ kind: "invalid_request" });
+      }
+      if (!isReadMethod(method) && retry !== "never") {
+        return failure({ kind: "invalid_request" });
+      }
+      if (retry !== "never" && retry !== "safe-read") {
+        return failure({ kind: "invalid_request" });
+      }
+      if (isReadMethod(method) && Object.prototype.hasOwnProperty.call(options, "json")) {
+        return failure({ kind: "invalid_request" });
+      }
+
+      let body;
+      if (Object.prototype.hasOwnProperty.call(options, "json")) {
+        try {
+          body = JSON.stringify(options.json);
+        } catch {
+          return failure({ kind: "invalid_request" });
+        }
+        if (body === undefined || Buffer.byteLength(body, "utf8") > MAX_REQUEST_BODY_BYTES) {
+          return failure({ kind: "invalid_request" });
+        }
+      }
+
+      const maxAttempts = retry === "safe-read" && isReadMethod(method)
+        ? MAX_READ_RETRIES + 1
+        : 1;
+      let currentFailure = null;
+
+      while (attempts < maxAttempts) {
+        if (abortKind !== null || this._now() >= deadline) {
+          if (abortKind === null) abort("timeout");
+          return cancelledFailure();
+        }
+        attempts += 1;
+
+        const attemptResult = await this._performAttempt({
+          requestUrl,
+          method,
+          body,
+          selectedKey,
+          apiVersion,
+          responseType,
+          validate: options.validate,
+          signal: controller.signal,
+          keys,
+          abortKind: () => abortKind,
+          deadline,
+          now: this._now,
+          abortTimeout: () => abort("timeout"),
+        });
+        if (abortKind !== null || this._now() >= deadline) {
+          if (abortKind === null) abort("timeout");
+          return cancelledFailure();
+        }
+        if (attemptResult.ok) {
+          const serverRequestId = serverRequestIdFrom(attemptResult.headers);
+          return Object.freeze({
+            ok: true,
+            data: attemptResult.data,
+            status: attemptResult.status,
+            headers: attemptResult.headers,
+            requestId,
+            serverRequestId,
+            attempts,
+            redirectCount: attemptResult.redirectCount,
+          });
+        }
+
+        const unsafeWrite = !isReadMethod(method);
+        const outcomeUnknown = unsafeWrite && attemptResult.dispatched && (
+          attemptResult.status === null
+          || attemptResult.status >= 500
+          || (attemptResult.status >= 200 && attemptResult.status < 300)
+        );
+        currentFailure = failure({
+          ...attemptResult,
+          retryable: isReadMethod(method) && attemptResult.retryable,
+          outcomeUnknown,
+        });
+
+        const shouldRetry = attempts < maxAttempts
+          && retry === "safe-read"
+          && attemptResult.retryable;
+        if (!shouldRetry) {
+          return currentFailure;
+        }
+
+        const retryAfterMs = attemptResult.retryAfterMs;
+        const delayMs = retryAfterMs === null
+          ? Math.min(250 * (2 ** (attempts - 1)), MAX_AUTO_RETRY_DELAY_MS)
+          : retryAfterMs;
+        const remaining = deadline - this._now();
+        if (delayMs > MAX_AUTO_RETRY_DELAY_MS || delayMs >= remaining) {
+          return currentFailure;
+        }
+        const completedDelay = await this._waitForRetry(delayMs, controller.signal);
+        if (!completedDelay || abortKind !== null) {
+          return cancelledFailure();
+        }
+      }
+
+      return currentFailure || failure({ kind: "network_error" });
+    } finally {
+      if (timeoutHandle !== null) {
+        this._clearTimeout(timeoutHandle);
+      }
+      if (externalSignal && externalAbortListener && typeof externalSignal.removeEventListener === "function") {
+        externalSignal.removeEventListener("abort", externalAbortListener);
+      }
+      if (cancellationDisposable && typeof cancellationDisposable.dispose === "function") {
+        cancellationDisposable.dispose();
+      }
+    }
+  }
+
+  async _performAttempt({
+    requestUrl,
+    method,
+    body,
+    selectedKey,
+    apiVersion,
+    responseType,
+    validate,
+    signal,
+    keys,
+    abortKind,
+    deadline,
+    now,
+    abortTimeout,
+  }) {
+    let currentUrl = requestUrl;
+    let redirectCount = 0;
+    let dispatched = false;
+
+    while (true) {
+      if (signal.aborted || now() >= deadline) {
+        if (!signal.aborted) abortTimeout();
+        return { ok: false, kind: abortKind() || "cancelled", status: null, headers: EMPTY_HEADERS, dispatched };
+      }
+      let response;
+      try {
+        const headers = {
+          Accept: "application/json",
+          "User-Agent": userAgent,
+          "X-Api-Key": selectedKey,
+        };
+        if (body !== undefined) {
+          headers["Content-Type"] = "application/json";
+        }
+        dispatched = true;
+        const fetchResult = await this._awaitAbortable(this._fetch(currentUrl, {
+          method,
+          headers,
+          ...(body !== undefined ? { body } : {}),
+          redirect: "manual",
+          signal,
+        }), signal, cancelResponseBody);
+        if (fetchResult.aborted) {
+          return { ok: false, kind: abortKind() || "cancelled", status: null, headers: EMPTY_HEADERS, dispatched };
+        }
+        if (!fetchResult.ok) {
+          throw fetchResult.error;
+        }
+        response = fetchResult.value;
+      } catch (error) {
+        if (signal.aborted) {
+          return { ok: false, kind: abortKind() || "cancelled", status: null, headers: EMPTY_HEADERS, dispatched };
+        }
+        return {
+          ok: false,
+          kind: "network_error",
+          status: null,
+          headers: EMPTY_HEADERS,
+          retryable: true,
+          retryAfterMs: null,
+          bodyBytes: 0,
+          causeCode: safeCauseCode(error),
+          dispatched,
+        };
+      }
+
+      if (signal.aborted || now() >= deadline) {
+        if (!signal.aborted) abortTimeout();
+        await cancelResponseBody(response);
+        return { ok: false, kind: abortKind() || "cancelled", status: null, headers: EMPTY_HEADERS, dispatched };
+      }
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = safeHeaderValue(response.headers, "location");
+        await cancelResponseBody(response);
+        if (!isReadMethod(method) || redirectCount >= MAX_REDIRECTS || !location) {
+          return {
+            ok: false,
+            kind: "redirect_rejected",
+            status: response.status,
+            headers: snapshotHeaders(response.headers, keys),
+            retryable: false,
+            retryAfterMs: null,
+            bodyBytes: 0,
+            dispatched,
+          };
+        }
+        const redirectUrl = validateApiUrl(location, apiVersion, keys, {
+          allowAbsolute: true,
+          baseUrl: currentUrl,
+        });
+        if (!redirectUrl || redirectUrl.toString() === currentUrl.toString()) {
+          return {
+            ok: false,
+            kind: "redirect_rejected",
+            status: response.status,
+            headers: snapshotHeaders(response.headers, keys),
+            retryable: false,
+            retryAfterMs: null,
+            bodyBytes: 0,
+            dispatched,
+          };
+        }
+        currentUrl = redirectUrl;
+        redirectCount += 1;
+        continue;
+      }
+
+      const headers = snapshotHeaders(response.headers, keys);
+      const status = Number.isInteger(response.status) ? response.status : null;
+      if (!response.ok) {
+        const discarded = await discardBoundedBody(response, MAX_ERROR_BODY_BYTES, signal);
+        if (signal.aborted || discarded.aborted) {
+          return { ok: false, kind: abortKind() || "cancelled", status: null, headers, dispatched };
+        }
+        const kind = errorKindForStatus(status);
+        const retryAfterMs = parseRetryAfter(headers["retry-after"], this._now());
+        return {
+          ok: false,
+          kind,
+          status,
+          headers,
+          retryable: RETRYABLE_STATUS_CODES.has(status),
+          retryAfterMs,
+          bodyBytes: discarded.bytes || 0,
+          dispatched,
+        };
+      }
+
+      if (status === 204 || status === 205) {
+        if (!responseTypeAcceptsEmpty(responseType)) {
+          return {
+            ok: false,
+            kind: "invalid_response",
+            status,
+            headers,
+            retryable: false,
+            retryAfterMs: null,
+            bodyBytes: 0,
+            dispatched,
+          };
+        }
+        return { ok: true, data: null, status, headers, redirectCount };
+      }
+
+      const bodyResult = await readBoundedBody(response, MAX_SUCCESS_BODY_BYTES, signal);
+      if (signal.aborted || bodyResult.aborted || now() >= deadline) {
+        if (!signal.aborted && now() >= deadline) abortTimeout();
+        return { ok: false, kind: abortKind() || "cancelled", status: null, headers, dispatched };
+      }
+      if (bodyResult.readFailed) {
+        return {
+          ok: false,
+          kind: "network_error",
+          status,
+          headers,
+          retryable: true,
+          retryAfterMs: null,
+          bodyBytes: bodyResult.bytes || 0,
+          dispatched,
+        };
+      }
+      if (bodyResult.unsupported) {
+        return {
+          ok: false,
+          kind: "invalid_response",
+          status,
+          headers,
+          retryable: false,
+          retryAfterMs: null,
+          bodyBytes: 0,
+          dispatched,
+        };
+      }
+      if (bodyResult.oversized) {
+        return {
+          ok: false,
+          kind: "invalid_response",
+          status,
+          headers,
+          retryable: false,
+          retryAfterMs: null,
+          bodyBytes: bodyResult.bytes || 0,
+          dispatched,
+        };
+      }
+
+      if (bodyResult.text.length === 0) {
+        if (!responseTypeAcceptsEmpty(responseType)) {
+          return {
+            ok: false,
+            kind: "invalid_response",
+            status,
+            headers,
+            retryable: false,
+            retryAfterMs: null,
+            bodyBytes: 0,
+            dispatched,
+          };
+        }
+        return { ok: true, data: null, status, headers, redirectCount };
+      }
+      if (responseType === "empty" || !isJsonContentType(headers["content-type"])) {
+        return {
+          ok: false,
+          kind: "invalid_response",
+          status,
+          headers,
+          retryable: false,
+          retryAfterMs: null,
+          bodyBytes: bodyResult.bytes,
+          dispatched,
+        };
+      }
+
+      let data;
+      try {
+        data = JSON.parse(bodyResult.text);
+      } catch {
+        return {
+          ok: false,
+          kind: "invalid_response",
+          status,
+          headers,
+          retryable: false,
+          retryAfterMs: null,
+          bodyBytes: bodyResult.bytes,
+          dispatched,
+        };
+      }
+      if (!validateResponseShape(data, responseType)) {
+        return {
+          ok: false,
+          kind: "invalid_response",
+          status,
+          headers,
+          retryable: false,
+          retryAfterMs: null,
+          bodyBytes: bodyResult.bytes,
+          dispatched,
+        };
+      }
+      if (typeof validate === "function") {
+        let valid = false;
+        try {
+          valid = validate(data) === true;
+        } catch {
+          valid = false;
+        }
+        if (!valid) {
+          return {
+            ok: false,
+            kind: "invalid_response",
+            status,
+            headers,
+            retryable: false,
+            retryAfterMs: null,
+            bodyBytes: bodyResult.bytes,
+            dispatched,
+          };
+        }
+      }
+      return { ok: true, data, status, headers, redirectCount };
+    }
+  }
+
+  _awaitAbortable(promise, signal, onLateValue = null) {
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (result) => {
+        if (settled) return false;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(result);
+        return true;
+      };
+      const onAbort = () => finish({ aborted: true });
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) {
+        onAbort();
+      }
+      Promise.resolve(promise).then(
+        (value) => {
+          if (!finish({ ok: true, value }) && typeof onLateValue === "function") {
+            Promise.resolve(onLateValue(value)).catch(() => {});
+          }
+        },
+        error => finish({ ok: false, error })
+      );
+      if (signal.aborted) {
+        onAbort();
+      }
+    });
+  }
+
+  _waitForRetry(delayMs, signal) {
+    return new Promise((resolve) => {
+      let settled = false;
+      let handle = null;
+      const finish = (value) => {
+        if (settled) return;
+        settled = true;
+        if (handle !== null) this._clearTimeout(handle);
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      };
+      const onAbort = () => finish(false);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) {
+        finish(false);
+        return;
+      }
+      handle = this._setTimeout(() => finish(true), delayMs);
+      if (signal.aborted) {
+        finish(false);
+      }
+    });
+  }
+}
+
+function isApiResult(value) {
+  return Boolean(value) && typeof value === "object" && typeof value.ok === "boolean";
+}
+
+module.exports = {
+  CloudsmithAPI,
+  DEFAULT_TIMEOUT_MS,
+  isApiResult,
+};

--- a/util/connectionManager.js
+++ b/util/connectionManager.js
@@ -16,12 +16,16 @@ class ConnectionManager {
     const { CloudsmithAPI } = require("./cloudsmithAPI");
     let checkPassed = "false";
     const cloudsmithAPI = new CloudsmithAPI(this.context);
-    const userAuthenticated = await cloudsmithAPI.get("user/self", apiKey);
+    const result = await cloudsmithAPI.get("user/self", {
+      apiKey,
+      responseType: "object",
+      validate: value => typeof value.authenticated === "boolean",
+      retry: "never",
+    });
 
-    if (!userAuthenticated.authenticated) {
-      // Store the raw error for better messaging
-      this._lastError = typeof userAuthenticated === "string" ? userAuthenticated : null;
-      if (userAuthenticated.authenticated === undefined) {
+    if (!result.ok || !result.data.authenticated) {
+      this._lastError = result.ok ? null : result.error;
+      if (!result.ok) {
         checkPassed = "error";
       } else {
         checkPassed = "false";

--- a/util/dependencyVulnEnricher.js
+++ b/util/dependencyVulnEnricher.js
@@ -1,5 +1,6 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const { CloudsmithAPI } = require("./cloudsmithAPI");
+const { apiEndpoint } = require("./apiEndpoint");
 const { getFoundDependencyKey } = require("./foundDependencyKey");
 
 const VULNERABILITY_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -336,26 +337,37 @@ async function fetchVulnerabilitySummary(api, packageModel, fallbackSummary, can
     return fallbackSummary;
   }
 
-  const workspace = encodeURIComponent(String(packageModel.namespace || "").trim());
-  const repo = encodeURIComponent(String(packageModel.repository || "").trim());
-  const identifier = encodeURIComponent(String(
+  const workspace = String(packageModel.namespace || "").trim();
+  const repo = String(packageModel.repository || "").trim();
+  const identifier = String(
     packageModel.slug_perm
       || packageModel.slugPerm
       || packageModel.slug
       || packageModel.identifier
       || ""
-  ).trim());
+  ).trim();
 
   if (!workspace || !repo || !identifier) {
     return fallbackSummary;
   }
 
-  const response = await api.getV2(`vulnerabilities/${workspace}/${repo}/${identifier}/`);
-  if (typeof response === "string") {
-    return fallbackSummary;
+  let endpoint;
+  try {
+    endpoint = apiEndpoint(["vulnerabilities", workspace, repo, identifier]);
+  } catch {
+    return null;
+  }
+  const response = await api.getV2(endpoint, {
+    responseType: "json",
+    validate: isRecognizedVulnerabilityDetail,
+    retry: "never",
+    cancellationToken,
+  });
+  if (!response.ok || isCancellationRequested(cancellationToken)) {
+    return null;
   }
 
-  const summary = summarizeEntries(extractVulnerabilityEntries(response), fallbackSummary);
+  const summary = summarizeEntries(extractVulnerabilityEntries(response.data), fallbackSummary);
   setCachedVulnerabilitySummary(packageKey, summary);
   return summary;
 }
@@ -415,11 +427,13 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
       cancellationToken
     );
 
-    patchMap.set(target.key, summary);
+    if (summary) {
+      patchMap.set(target.key, summary);
+    }
     completed += 1;
 
     if (onProgress) {
-      onProgress(new Map([[target.key, summary]]), {
+      onProgress(summary ? new Map([[target.key, summary]]) : new Map(), {
         completed,
         total: detailTargets.length,
         workspace,
@@ -429,6 +443,42 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
   });
 
   return applyVulnerabilityPatch(dependencies, patchMap);
+}
+
+function isRecognizedVulnerabilityDetail(value) {
+  if (Array.isArray(value)) {
+    return isVulnerabilityRecordArray(value);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "results")) {
+    return Array.isArray(value.results) && isVulnerabilityRecordArray(value.results);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "vulnerabilities")) {
+    return Array.isArray(value.vulnerabilities) && isVulnerabilityRecordArray(value.vulnerabilities);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "items")) {
+    return Array.isArray(value.items) && isVulnerabilityRecordArray(value.items);
+  }
+  return Array.isArray(value.scans) && value.scans.every(scan => (
+    scan
+    && typeof scan === "object"
+    && !Array.isArray(scan)
+    && Array.isArray(scan.results)
+    && isVulnerabilityRecordArray(scan.results)
+  ));
+}
+
+function isVulnerabilityRecordArray(value) {
+  return Array.isArray(value) && value.every(entry => (
+    Boolean(entry)
+    && typeof entry === "object"
+    && !Array.isArray(entry)
+    && [entry.vulnerability_id, entry.identifier, entry.id, entry.name]
+      .some(identifier => typeof identifier === "string" && identifier.trim().length > 0)
+    && (entry.severity === undefined || entry.severity === null || typeof entry.severity === "string")
+  ));
 }
 
 module.exports = {

--- a/util/errorFormatter.js
+++ b/util/errorFormatter.js
@@ -1,39 +1,34 @@
-// Human-readable error message formatter for API errors.
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+// Human-readable error message formatter for structured API and local errors.
 
 /**
- * Convert a raw API error string into a user-friendly message.
- * @param   {string} errorString  Raw error from CloudsmithAPI (e.g., "Response status: 403 - Forbidden")
+ * Convert a structured API error or a local domain error into a user-friendly message.
+ * @param   {Object|string} error  Cloudsmith API result/error or a local error message.
  * @returns {string}              Human-readable error message.
  */
-function formatApiError(errorString) {
-  if (!errorString || typeof errorString !== "string") {
-    return "Could not complete the request.";
+function formatApiError(error) {
+  const apiError = error && error.ok === false
+    ? error.error
+    : error && typeof error === "object" && typeof error.kind === "string"
+      ? error
+      : null;
+  if (apiError && typeof apiError.message === "string") {
+    return apiError.message;
   }
+  if (error instanceof Error && typeof error.message === "string") {
+    return sanitizeLocalMessage(error.message);
+  }
+  if (typeof error === "string" && error) {
+    return sanitizeLocalMessage(error);
+  }
+  return "Could not complete the request.";
+}
 
-  const lower = errorString.toLowerCase();
-
-  if (lower.includes("403") || lower.includes("forbidden")) {
-    return "Could not access this resource. Check permissions.";
-  }
-  if (lower.includes("401") || lower.includes("unauthorized")) {
-    return "Authentication failed. Check the API key.";
-  }
-  if (lower.includes("404") || lower.includes("not found")) {
-    return "Could not find the requested resource. It may have been deleted or moved.";
-  }
-  if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many")) {
-    return "Rate limited by the Cloudsmith API. Wait a moment and try again.";
-  }
-  if (lower.includes("enotfound") || lower.includes("etimedout") || lower.includes("econnrefused") || lower.includes("fetch failed") || lower.includes("network")) {
-    return "Could not reach the Cloudsmith API. Check the network connection.";
-  }
-  if (lower.includes("500") || lower.includes("internal server")) {
-    return "The Cloudsmith API returned an internal error. Try again later.";
-  }
-
-  // Truncate long messages
-  const truncated = errorString.length > 100 ? errorString.substring(0, 100) + "..." : errorString;
-  return "Request failed: " + truncated;
+function sanitizeLocalMessage(message) {
+  const sanitized = String(message).replace(/[\u0000-\u001f\u007f]/g, " ");
+  const truncated = sanitized.length > 160 ? `${sanitized.slice(0, 160)}...` : sanitized;
+  return `Request failed: ${truncated}`;
 }
 
 module.exports = { formatApiError };

--- a/util/packageQuery.js
+++ b/util/packageQuery.js
@@ -1,0 +1,58 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const MAX_IDENTITY_VALUE_LENGTH = 4096;
+
+function normalizeIdentityValue(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return typeof value === "string" ? value : null;
+}
+
+function escapeExactQueryValue(value) {
+  const normalized = normalizeIdentityValue(value);
+  if (
+    normalized === null
+    || normalized.length === 0
+    || normalized.length > MAX_IDENTITY_VALUE_LENGTH
+    || /[\u0000-\u001f\u007f]/.test(normalized)
+  ) {
+    throw new Error("Package identity contains an invalid query value.");
+  }
+
+  return normalized.replace(/[\\+\-!(){}\[\]^"~*?:/|&]/g, "\\$&");
+}
+
+function buildExactPackageQuery(name, version, format = null) {
+  const clauses = [
+    `name:"${escapeExactQueryValue(name)}"`,
+    `version:"${escapeExactQueryValue(version)}"`,
+  ];
+  if (format !== null && format !== undefined && format !== "") {
+    clauses.push(`format:"${escapeExactQueryValue(format)}"`);
+  }
+  return clauses.join(" AND ");
+}
+
+function packageMatchesExactIdentity(pkg, expected) {
+  if (!pkg || typeof pkg !== "object" || Array.isArray(pkg) || !expected) {
+    return false;
+  }
+  const expectedName = normalizeIdentityValue(expected.name);
+  const expectedVersion = normalizeIdentityValue(expected.version);
+  const expectedFormat = normalizeIdentityValue(expected.format);
+  if (
+    normalizeIdentityValue(pkg.name) !== expectedName
+    || normalizeIdentityValue(pkg.version) !== expectedVersion
+  ) {
+    return false;
+  }
+  return expectedFormat === null || expectedFormat === ""
+    ? true
+    : normalizeIdentityValue(pkg.format) === expectedFormat;
+}
+
+module.exports = {
+  buildExactPackageQuery,
+  packageMatchesExactIdentity,
+};

--- a/util/packageVulnerabilities.js
+++ b/util/packageVulnerabilities.js
@@ -1,5 +1,7 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
+const { apiEndpoint, encodeApiPathSegment } = require("./apiEndpoint");
+
 const VULNERABILITIES_DETECTED_STATUS = "scan detected vulnerabilities";
 
 function unwrapValue(value) {
@@ -116,19 +118,26 @@ function result(error, results = [], maxSeverity = "Unknown", numVulns = 0) {
  * Fetch the latest package scan and its vulnerability records from the v1 API.
  * API failures remain distinct from a successful zero-vulnerability response.
  */
-async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifier, expectedCount = 0) {
+async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifier, expectedCount = 0, options = {}) {
   const fallbackCount = expectedCount > 0 ? expectedCount : 0;
-  const path = [workspace, repo, packageIdentifier]
-    .map(value => encodeURIComponent(String(value || "").trim()))
-    .join("/");
+  let scanListEndpoint;
+  try {
+    scanListEndpoint = apiEndpoint(["vulnerabilities", workspace, repo, packageIdentifier]);
+  } catch (error) {
+    return result(error, [], "Unknown", fallbackCount);
+  }
 
-  const scanList = await api.get(`vulnerabilities/${path}/`);
-  if (typeof scanList === "string") {
-    return result(scanList, [], "Unknown", fallbackCount);
+  const scanListResult = await api.get(scanListEndpoint, {
+    responseType: "array",
+    validate: isScanRecordArray,
+    retry: options.retry || "safe-read",
+    signal: options.signal,
+    cancellationToken: options.cancellationToken,
+  });
+  if (!scanListResult.ok) {
+    return result(scanListResult.error, [], "Unknown", fallbackCount);
   }
-  if (!Array.isArray(scanList)) {
-    return result("The Cloudsmith API returned an invalid vulnerability scan list.", [], "Unknown", fallbackCount);
-  }
+  const scanList = scanListResult.data;
   if (scanList.length === 0) {
     if (fallbackCount > 0 || expectedCount < 0) {
       return result("No vulnerability scan details were returned for this package.", [], "Unknown", fallbackCount);
@@ -152,17 +161,34 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
     return result(null, [], maxSeverity, 0);
   }
 
-  const scanDetail = await api.get(
-    `vulnerabilities/${path}/${encodeURIComponent(String(scanId))}/`
-  );
-  if (typeof scanDetail === "string") {
-    return result(scanDetail, [], maxSeverity, numVulns);
-  }
-  if (!scanDetail || typeof scanDetail !== "object") {
-    return result("The Cloudsmith API returned invalid vulnerability scan details.", [], maxSeverity, numVulns);
+  let scanDetailEndpoint;
+  try {
+    scanDetailEndpoint = apiEndpoint(["vulnerabilities", workspace, repo, packageIdentifier, scanId]);
+  } catch {
+    return result(
+      new Error("The vulnerability scan identifier was invalid."),
+      [],
+      maxSeverity,
+      numVulns
+    );
   }
 
-  const results = extractVulnerabilityResults(scanDetail);
+  const scanDetailResult = await api.get(
+    scanDetailEndpoint,
+    {
+      responseType: "object",
+      validate: isRecognizedVulnerabilityPayload,
+      retry: options.retry || "safe-read",
+      signal: options.signal,
+      cancellationToken: options.cancellationToken,
+    }
+  );
+  if (!scanDetailResult.ok) {
+    return result(scanDetailResult.error, [], maxSeverity, numVulns);
+  }
+  const scanDetail = scanDetailResult.data;
+
+  const results = extractVulnerabilityResults(scanDetail).map(normalizeVulnerabilityRecord);
   if (results.length === 0 && (numVulns > 0 || scanReportsVulnerabilities(targetScan))) {
     return result(
       "The scan reports vulnerabilities, but no vulnerability detail records were returned.",
@@ -173,6 +199,93 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
   }
 
   return result(null, results, maxSeverity, results.length || numVulns);
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(item => (
+    Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  ));
+}
+
+function hasUsableScanIdentifier(value) {
+  const identifier = unwrapValue(value && value.identifier);
+  if (typeof identifier !== "string" || identifier.length === 0) {
+    return false;
+  }
+  try {
+    encodeApiPathSegment(identifier);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isScanRecordArray(value) {
+  return isRecordArray(value) && value.every(hasUsableScanIdentifier);
+}
+
+function isVulnerabilityRecordArray(value) {
+  return isRecordArray(value) && value.every(isVulnerabilityRecord);
+}
+
+function vulnerabilityIdentifier(value) {
+  const candidate = value && (
+    value.vulnerability_id
+    || value.identifier
+    || value.id
+    || value.name
+  );
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : null;
+}
+
+function isVulnerabilityRecord(value) {
+  return Boolean(vulnerabilityIdentifier(value))
+    && (value.severity === undefined || value.severity === null || typeof value.severity === "string");
+}
+
+function normalizeVulnerabilityRecord(value) {
+  return typeof value.vulnerability_id === "string" && value.vulnerability_id.trim().length > 0
+    ? value
+    : { ...value, vulnerability_id: vulnerabilityIdentifier(value) };
+}
+
+function hasRecognizedVulnerabilityArray(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "results")) {
+    return Array.isArray(value.results) && isVulnerabilityRecordArray(value.results);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "vulnerabilities")) {
+    return Array.isArray(value.vulnerabilities) && isVulnerabilityRecordArray(value.vulnerabilities);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "Vulnerabilities")) {
+    return Array.isArray(value.Vulnerabilities) && isVulnerabilityRecordArray(value.Vulnerabilities);
+  }
+  return false;
+}
+
+function isRecognizedVulnerabilityPayload(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "results")) {
+    return Array.isArray(value.results) && isVulnerabilityRecordArray(value.results);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "vulnerabilities")) {
+    return Array.isArray(value.vulnerabilities) && isVulnerabilityRecordArray(value.vulnerabilities);
+  }
+  if (Array.isArray(value.scan)) {
+    return value.scan.every(hasRecognizedVulnerabilityArray);
+  }
+  if (value.scan && typeof value.scan === "object") {
+    return hasRecognizedVulnerabilityArray(value.scan);
+  }
+  return Array.isArray(value.scans) && value.scans.every(scan => (
+    hasRecognizedVulnerabilityArray(scan)
+  ));
 }
 
 module.exports = {

--- a/util/paginatedFetch.js
+++ b/util/paginatedFetch.js
@@ -1,5 +1,8 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 // Handles paginated API responses from Cloudsmith.
-// Returns both data and pagination metadata.
+
+const { appendApiQuery } = require("./apiEndpoint");
 
 const MAX_FETCH_ALL_PAGES = 20;
 
@@ -17,33 +20,51 @@ class PaginatedFetch {
      * @param   query     Optional query string to append
      * @returns { data: [], pagination: { page, pageTotal, count, pageSize } }
      */
-    async fetchPage(endpoint, page, pageSize, query) {
-        const separator = endpoint.includes('?') ? '&' : '?';
-        let url = `${endpoint}${separator}page=${page}&page_size=${pageSize}`;
-
-        if (query) {
-            url += `&query=${encodeURIComponent(query)}`;
-        }
-
-        const result = await this.api.getWithHeaders(url);
-
-        // Handle error case (makeRequest returns error string)
-        if (typeof result === 'string') {
+    async fetchPage(endpoint, page, pageSize, query, options = {}) {
+        let url;
+        try {
+            url = appendApiQuery(endpoint, {
+                page,
+                page_size: pageSize,
+                ...(query ? { query } : {}),
+            });
+        } catch {
             return {
                 data: [],
                 pagination: { page: 1, pageTotal: 1, count: 0, pageSize: pageSize },
-                error: result
+                error: localInvalidResponseError("The paginated API endpoint was invalid."),
+            };
+        }
+
+        const result = await this.api.get(url, {
+            responseType: "array",
+            validate: typeof options.validate === "function" ? options.validate : isRecordArray,
+            retry: options.retry || "never",
+            signal: options.signal,
+            cancellationToken: options.cancellationToken,
+        });
+
+        if (!result.ok) {
+            return {
+                data: [],
+                pagination: { page: 1, pageTotal: 1, count: 0, pageSize: pageSize },
+                error: result.error,
+            };
+        }
+
+        const pagination = parsePagination(result.headers, page, pageSize, result.data.length);
+        if (!pagination) {
+            return {
+                data: [],
+                pagination: { page, pageTotal: page, count: 0, pageSize },
+                error: localInvalidResponseError("Cloudsmith returned invalid pagination metadata."),
             };
         }
 
         return {
-            data: result.data || [],
-            pagination: {
-                page: parseInt(result.headers.page, 10) || page,
-                pageTotal: parseInt(result.headers.pageTotal, 10) || 1,
-                count: parseInt(result.headers.count, 10) || 0,
-                pageSize: parseInt(result.headers.pageSize, 10) || pageSize,
-            }
+            data: result.data,
+            pagination,
+            error: null,
         };
     }
 
@@ -98,6 +119,79 @@ class PaginatedFetch {
             pagination,
         };
     }
+}
+
+function isRecordArray(value) {
+    return Array.isArray(value) && value.every(item => (
+        Boolean(item) && typeof item === "object" && !Array.isArray(item)
+    ));
+}
+
+function parseOptionalInteger(value) {
+    if (value === undefined) {
+        return { present: false, valid: true, value: null };
+    }
+    const normalized = String(value).trim();
+    const parsed = /^\d+$/.test(normalized) ? Number(normalized) : NaN;
+    return {
+        present: true,
+        valid: Number.isSafeInteger(parsed) && parsed >= 0,
+        value: parsed,
+    };
+}
+
+function parsePagination(headers, requestedPage, requestedPageSize, itemCount) {
+    const page = parseOptionalInteger(headers["x-pagination-page"]);
+    const pageTotal = parseOptionalInteger(headers["x-pagination-pagetotal"]);
+    const count = parseOptionalInteger(headers["x-pagination-count"]);
+    const pageSize = parseOptionalInteger(headers["x-pagination-pagesize"]);
+    if (![page, pageTotal, count, pageSize].every(field => field.valid)) {
+        return null;
+    }
+    const effectivePage = page.present ? page.value : requestedPage;
+    const effectivePageSize = pageSize.present ? pageSize.value : requestedPageSize;
+    if (
+        !Number.isInteger(effectivePage)
+        || effectivePage < 1
+        || !Number.isInteger(effectivePageSize)
+        || effectivePageSize < 1
+        || itemCount > effectivePageSize
+        || (!pageTotal.present && !count.present)
+    ) {
+        return null;
+    }
+    const effectivePageTotal = pageTotal.present
+        ? pageTotal.value
+        : Math.max(1, Math.ceil(count.value / effectivePageSize));
+    if (!Number.isInteger(effectivePageTotal) || effectivePageTotal < 1 || effectivePage > effectivePageTotal) {
+        return null;
+    }
+    if (count.present) {
+        const calculatedPageTotal = Math.max(1, Math.ceil(count.value / effectivePageSize));
+        const minimumReturned = ((effectivePage - 1) * effectivePageSize) + itemCount;
+        if (calculatedPageTotal !== effectivePageTotal || minimumReturned > count.value) {
+            return null;
+        }
+    }
+    return {
+        page: effectivePage,
+        pageTotal: effectivePageTotal,
+        count: count.present ? count.value : itemCount,
+        pageSize: effectivePageSize,
+    };
+}
+
+function localInvalidResponseError(message) {
+    return Object.freeze({
+        kind: "invalid_response",
+        status: null,
+        retryable: false,
+        message,
+        requestId: null,
+        retryAfterMs: null,
+        outcomeUnknown: false,
+        diagnostic: Object.freeze({}),
+    });
 }
 
 module.exports = { PaginatedFetch };

--- a/util/registryEndpoints.js
+++ b/util/registryEndpoints.js
@@ -4,8 +4,17 @@ const {
   sanitizePackageNameInput,
 } = require("./packageNameNormalizer");
 
-const CLOUDSMITH_HOST_SUFFIX = ".cloudsmith.io";
 const MAX_REGISTRY_VALUE_LENGTH = 4096;
+const TRUSTED_REGISTRY_HOSTS = new Set([
+  "cargo.cloudsmith.io",
+  "composer.cloudsmith.io",
+  "dart.cloudsmith.io",
+  "dl.cloudsmith.io",
+  "docker.cloudsmith.io",
+  "golang.cloudsmith.io",
+  "npm.cloudsmith.io",
+  "nuget.cloudsmith.io",
+]);
 
 const UNSUPPORTED_PULL_FORMATS = new Set([
   "alpine",
@@ -38,33 +47,49 @@ function isPullUnsupportedFormat(format) {
 }
 
 function encodePathSegment(value) {
-  const normalized = String(value == null ? "" : value)
-    .replace(/\0/g, "")
-    .trim();
+  const raw = String(value == null ? "" : value);
+  const normalized = raw.trim();
 
-  if (!normalized || normalized.length > MAX_REGISTRY_VALUE_LENGTH) {
+  if (
+    !normalized
+    || normalized !== raw
+    || normalized.length > MAX_REGISTRY_VALUE_LENGTH
+    || /[\u0000-\u001f\u007f\\/?#]/.test(normalized)
+  ) {
     return "";
   }
 
-  if (normalized === ".") {
-    return "%2E";
+  let decoded = normalized;
+  for (let depth = 0; depth < 3; depth += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return "";
+    }
+    if (next === decoded) {
+      break;
+    }
+    decoded = next;
   }
-
-  if (normalized === "..") {
-    return "%2E%2E";
+  if (decoded === "." || decoded === ".." || /[\u0000-\u001f\u007f\\/?#]/.test(decoded)) {
+    return "";
   }
 
   return encodeURIComponent(normalized);
 }
 
 function encodePath(value) {
-  return String(value == null ? "" : value)
-    .replace(/\0/g, "")
-    .trim()
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => encodePathSegment(segment))
-    .join("/");
+  const raw = String(value == null ? "" : value);
+  if (!raw || raw !== raw.trim() || /[\\?#\u0000-\u001f\u007f]/.test(raw)) {
+    return "";
+  }
+  const segments = raw.split("/");
+  if (segments.some(segment => !segment)) {
+    return "";
+  }
+  const encoded = segments.map(encodePathSegment);
+  return encoded.every(Boolean) ? encoded.join("/") : "";
 }
 
 function normalizePythonName(name) {
@@ -72,17 +97,23 @@ function normalizePythonName(name) {
 }
 
 function encodeGoModulePath(modulePath) {
-  return [...String(modulePath || "")]
-    .map((character) => {
-      if (character === "!") {
-        return "!!";
-      }
-      if (character >= "A" && character <= "Z") {
-        return `!${character.toLowerCase()}`;
-      }
-      return character;
-    })
-    .join("");
+  const raw = String(modulePath || "");
+  if (!raw || raw !== raw.trim() || /[\\?#\u0000-\u001f\u007f]/.test(raw)) {
+    return "";
+  }
+  const segments = raw.split("/");
+  if (segments.some(segment => !encodePathSegment(segment))) {
+    return "";
+  }
+  return segments.map(segment => encodePathSegment(
+    [...segment]
+      .map((character) => {
+        if (character === "!") return "!!";
+        if (character >= "A" && character <= "Z") return `!${character.toLowerCase()}`;
+        return character;
+      })
+      .join("")
+  )).join("/");
 }
 
 function cargoIndexPath(crateName) {
@@ -159,20 +190,17 @@ function buildMavenCoordinates(dependency) {
     return null;
   }
 
-  const groupPath = groupId
-    .split(".")
-    .filter(Boolean)
-    .map((segment) => encodePathSegment(segment))
-    .join("/");
-
-  if (!groupPath) {
+  const groupSegments = groupId.split(".").map(segment => encodePathSegment(segment));
+  const encodedArtifactId = encodePathSegment(artifactId);
+  const encodedVersion = encodePathSegment(version);
+  if (!groupSegments.every(Boolean) || !encodedArtifactId || !encodedVersion) {
     return null;
   }
 
   return {
-    groupPath,
-    artifactId: encodePathSegment(artifactId),
-    version: encodePathSegment(version),
+    groupPath: groupSegments.join("/"),
+    artifactId: encodedArtifactId,
+    version: encodedVersion,
   };
 }
 
@@ -198,8 +226,9 @@ function buildComposerCoordinates(name) {
 }
 
 function buildSwiftCoordinates(name) {
-  const parts = sanitizePackageNameInput(name).split("/").filter(Boolean);
-  if (parts.length < 2) {
+  const rawName = sanitizePackageNameInput(name);
+  const parts = rawName.split("/");
+  if (parts.length < 2 || parts.some(part => !encodePathSegment(part))) {
     return null;
   }
 
@@ -209,7 +238,7 @@ function buildSwiftCoordinates(name) {
   };
 }
 
-function buildRegistryTriggerPlan(workspace, repo, dependency) {
+function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
   const format = formatForDependency(dependency);
   if (!format || isPullUnsupportedFormat(format)) {
     return null;
@@ -218,6 +247,9 @@ function buildRegistryTriggerPlan(workspace, repo, dependency) {
   const safeWorkspace = encodePathSegment(workspace);
   const safeRepo = encodePathSegment(repo);
   const version = encodePathSegment(dependency && dependency.version);
+  if (!safeWorkspace || !safeRepo) {
+    return null;
+  }
 
   switch (format) {
     case "maven": {
@@ -423,15 +455,68 @@ function buildRegistryTriggerPlan(workspace, repo, dependency) {
   }
 }
 
+function buildRegistryTriggerPlan(workspace, repo, dependency) {
+  const safeWorkspace = encodePathSegment(workspace);
+  const safeRepo = encodePathSegment(repo);
+  const rawName = String(dependency && dependency.name || "");
+  const rawVersion = String(dependency && dependency.version || "");
+  if (
+    !safeWorkspace
+    || !safeRepo
+    || !rawName
+    || /[\u0000-\u001f\u007f\\?#]/.test(rawName)
+    || /[\u0000-\u001f\u007f\\/?#]/.test(rawVersion)
+    || rawName.split("/").some(segment => segment === "." || segment === ".." || segment === "")
+  ) {
+    return null;
+  }
+  const plan = buildRegistryTriggerPlanUnchecked(workspace, repo, dependency);
+  if (!plan || !plan.request || typeof plan.request.url !== "string") {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(plan.request.url);
+  } catch {
+    return null;
+  }
+  if (!isTrustedRegistryUrl(parsed.toString()) || parsed.search || parsed.hash) {
+    return null;
+  }
+  const expectedPrefix = parsed.hostname === "docker.cloudsmith.io"
+    ? `/v2/${safeWorkspace}/${safeRepo}/`
+    : parsed.hostname === "dl.cloudsmith.io"
+      ? `/basic/${safeWorkspace}/${safeRepo}/`
+      : `/${safeWorkspace}/${safeRepo}/`;
+  if (!parsed.pathname.startsWith(expectedPrefix)) {
+    return null;
+  }
+  const remainingSegments = parsed.pathname.slice(expectedPrefix.length).split("/");
+  if (remainingSegments[remainingSegments.length - 1] === "") {
+    if (plan.strategy !== "python-simple-index") {
+      return null;
+    }
+    remainingSegments.pop();
+  }
+  return remainingSegments.length > 0 && remainingSegments.every(Boolean) ? plan : null;
+}
+
 function isTrustedCloudsmithHost(host) {
   const normalizedHost = String(host || "").trim().toLowerCase();
-  return normalizedHost === "cloudsmith.io" || normalizedHost.endsWith(CLOUDSMITH_HOST_SUFFIX);
+  return TRUSTED_REGISTRY_HOSTS.has(normalizedHost);
 }
 
 function isTrustedRegistryUrl(candidateUrl) {
   try {
     const parsed = new URL(candidateUrl);
-    return parsed.protocol === "https:" && isTrustedCloudsmithHost(parsed.host);
+    return parsed.protocol === "https:"
+      && parsed.origin === `https://${parsed.hostname}`
+      && parsed.port === ""
+      && parsed.username === ""
+      && parsed.password === ""
+      && parsed.hash === ""
+      && isTrustedCloudsmithHost(parsed.hostname);
   } catch {
     return false;
   }
@@ -457,16 +542,51 @@ function resolveAndValidateRegistryUrl(candidate, baseUrl) {
 }
 
 function collectHrefValues(html) {
+  const source = String(html || "");
+  const lower = source.toLowerCase();
   const hrefs = [];
-  const pattern = /<a\b[^>]*\bhref\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi;
-  let match = pattern.exec(String(html || ""));
+  const maximumTagLength = 4096;
+  const maximumCandidates = 500;
+  let cursor = 0;
 
-  while (match) {
-    hrefs.push(match[1] || match[2] || match[3] || "");
-    match = pattern.exec(String(html || ""));
+  while (cursor < source.length && hrefs.length < maximumCandidates) {
+    const anchorStart = lower.indexOf("<a", cursor);
+    if (anchorStart < 0) {
+      break;
+    }
+    const boundary = lower[anchorStart + 2];
+    if (boundary && !/[\s/>]/.test(boundary)) {
+      cursor = anchorStart + 2;
+      continue;
+    }
+
+    let tagEnd = anchorStart + 2;
+    const tagLimit = Math.min(source.length, anchorStart + maximumTagLength + 1);
+    while (tagEnd < tagLimit && source[tagEnd] !== "<" && source[tagEnd] !== ">") {
+      tagEnd += 1;
+    }
+    if (tagEnd >= source.length) {
+      break;
+    }
+    if (source[tagEnd] === "<") {
+      cursor = tagEnd;
+      continue;
+    }
+    if (tagEnd >= tagLimit) {
+      cursor = tagEnd;
+      continue;
+    }
+
+    const tag = source.slice(anchorStart, tagEnd + 1);
+    const match = /\bhref\s*=\s*(?:"([^"<>]{1,4096})"|'([^'<>]{1,4096})'|([^\s<>]{1,4096}))/i.exec(tag);
+    const href = match && (match[1] || match[2] || match[3]);
+    if (href) {
+      hrefs.push(href);
+    }
+    cursor = tagEnd + 1;
   }
 
-  return hrefs.filter(Boolean);
+  return hrefs;
 }
 
 function scorePythonArtifact(url, version) {

--- a/util/remediationHelper.js
+++ b/util/remediationHelper.js
@@ -1,6 +1,7 @@
 // Remediation helper - finds safe alternative versions of a package
 
 const { SearchQueryBuilder } = require('./searchQueryBuilder');
+const { apiEndpoint } = require('./apiEndpoint');
 
 class RemediationHelper {
   constructor(cloudsmithAPI) {
@@ -20,17 +21,24 @@ class RemediationHelper {
   async findSafeVersions(workspace, repo, packageName, format) {
     const qb = new SearchQueryBuilder();
     const query = qb.name(packageName).format(format).raw('NOT status:quarantined').raw('deny_policy_violated:false').build();
-    const endpoint = `packages/${workspace}/${repo}/?query=${encodeURIComponent(query)}&sort=-version&page_size=10`;
-
-    const result = await this.api.get(endpoint);
-
-    if (typeof result === "string") {
-      return { success: false, versions: [], error: result };
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["packages", workspace, repo], {
+        query: { query, sort: "-version", page_size: 10 },
+      });
+    } catch (error) {
+      return { success: false, versions: [], error };
     }
-    if (!result || !Array.isArray(result)) {
-      return { success: false, versions: [], error: "Unexpected API response" };
-    }
-    return { success: true, versions: result, error: null };
+
+    const result = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isSafePackageArray,
+      retry: "safe-read",
+    });
+
+    return result.ok
+      ? { success: true, versions: result.data, error: null }
+      : { success: false, versions: [], error: result.error };
   }
 
   /**
@@ -45,18 +53,51 @@ class RemediationHelper {
   async findSafeVersionsAcrossRepos(workspace, packageName, format) {
     const qb = new SearchQueryBuilder();
     const query = qb.name(packageName).format(format).raw('NOT status:quarantined').raw('deny_policy_violated:false').build();
-    const endpoint = `packages/${workspace}/?query=${encodeURIComponent(query)}&sort=-version&page_size=10`;
-
-    const result = await this.api.get(endpoint);
-
-    if (typeof result === "string") {
-      return { success: false, versions: [], error: result };
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["packages", workspace], {
+        query: { query, sort: "-version", page_size: 10 },
+      });
+    } catch (error) {
+      return { success: false, versions: [], error };
     }
-    if (!result || !Array.isArray(result)) {
-      return { success: false, versions: [], error: "Unexpected API response" };
-    }
-    return { success: true, versions: result, error: null };
+
+    const result = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isSafePackageArray,
+      retry: "safe-read",
+    });
+    return result.ok
+      ? { success: true, versions: result.data, error: null }
+      : { success: false, versions: [], error: result.error };
   }
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(item => (
+    Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  ));
+}
+
+function unwrapIdentifier(value) {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
+    ? value.value
+    : null;
+}
+
+function isSafePackageArray(value) {
+  return isRecordArray(value) && value.every(pkg => (
+    typeof pkg.name === "string" && pkg.name.length > 0
+    && typeof pkg.format === "string" && pkg.format.length > 0
+    && (typeof pkg.version === "string" || typeof pkg.version === "number")
+    && String(pkg.version).length > 0
+    && typeof pkg.repository === "string" && pkg.repository.length > 0
+    && typeof pkg.namespace === "string" && pkg.namespace.length > 0
+    && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+  ));
 }
 
 module.exports = { RemediationHelper };

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -1,6 +1,6 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const { CloudsmithAPI } = require("./cloudsmithAPI");
-const { CredentialManager } = require("./credentialManager");
+const { apiEndpoint } = require("./apiEndpoint");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
 const {
   getSupportedUpstreamFormats,
@@ -65,6 +65,7 @@ function getCachedUpstreamResponse(globalState, cacheKey, workspace, repo) {
   const isValidCacheEntry = isCacheObjectRecord(cached)
     && Number.isFinite(cached.timestamp)
     && Array.isArray(cached.upstreams)
+    && cached.upstreams.every(isUpstreamRecord)
     && Number.isFinite(cached.active)
     && Number.isFinite(cached.total)
     && Array.isArray(cached.failedFormats)
@@ -104,50 +105,12 @@ async function persistUpstreamResponse(globalState, cacheKey, workspace, repo, r
   }
 }
 
-function getUpstreamErrorStatusCode(message) {
-  const normalized = typeof message === "string" ? message.toLowerCase() : "";
-  const statusMatch = normalized.match(/response status:\s*(\d{3})/);
-  if (!statusMatch) {
-    return null;
-  }
-
-  return Number(statusMatch[1]);
+function isBenignUpstreamFormatError(error) {
+  return Boolean(error) && BENIGN_UPSTREAM_FORMAT_STATUS_CODES.has(error.status);
 }
 
-function isBenignUpstreamFormatError(message) {
-  const normalized = typeof message === "string" ? message.toLowerCase() : "";
-  if (!normalized) {
-    return false;
-  }
-
-  const statusCode = getUpstreamErrorStatusCode(normalized);
-  if (statusCode !== null) {
-    return BENIGN_UPSTREAM_FORMAT_STATUS_CODES.has(statusCode);
-  }
-
-  const benignKeywords = [
-    "not found",
-    "unsupported",
-    "not applicable",
-    "unknown format",
-    "no upstream",
-    "does not exist",
-  ];
-
-  if (benignKeywords.some((keyword) => normalized.includes(keyword))) {
-    return true;
-  }
-
-  return false;
-}
-
-function isWarningWorthyUpstreamFormatError(message) {
-  const normalized = typeof message === "string" ? message.toLowerCase() : "";
-  if (!normalized) {
-    return true;
-  }
-
-  return !isBenignUpstreamFormatError(normalized);
+function isWarningWorthyUpstreamFormatError(error) {
+  return !isBenignUpstreamFormatError(error);
 }
 
 function isAbortError(error) {
@@ -167,23 +130,6 @@ function getActiveUpstreamsFromRepositoryState(state, format) {
   return upstreams.filter((upstream) => upstream && upstream.is_active !== false);
 }
 
-function getUpstreamRequestOptions(apiKey, signal) {
-  const headers = {
-    accept: "application/json",
-    "content-type": "application/json",
-  };
-
-  if (apiKey) {
-    headers["X-Api-Key"] = apiKey;
-  }
-
-  return {
-    method: "GET",
-    headers,
-    signal,
-  };
-}
-
 function sortUpstreams(left, right) {
   const leftName = typeof left.name === "string" ? left.name : "";
   const rightName = typeof right.name === "string" ? right.name : "";
@@ -201,42 +147,43 @@ function sortUpstreams(left, right) {
   return leftFormat.localeCompare(rightFormat, undefined, { sensitivity: "base" });
 }
 
-async function fetchFormatUpstreams(api, workspace, repo, format, apiKey, signal) {
+async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) {
+  const { signal, cancellationToken } = options;
   try {
     if (signal && signal.aborted) {
       return { format, status: "aborted", upstreams: [] };
     }
 
-    const result = await api.makeRequest(
-      `repos/${workspace}/${repo}/upstream/${format}/`,
-      getUpstreamRequestOptions(apiKey, signal)
+    const result = await api.get(
+      apiEndpoint(["repos", workspace, repo, "upstream", format]),
+      {
+        responseType: "array",
+        validate: isUpstreamArray,
+        retry: "never",
+        signal,
+        cancellationToken,
+      }
     );
 
     if (signal && signal.aborted) {
       return { format, status: "aborted", upstreams: [] };
     }
 
-    if (typeof result === "string") {
-      if (isWarningWorthyUpstreamFormatError(result)) {
-        return { format, status: "failed", error: result, upstreams: [] };
+    if (!result.ok) {
+      if (result.error.kind === "cancelled") {
+        return { format, status: "aborted", upstreams: [] };
+      }
+      if (isWarningWorthyUpstreamFormatError(result.error)) {
+        return { format, status: "failed", error: result.error, upstreams: [] };
       }
 
       return { format, status: "loaded", upstreams: [] };
     }
 
-    if (!Array.isArray(result)) {
-      return {
-        format,
-        status: "failed",
-        error: `Unexpected upstream response for format "${format}".`,
-        upstreams: [],
-      };
-    }
-
     return {
       format,
       status: "loaded",
-      upstreams: result.map((upstream) => ({
+      upstreams: result.data.map((upstream) => ({
         ...upstream,
         _format: format,
         format,
@@ -247,12 +194,7 @@ async function fetchFormatUpstreams(api, workspace, repo, format, apiKey, signal
       return { format, status: "aborted", upstreams: [] };
     }
 
-    const message = error && error.message ? error.message : String(error);
-    if (!isWarningWorthyUpstreamFormatError(message)) {
-      return { format, status: "loaded", upstreams: [] };
-    }
-
-    return { format, status: "failed", error: message, upstreams: [] };
+    return { format, status: "failed", error, upstreams: [] };
   }
 }
 
@@ -273,17 +215,26 @@ class UpstreamChecker {
    */
   async existsLocally(workspace, repo, name, format) {
     const qb = new SearchQueryBuilder();
-    const query = encodeURIComponent(qb.name(name).format(format).build());
-    const result = await this.api.get(
-      `packages/${workspace}/${repo}/?query=${query}&page_size=1`
-    );
-    if (typeof result === "string") {
-      return { data: null, error: result };
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["packages", workspace, repo], {
+        query: { query: qb.name(name).format(format).build(), page_size: 1 },
+      });
+    } catch (error) {
+      return { data: null, error };
     }
-    if (!Array.isArray(result) || result.length === 0) {
+    const result = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isPackageArray,
+      retry: "safe-read",
+    });
+    if (!result.ok) {
+      return { data: null, error: result.error };
+    }
+    if (result.data.length === 0) {
       return { data: null, error: null };
     }
-    return { data: result[0], error: null };
+    return { data: result.data[0], error: null };
   }
 
   /**
@@ -295,18 +246,27 @@ class UpstreamChecker {
    * @returns {Array}             Array of upstream config objects.
    */
   async getUpstreamsForFormat(workspace, repo, format) {
-    const result = await this.api.get(`repos/${workspace}/${repo}/upstream/${format}/`);
-    if (typeof result === "string") {
-      return { data: [], error: result };
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["repos", workspace, repo, "upstream", format]);
+    } catch (error) {
+      return { data: [], error };
     }
-    if (!Array.isArray(result)) {
-      return { data: [], error: null };
+    const result = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isUpstreamArray,
+      retry: "safe-read",
+    });
+    if (!result.ok) {
+      return isBenignUpstreamFormatError(result.error)
+        ? { data: [], error: null }
+        : { data: [], error: result.error };
     }
-    return { data: result, error: null };
+    return { data: result.data, error: null };
   }
 
   async getUpstreamDataForFormats(workspace, repo, formats, options = {}) {
-    const { signal } = options;
+    const { signal, cancellationToken } = options;
     const requestedFormats = getSupportedUpstreamFormats(formats);
 
     if (signal && signal.aborted) {
@@ -333,14 +293,6 @@ class UpstreamChecker {
       return cached;
     }
 
-    let apiKey = null;
-    try {
-      const credentialManager = new CredentialManager(this.context);
-      apiKey = await credentialManager.getApiKey();
-    } catch {
-      apiKey = null;
-    }
-
     if (signal && signal.aborted) {
       return null;
     }
@@ -356,7 +308,10 @@ class UpstreamChecker {
 
       const batch = requestedFormats.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
       const batchResults = await Promise.all(
-        batch.map((format) => fetchFormatUpstreams(this.api, workspace, repo, format, apiKey, signal))
+        batch.map((format) => fetchFormatUpstreams(this.api, workspace, repo, format, {
+          signal,
+          cancellationToken,
+        }))
       );
 
       if (signal && signal.aborted) {
@@ -439,9 +394,19 @@ class UpstreamChecker {
     }
 
     const signal = options && options.signal ? options.signal : null;
-    const fetchState = await this._fetchRepositoryUpstreamState(workspace, repo, signal);
+    const cancellationToken = options && options.cancellationToken
+      ? options.cancellationToken
+      : null;
+    const fetchState = await this._fetchRepositoryUpstreamState(workspace, repo, {
+      signal,
+      cancellationToken,
+    });
 
-    if (!signal?.aborted && fetchState.failedFormats.length === 0) {
+    if (
+      !signal?.aborted
+      && !cancellationToken?.isCancellationRequested
+      && fetchState.failedFormats.length === 0
+    ) {
       await this._cacheRepositoryUpstreamState(workspace, repo, fetchState);
     }
 
@@ -548,7 +513,8 @@ class UpstreamChecker {
     const cached = globalState.get(this._getRepositoryUpstreamCacheKey(workspace, repo));
     const isValidCacheEntry = this._isCacheObjectRecord(cached)
       && Number.isFinite(cached.timestamp)
-      && this._isCacheObjectRecord(cached.groupedUpstreams);
+      && this._isCacheObjectRecord(cached.groupedUpstreams)
+      && Object.values(cached.groupedUpstreams).every(isUpstreamArray);
 
     if (!isValidCacheEntry) {
       if (cached !== undefined) {
@@ -594,33 +560,18 @@ class UpstreamChecker {
     }
   }
 
-  async _fetchRepositoryUpstreamState(workspace, repo, signal) {
+  async _fetchRepositoryUpstreamState(workspace, repo, options = {}) {
+    const { signal, cancellationToken } = options;
     const groupedUpstreams = new Map();
     const failedFormats = [];
     let successfulFormats = 0;
-    let apiKey = null;
-
-    try {
-      const credentialManager = new CredentialManager(this.context);
-      apiKey = await credentialManager.getApiKey();
-    } catch (error) {
-      if (this._isAbortError(error) || signal?.aborted) {
-        return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
-      }
-
-      return this._buildRepositoryUpstreamState(
-        groupedUpstreams,
-        [...SUPPORTED_UPSTREAM_FORMATS],
-        successfulFormats
-      );
-    }
 
     for (
       let index = 0;
       index < SUPPORTED_UPSTREAM_FORMATS.length;
       index += UPSTREAM_FETCH_BATCH_SIZE
     ) {
-      if (signal?.aborted) {
+      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
         return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
       }
 
@@ -631,11 +582,11 @@ class UpstreamChecker {
 
       const batchResults = await Promise.all(
         batch.map((format) =>
-          this._fetchFormatUpstreams(workspace, repo, format, apiKey, signal)
+          this._fetchFormatUpstreams(workspace, repo, format, options)
         )
       );
 
-      if (signal?.aborted) {
+      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
         return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
       }
 
@@ -662,45 +613,46 @@ class UpstreamChecker {
     return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
   }
 
-  async _fetchFormatUpstreams(workspace, repo, format, apiKey, signal) {
+  async _fetchFormatUpstreams(workspace, repo, format, options = {}) {
+    const { signal, cancellationToken } = options;
     try {
-      if (signal?.aborted) {
+      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
         return { format, status: "aborted", upstreams: [] };
       }
 
-      const result = await this.api.makeRequest(
-        `repos/${workspace}/${repo}/upstream/${format}/`,
-        this._getRequestOptions(apiKey, signal)
+      const result = await this.api.get(
+        apiEndpoint(["repos", workspace, repo, "upstream", format]),
+        {
+          responseType: "array",
+          validate: isUpstreamArray,
+          retry: "never",
+          signal,
+          cancellationToken,
+        }
       );
 
-      if (signal?.aborted) {
+      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
         return { format, status: "aborted", upstreams: [] };
       }
 
-      if (typeof result === "string") {
-        if (this._isWarningWorthyFormatError(result)) {
+      if (!result.ok) {
+        if (result.error.kind === "cancelled") {
+          return { format, status: "aborted", upstreams: [] };
+        }
+        if (this._isWarningWorthyFormatError(result.error)) {
           return { format, status: "failed", upstreams: [] };
         }
         return { format, status: "loaded", upstreams: [] };
       }
 
-      if (!Array.isArray(result)) {
-        return { format, status: "failed", upstreams: [] };
-      }
-
       return {
         format,
         status: "loaded",
-        upstreams: result.map((upstream) => ({ ...upstream, format })),
+        upstreams: result.data.map((upstream) => ({ ...upstream, format })),
       };
     } catch (error) {
       if (this._isAbortError(error) || signal?.aborted) {
         return { format, status: "aborted", upstreams: [] };
-      }
-
-      const message = error && error.message ? error.message : "";
-      if (!this._isWarningWorthyFormatError(message)) {
-        return { format, status: "loaded", upstreams: [] };
       }
 
       return { format, status: "failed", upstreams: [] };
@@ -764,17 +716,41 @@ class UpstreamChecker {
     return grouped;
   }
 
-  _getRequestOptions(apiKey, signal) {
-    return getUpstreamRequestOptions(apiKey, signal);
-  }
-
   _isAbortError(error) {
     return isAbortError(error);
   }
 
-  _isWarningWorthyFormatError(message) {
-    return isWarningWorthyUpstreamFormatError(message);
+  _isWarningWorthyFormatError(error) {
+    return isWarningWorthyUpstreamFormatError(error);
   }
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(item => (
+    Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  ));
+}
+
+function isPackageArray(value) {
+  return isRecordArray(value) && value.every(item => (
+    typeof item.name === "string"
+    && item.name.length > 0
+    && typeof item.format === "string"
+    && item.format.length > 0
+  ));
+}
+
+function isUpstreamRecord(value) {
+  return Boolean(value)
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && typeof value.name === "string"
+    && value.name.trim().length > 0
+    && (value.is_active === undefined || typeof value.is_active === "boolean");
+}
+
+function isUpstreamArray(value) {
+  return Array.isArray(value) && value.every(isUpstreamRecord);
 }
 
 async function getAllUpstreamData(context, workspace, repo, options = {}) {

--- a/util/upstreamGapAnalyzer.js
+++ b/util/upstreamGapAnalyzer.js
@@ -151,7 +151,12 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
       return;
     }
 
-    const state = await upstreamChecker.getRepositoryUpstreamState(workspace, repo);
+    const state = await upstreamChecker.getRepositoryUpstreamState(workspace, repo, {
+      cancellationToken,
+    });
+    if (cancellationToken && cancellationToken.isCancellationRequested) {
+      return;
+    }
     repoUpstreamStates.set(repo, {
       repo,
       groupedUpstreams: state && state.groupedUpstreams instanceof Map

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -1,7 +1,9 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
+const { apiEndpoint } = require("./apiEndpoint");
 const { CredentialManager } = require("./credentialManager");
+const { formatApiError } = require("./errorFormatter");
 const { PaginatedFetch } = require("./paginatedFetch");
 const {
   buildRegistryTriggerPlan,
@@ -21,7 +23,14 @@ const MAX_CONCURRENT_PULLS = 5;
 const INITIAL_AUTH_PROBE_CONCURRENCY = 3;
 const MAX_REGISTRY_REDIRECTS = 5;
 const REQUEST_TIMEOUT_MS = 30 * 1000;
+const MAX_REGISTRY_METADATA_BYTES = 1024 * 1024;
 const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
+const SAFE_REGISTRY_ERROR_MESSAGES = new Set([
+  "Refused to send Cloudsmith credentials to an untrusted registry host.",
+  "Registry metadata response exceeded the size limit.",
+  "Registry redirect target was rejected.",
+  "Registry request exceeded the redirect limit.",
+]);
 
 const PULL_STATUS = Object.freeze({
   PENDING: "pending",
@@ -47,6 +56,8 @@ class UpstreamPullService {
     this._api = options.api || new CloudsmithAPI(context);
     this._credentialManager = options.credentialManager || new CredentialManager(context);
     this._fetchImpl = options.fetchImpl || fetch;
+    this._setTimeout = options.setTimeout || setTimeout;
+    this._clearTimeout = options.clearTimeout || clearTimeout;
     this._fetchRepositories = options.fetchRepositories || this._fetchWorkspaceRepositories.bind(this);
     this._showQuickPick = options.showQuickPick || vscode.window.showQuickPick.bind(vscode.window);
     this._showErrorMessage = options.showErrorMessage || vscode.window.showErrorMessage.bind(vscode.window);
@@ -490,14 +501,20 @@ class UpstreamPullService {
 
   async _fetchWorkspaceRepositories(workspace) {
     const paginatedFetch = new PaginatedFetch(this._api);
-    const endpoint = `repos/${workspace}/?sort=name`;
+    const endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
     const repositories = [];
     let page = 1;
 
     while (true) {
-      const result = await paginatedFetch.fetchPage(endpoint, page, WORKSPACE_REPOSITORY_PAGE_SIZE);
+      const result = await paginatedFetch.fetchPage(
+        endpoint,
+        page,
+        WORKSPACE_REPOSITORY_PAGE_SIZE,
+        null,
+        { validate: isRepositoryArray, retry: "never" }
+      );
       if (result.error) {
-        throw new Error(`Could not fetch workspace repositories. ${result.error}`);
+        throw new Error(`Could not fetch workspace repositories. ${formatApiError(result.error)}`);
       }
 
       repositories.push(...(Array.isArray(result.data) ? result.data : []));
@@ -532,7 +549,12 @@ class UpstreamPullService {
       };
     }
 
-    const metadataAttempt = await this._requestRegistry(plan.request, apiKey, token);
+    const metadataAttempt = await this._requestRegistry(
+      plan.request,
+      apiKey,
+      token,
+      { captureBody: plan.strategy !== "direct" }
+    );
     if (metadataAttempt.canceled) {
       return metadataAttempt;
     }
@@ -584,7 +606,8 @@ class UpstreamPullService {
         headers: {},
       },
       apiKey,
-      token
+      token,
+      { captureBody: false }
     );
 
     if (artifactAttempt.canceled) {
@@ -594,19 +617,31 @@ class UpstreamPullService {
     return mapRegistryAttempt(dependency, artifactAttempt, artifactUrl, format);
   }
 
-  async _requestRegistry(request, apiKey, token) {
+  async _requestRegistry(request, apiKey, token, options = {}) {
     const controller = new AbortController();
-    let didTimeout = false;
-    const timeoutHandle = setTimeout(() => {
-      didTimeout = true;
+    let abortCause = null;
+    const abort = (cause) => {
+      if (abortCause) {
+        return;
+      }
+      abortCause = cause;
       controller.abort();
+    };
+    const timeoutHandle = this._setTimeout(() => {
+      abort("timeout");
     }, REQUEST_TIMEOUT_MS);
 
     const cancellationDisposable = token && typeof token.onCancellationRequested === "function"
-      ? token.onCancellationRequested(() => controller.abort())
+      ? token.onCancellationRequested(() => abort("cancelled"))
       : null;
+    if (token && token.isCancellationRequested) {
+      abort("cancelled");
+    }
 
     try {
+      if (abortCause === "cancelled") {
+        return { canceled: true };
+      }
       const response = await this._fetchRegistryResponse(
         request,
         apiKey,
@@ -614,25 +649,36 @@ class UpstreamPullService {
         0
       );
 
+      const body = options.captureBody === false
+        ? await discardRegistryBody(response, controller.signal)
+        : await readRegistryBody(response, MAX_REGISTRY_METADATA_BYTES, controller.signal);
+
+      if (abortCause === "cancelled" || (token && token.isCancellationRequested)) {
+        return { canceled: true };
+      }
+      if (abortCause === "timeout" || controller.signal.aborted) {
+        throw new Error("Registry request was aborted.");
+      }
+
       return {
         statusCode: response.status,
-        body: await response.text(),
+        body,
       };
     } catch (error) {
-      if (token && token.isCancellationRequested) {
+      if (abortCause === "cancelled" || (token && token.isCancellationRequested)) {
         return { canceled: true };
       }
 
       return {
         statusCode: 0,
         body: "",
-        errorMessage: didTimeout
+        errorMessage: abortCause === "timeout"
           ? "Registry request timed out."
           : buildRegistryErrorMessage(request.url, error),
-        networkError: isNetworkError(error) || didTimeout,
+        networkError: isNetworkError(error) || abortCause === "timeout",
       };
     } finally {
-      clearTimeout(timeoutHandle);
+      this._clearTimeout(timeoutHandle);
       if (cancellationDisposable && typeof cancellationDisposable.dispose === "function") {
         cancellationDisposable.dispose();
       }
@@ -644,21 +690,29 @@ class UpstreamPullService {
       throw new Error("Refused to send Cloudsmith credentials to an untrusted registry host.");
     }
 
-    const response = await this._fetchImpl(request.url, {
+    const fetchResult = await this._awaitRegistryAbortable(this._fetchImpl(request.url, {
       method: request.method || "GET",
       headers: {
         Authorization: buildBasicAuthHeader(apiKey),
-        ...(request.headers || {}),
+        ...buildRegistryRequestHeaders(request.headers),
       },
       redirect: "manual",
       signal,
-    });
+    }), signal, cancelRegistryBody);
+    if (fetchResult.aborted) {
+      throw new Error("Registry request was aborted.");
+    }
+    if (!fetchResult.ok) {
+      throw fetchResult.error;
+    }
+    const response = fetchResult.value;
 
     if (!isRedirectStatus(response.status)) {
       return response;
     }
 
     if (redirectCount >= MAX_REGISTRY_REDIRECTS) {
+      await cancelRegistryBody(response);
       throw new Error("Registry request exceeded the redirect limit.");
     }
 
@@ -666,9 +720,14 @@ class UpstreamPullService {
       ? response.headers.get("location")
       : "";
     const redirectUrl = resolveAndValidateRegistryUrl(location, request.url);
-    if (!redirectUrl || !isTrustedRegistryUrl(redirectUrl)) {
+    const currentUrl = new URL(request.url);
+    const nextUrl = redirectUrl ? new URL(redirectUrl) : null;
+    if (!nextUrl || nextUrl.hostname !== currentUrl.hostname) {
+      await cancelRegistryBody(response);
       throw new Error("Registry redirect target was rejected.");
     }
+
+    await cancelRegistryBody(response);
 
     return this._fetchRegistryResponse(
       {
@@ -680,6 +739,228 @@ class UpstreamPullService {
       redirectCount + 1
     );
   }
+
+  _awaitRegistryAbortable(promise, signal, onLateValue = null) {
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (result) => {
+        if (settled) return false;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(result);
+        return true;
+      };
+      const onAbort = () => finish({ aborted: true });
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) {
+        onAbort();
+      }
+      Promise.resolve(promise).then(
+        (value) => {
+          if (!finish({ ok: true, value }) && typeof onLateValue === "function") {
+            try {
+              Promise.resolve(onLateValue(value)).catch(() => {});
+            } catch {
+              // Late response cleanup is best effort.
+            }
+          }
+        },
+        error => finish({ ok: false, error })
+      );
+      if (signal.aborted) {
+        onAbort();
+      }
+    });
+  }
+}
+
+function isRepositoryArray(value) {
+  return Array.isArray(value) && value.every(repository => (
+    repository
+    && typeof repository === "object"
+    && !Array.isArray(repository)
+    && typeof repository.slug === "string"
+    && repository.slug.length > 0
+    && typeof repository.name === "string"
+    && repository.name.length > 0
+  ));
+}
+
+function buildRegistryRequestHeaders(headers) {
+  if (!headers || typeof headers !== "object") {
+    return {};
+  }
+  const accept = headers.Accept || headers.accept;
+  if (typeof accept !== "string" || accept.length > 1024 || /[\r\n]/.test(accept)) {
+    return {};
+  }
+  return { Accept: accept };
+}
+
+function cancelRegistryBody(response) {
+  if (response && response.body && typeof response.body.cancel === "function") {
+    try {
+      Promise.resolve(response.body.cancel()).catch(() => {});
+    } catch {
+      // The connection may already have been closed by the fetch implementation.
+    }
+  }
+}
+
+async function discardRegistryBody(response, signal) {
+  if (!response || !response.body) {
+    return "";
+  }
+  if (typeof response.body.getReader !== "function") {
+    await cancelRegistryBody(response);
+    throw new Error("Registry response did not provide a readable body stream.");
+  }
+
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      if (signal && signal.aborted) {
+        cancelRegistryReader(reader);
+        throw new Error("Registry response body read was aborted.");
+      }
+      const chunkResult = await readRegistryChunk(reader, signal);
+      if (chunkResult.aborted) {
+        throw new Error("Registry response body read was aborted.");
+      }
+      if (!chunkResult.ok) {
+        throw chunkResult.error;
+      }
+      const chunk = chunkResult.value;
+      if (chunk.done) {
+        break;
+      }
+    }
+    if (signal && signal.aborted) {
+      throw new Error("Registry response body read was aborted.");
+    }
+    return "";
+  } catch (error) {
+    try {
+      cancelRegistryReader(reader);
+    } catch {
+      // The connection may already be closed.
+    }
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The stream may already be detached.
+    }
+  }
+}
+
+async function readRegistryBody(response, byteLimit, signal) {
+  const contentLength = response && response.headers && typeof response.headers.get === "function"
+    ? Number(response.headers.get("content-length"))
+    : NaN;
+  if (Number.isFinite(contentLength) && contentLength > byteLimit) {
+    await cancelRegistryBody(response);
+    throw new Error("Registry metadata response exceeded the size limit.");
+  }
+
+  if (!response || !response.body) {
+    return "";
+  }
+  if (typeof response.body.getReader !== "function") {
+    await cancelRegistryBody(response);
+    throw new Error("Registry metadata response did not provide a readable body stream.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let text = "";
+  let completed = false;
+  try {
+    while (true) {
+      if (signal && signal.aborted) {
+        cancelRegistryReader(reader);
+        throw new Error("Registry metadata response read was aborted.");
+      }
+      const chunkResult = await readRegistryChunk(reader, signal);
+      if (chunkResult.aborted) {
+        throw new Error("Registry metadata response read was aborted.");
+      }
+      if (!chunkResult.ok) {
+        throw chunkResult.error;
+      }
+      const chunk = chunkResult.value;
+      if (chunk.done) {
+        break;
+      }
+      bytesRead += chunk.value.byteLength;
+      if (bytesRead > byteLimit) {
+        cancelRegistryReader(reader);
+        throw new Error("Registry metadata response exceeded the size limit.");
+      }
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+    if (signal && signal.aborted) {
+      throw new Error("Registry metadata response read was aborted.");
+    }
+    text += decoder.decode();
+    completed = true;
+    return text;
+  } catch (error) {
+    if (!completed) {
+      try {
+        cancelRegistryReader(reader);
+      } catch {
+        // The connection may already be closed.
+      }
+    }
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The stream may already be detached.
+    }
+  }
+}
+
+function cancelRegistryReader(reader) {
+  if (!reader || typeof reader.cancel !== "function") {
+    return;
+  }
+  try {
+    Promise.resolve(reader.cancel()).catch(() => {});
+  } catch {
+    // The stream may already be closed or detached.
+  }
+}
+
+function readRegistryChunk(reader, signal) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+    const onAbort = () => {
+      cancelRegistryReader(reader);
+      finish({ aborted: true });
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    Promise.resolve()
+      .then(() => reader.read())
+      .then(value => finish({ ok: true, value }), error => finish({ ok: false, error }));
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
 }
 
 function buildPullExecutionPlan(workspace, repo, dependencies, activeUpstreamFormats) {
@@ -961,9 +1242,11 @@ function buildRegistryErrorMessage(url, error) {
     return "Cannot reach the Cloudsmith registry. Check your network connection.";
   }
 
+  if (error && SAFE_REGISTRY_ERROR_MESSAGES.has(error.message)) {
+    return error.message;
+  }
   const host = safeHost(url);
-  const message = error && error.message ? error.message : "Registry request failed.";
-  return host ? `${message} (${host})` : message;
+  return host ? `Registry request failed (${host}).` : "Registry request failed.";
 }
 
 function isNetworkError(error) {

--- a/util/workspaceRepositoryFetcher.js
+++ b/util/workspaceRepositoryFetcher.js
@@ -1,5 +1,7 @@
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
+const { apiEndpoint } = require("./apiEndpoint");
+const { formatApiError } = require("./errorFormatter");
 const { PaginatedFetch } = require("./paginatedFetch");
 
 const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
@@ -16,10 +18,20 @@ function sortRepositories(repositories) {
   });
 }
 
-async function fetchWorkspaceRepositories(context, workspace) {
+async function fetchWorkspaceRepositories(context, workspace, options = {}) {
   const cloudsmithAPI = new CloudsmithAPI(context);
   const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
-  const endpoint = `repos/${workspace}/?sort=name`;
+  let endpoint;
+  try {
+    endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
+  } catch {
+    return {
+      repositories: [],
+      error: Object.freeze({ kind: "invalid_request", message: "The workspace identifier is invalid." }),
+      warning: null,
+      partial: false,
+    };
+  }
 
   return vscode.window.withProgress(
     {
@@ -39,7 +51,9 @@ async function fetchWorkspaceRepositories(context, workspace) {
         const result = await paginatedFetch.fetchPage(
           endpoint,
           page,
-          WORKSPACE_REPOSITORY_PAGE_SIZE
+          WORKSPACE_REPOSITORY_PAGE_SIZE,
+          null,
+          { ...options, validate: isRepositoryArray }
         );
 
         if (result.error) {
@@ -53,7 +67,7 @@ async function fetchWorkspaceRepositories(context, workspace) {
           }
 
           console.warn(
-            `[WorkspaceRepositories] Failed to load additional repositories for ${workspace} on page ${page}: ${result.error}`
+            `[WorkspaceRepositories] Failed to load an additional repository page: ${formatApiError(result.error)}`
           );
 
           return {
@@ -109,6 +123,18 @@ async function fetchWorkspaceRepositories(context, workspace) {
       };
     }
   );
+}
+
+function isRepositoryArray(value) {
+  return Array.isArray(value) && value.every(repository => (
+    repository
+    && typeof repository === "object"
+    && !Array.isArray(repository)
+    && typeof repository.slug === "string"
+    && repository.slug.length > 0
+    && typeof repository.name === "string"
+    && repository.name.length > 0
+  ));
 }
 
 module.exports = {

--- a/views/cloudsmithProvider.js
+++ b/views/cloudsmithProvider.js
@@ -3,6 +3,7 @@
 
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
 const { ConnectionManager } = require("../util/connectionManager");
 const InfoNode = require("../models/infoNode");
 const { WorkspaceInfoNode } = require("../models/workspaceInfoNode");
@@ -84,14 +85,32 @@ class CloudsmithProvider {
       )];
     }
 
-    workspaces = await cloudsmithAPI.get("namespaces/?sort=slug");
+    const result = await cloudsmithAPI.get("namespaces/?sort=slug", {
+      responseType: "array",
+      validate: value => value.every(workspace => (
+        workspace
+        && typeof workspace === "object"
+        && !Array.isArray(workspace)
+        && typeof workspace.slug === "string"
+        && workspace.slug.length > 0
+      )),
+      retry: "safe-read",
+    });
+    workspaces = result.ok
+      ? result.data.map(workspace => ({
+        ...workspace,
+        name: typeof workspace.name === "string" && workspace.name.length > 0
+          ? workspace.name
+          : workspace.slug,
+      }))
+      : null;
 
     if (this._treeView) {
       this._treeView.message = undefined;
     }
 
     const WorkspaceNodes = [];
-    if (typeof workspaces === 'string' || !workspaces || !Array.isArray(workspaces)) {
+    if (!workspaces) {
       await vscode.commands.executeCommand("setContext", "cloudsmith.hasMultipleWorkspaces", false);
       return [new InfoNode(
         "Could not load workspaces",
@@ -179,9 +198,12 @@ class CloudsmithProvider {
     let quotaData = null;
 
     try {
-      const quotaResult = await cloudsmithAPI.get(`quota/${workspaceSlug}/`);
-      if (typeof quotaResult !== "string" && quotaResult && quotaResult.usage) {
-        quotaData = quotaResult;
+      const quotaResult = await cloudsmithAPI.get(apiEndpoint(["quota", workspaceSlug]), {
+        responseType: "object",
+        retry: "safe-read",
+      });
+      if (quotaResult.ok && quotaResult.data.usage && typeof quotaResult.data.usage === "object") {
+        quotaData = quotaResult.data;
       }
     } catch {
       // Quota access is optional for the workspace summary row.

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint, appendApiQuery } = require("../util/apiEndpoint");
 const {
   ADAPTER_RESULT_STATUSES,
   createDefaultDependencyAdapterRegistry,
@@ -1178,14 +1179,26 @@ class DependencyHealthProvider {
   async _fetchWorkspaceRepositories(workspace, token) {
     const api = new CloudsmithAPI(this.context);
     const paginatedFetch = new PaginatedFetch(api);
-    const endpoint = `repos/${workspace}/?sort=name`;
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
+    } catch {
+      this._warnings.push("Could not load repositories for upstream analysis. The workspace identifier was invalid.");
+      return [];
+    }
     const repositories = [];
     let page = 1;
 
     while (!token || !token.isCancellationRequested) {
-      const result = await paginatedFetch.fetchPage(endpoint, page, WORKSPACE_REPOSITORY_PAGE_SIZE);
+      const result = await paginatedFetch.fetchPage(
+        endpoint,
+        page,
+        WORKSPACE_REPOSITORY_PAGE_SIZE,
+        null,
+        { cancellationToken: token, retry: "never", validate: isRepositoryPageArray }
+      );
       if (result.error) {
-        this._warnings.push(`Could not load repositories for upstream analysis. ${result.error}`);
+        this._warnings.push(`Could not load repositories for upstream analysis. ${result.error.message}`);
         break;
       }
 
@@ -1749,6 +1762,18 @@ class DependencyHealthProvider {
   }
 }
 
+function isRepositoryPageArray(value) {
+  return Array.isArray(value) && value.every(repository => (
+    repository
+    && typeof repository === "object"
+    && !Array.isArray(repository)
+    && typeof repository.slug === "string"
+    && repository.slug.length > 0
+    && typeof repository.name === "string"
+    && repository.name.length > 0
+  ));
+}
+
 function createScanOperation(status, id, values = {}) {
   return {
     status,
@@ -1867,7 +1892,7 @@ async function lookupExactDependency({
     || !format
     || lookupNames.length === 0
     || !api
-    || typeof api.getWithHeaders !== "function"
+    || typeof api.get !== "function"
   ) {
     return createCoverageLookupResult(
       CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
@@ -1911,26 +1936,29 @@ async function lookupExactDependency({
         );
       }
 
-      let response;
+      let requestEndpoint;
       try {
-        response = await api.getWithHeaders(
-          `${endpoint}?page=${page}&page_size=${LOOKUP_PAGE_SIZE}&query=${encodeURIComponent(query)}`
-        );
-      } catch (error) {
-        const status = isRateLimitError(error)
-          ? CLOUDSMITH_COVERAGE_STATUS.RATE_LIMITED
-          : pagesFetched > 0
-            ? CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
-            : CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED;
+        requestEndpoint = appendApiQuery(endpoint, {
+          page,
+          page_size: LOOKUP_PAGE_SIZE,
+          query,
+        });
+      } catch {
         return createCoverageLookupResult(
-          status,
+          pagesFetched > 0
+            ? CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
+            : CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
           null,
-          status === CLOUDSMITH_COVERAGE_STATUS.RATE_LIMITED
-            ? "Cloudsmith rate limited the dependency lookup."
-            : "The Cloudsmith lookup did not complete successfully.",
+          "The Cloudsmith lookup endpoint could not be constructed safely.",
           pagesFetched
         );
       }
+      const response = await api.get(requestEndpoint, {
+        responseType: "array",
+        validate: isPackageCandidateArray,
+        retry: "never",
+        cancellationToken: token,
+      });
       if (token && token.isCancellationRequested) {
         return createCoverageLookupResult(
           CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE,
@@ -1939,8 +1967,8 @@ async function lookupExactDependency({
           pagesFetched
         );
       }
-      if (typeof response === "string") {
-        const status = isRateLimitError(response)
+      if (!response.ok) {
+        const status = response.error.kind === "rate_limited"
           ? CLOUDSMITH_COVERAGE_STATUS.RATE_LIMITED
           : pagesFetched > 0
             ? CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
@@ -1954,17 +1982,6 @@ async function lookupExactDependency({
           pagesFetched
         );
       }
-      if (!response || typeof response !== "object" || !Array.isArray(response.data)) {
-        return createCoverageLookupResult(
-          pagesFetched > 0
-            ? CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
-            : CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
-          null,
-          "Cloudsmith returned an unexpected dependency lookup response.",
-          pagesFetched
-        );
-      }
-
       pagesFetched += 1;
       const match = matchCoverageCandidates(response.data, dependency, concreteVersion);
       if (match) {
@@ -1977,7 +1994,7 @@ async function lookupExactDependency({
       }
 
       const pagination = getLookupPaginationDirective(
-        response.headers,
+        normalizeLookupHeaders(response.headers),
         page,
         response.data.length,
         LOOKUP_PAGE_SIZE
@@ -2012,9 +2029,13 @@ function buildPackageLookupEndpoint(cloudsmithWorkspace, cloudsmithRepo) {
     return null;
   }
 
-  return repo
-    ? `packages/${encodeURIComponent(workspace)}/${encodeURIComponent(repo)}/`
-    : `packages/${encodeURIComponent(workspace)}/`;
+  try {
+    return repo
+      ? apiEndpoint(["packages", workspace, repo])
+      : apiEndpoint(["packages", workspace]);
+  } catch {
+    return null;
+  }
 }
 
 function getDependencyLookupNames(dependency) {
@@ -2163,8 +2184,24 @@ function parseOptionalNonNegativeInteger(value) {
   };
 }
 
-function isRateLimitError(message) {
-  return /(?:response\s+status\s*:\s*|\b)429\b/i.test(String(message || ""));
+function normalizeLookupHeaders(headers) {
+  return {
+    page: headers && headers["x-pagination-page"],
+    pageTotal: headers && headers["x-pagination-pagetotal"],
+    count: headers && headers["x-pagination-count"],
+    pageSize: headers && headers["x-pagination-pagesize"],
+  };
+}
+
+function isPackageCandidateArray(value) {
+  return Array.isArray(value) && value.every(candidate => (
+    candidate
+    && typeof candidate === "object"
+    && !Array.isArray(candidate)
+    && nonEmptyString(candidate.name)
+    && nonEmptyString(candidate.format)
+    && nonEmptyString(candidate.version)
+  ));
 }
 
 function isAbsentCoverageStatus(status) {

--- a/views/promotionProvider.js
+++ b/views/promotionProvider.js
@@ -4,42 +4,14 @@
 
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint, encodeApiPathSegment } = require("../util/apiEndpoint");
+const { formatApiError } = require("../util/errorFormatter");
+const { buildExactPackageQuery, packageMatchesExactIdentity } = require("../util/packageQuery");
 
 class PromotionProvider {
   constructor(context) {
     this.context = context;
     this.api = new CloudsmithAPI(context);
-  }
-
-  _normalizeFieldValue(value) {
-    if (value == null) {
-      return null;
-    }
-    return String(value);
-  }
-
-  _escapeQueryValue(value) {
-    if (value == null) {
-      return "";
-    }
-
-    return String(value)
-      .replace(/(\\|&&|\|\||[+\-!(){}\[\]^"~*?:/|&])/g, (match) => `\\${match}`)
-      .replace(/[\u0000-\u001f\u007f]/g, " ");
-  }
-
-  _buildExactPackageQuery(name, version, format) {
-    return `name:"${this._escapeQueryValue(name)}" AND version:"${this._escapeQueryValue(version)}" AND format:"${this._escapeQueryValue(format)}"`;
-  }
-
-  _packageMatchesExpected(pkg, expected) {
-    if (!pkg || typeof pkg !== "object" || !expected) {
-      return false;
-    }
-
-    return this._normalizeFieldValue(pkg.name) === this._normalizeFieldValue(expected.name)
-      && this._normalizeFieldValue(pkg.version) === this._normalizeFieldValue(expected.version)
-      && this._normalizeFieldValue(pkg.format) === this._normalizeFieldValue(expected.format);
   }
 
   _getPackageIdentifier(pkg) {
@@ -54,6 +26,9 @@ class PromotionProvider {
     }
     if (typeof pkg.slug_perm_raw === "string") {
       return pkg.slug_perm_raw;
+    }
+    if (typeof pkg.slug === "string") {
+      return pkg.slug;
     }
     return null;
   }
@@ -85,15 +60,25 @@ class PromotionProvider {
       return false;
     }
 
-    const tagPayload = JSON.stringify({ action: "add", tags });
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["packages", workspace, repo, identifier, "tag"]);
+    } catch {
+      console.warn(`[Promotion] Skipping ${label} tags because the package endpoint was invalid.`);
+      return false;
+    }
     const tagResult = await this.api.post(
-      `packages/${workspace}/${repo}/${identifier}/tag/`,
-      tagPayload,
-      apiKey
+      endpoint,
+      { action: "add", tags },
+      {
+        apiKey,
+        responseType: "object",
+        validate: isPackageWriteRecord,
+      }
     );
 
-    if (typeof tagResult === "string") {
-      console.warn(`[Promotion] Failed to apply ${label} tags for ${workspace}/${repo}/${identifier}: ${tagResult}`);
+    if (!tagResult.ok) {
+      console.warn(`[Promotion] Failed to apply ${label} tags: ${formatApiError(tagResult.error)}`);
       return false;
     }
 
@@ -105,25 +90,36 @@ class PromotionProvider {
       return null;
     }
 
-    const query = encodeURIComponent(
-      this._buildExactPackageQuery(packageInfo.name, packageInfo.version, packageInfo.format)
-    );
+    let endpoint;
+    try {
+      const query = buildExactPackageQuery(packageInfo.name, packageInfo.version, packageInfo.format);
+      endpoint = apiEndpoint(["packages", workspace, targetRepo], {
+        query: { query, page_size: 100 },
+      });
+    } catch {
+      return null;
+    }
     const results = await this.api.get(
-      `packages/${workspace}/${targetRepo}/?query=${query}&page_size=100`,
-      apiKey
+      endpoint,
+      {
+        apiKey,
+        responseType: "array",
+        validate: isPackageWriteArray,
+        retry: "never",
+      }
     );
 
-    if (typeof results === "string") {
-      console.warn(`[Promotion] Could not locate copied package in ${workspace}/${targetRepo}: ${results}`);
+    if (!results.ok) {
+      console.warn(`[Promotion] Could not locate copied package: ${formatApiError(results.error)}`);
       return null;
     }
 
-    if (!Array.isArray(results) || results.length === 0) {
+    if (results.data.length === 0) {
       console.warn(`[Promotion] Could not locate copied package in ${workspace}/${targetRepo}: no matching package found.`);
       return null;
     }
 
-    const exactResults = results.filter(pkg => this._packageMatchesExpected(pkg, packageInfo));
+    const exactResults = results.data.filter(pkg => packageMatchesExactIdentity(pkg, packageInfo));
     if (exactResults.length === 0) {
       console.warn(
         `[Promotion] Could not locate copied package in ${workspace}/${targetRepo}: query returned packages but none matched ${packageInfo.name}@${packageInfo.version} (${packageInfo.format}).`
@@ -165,11 +161,21 @@ class PromotionProvider {
     if (!defaultWs) {
       return;
     }
-    const repos = await this.api.get(`repos/${defaultWs}/?sort=name`);
-    if (typeof repos === "string" || !Array.isArray(repos)) {
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["repos", defaultWs], { query: { sort: "name" } });
+    } catch {
       return;
     }
-    const validSlugs = new Set(repos.map(r => r.slug));
+    const repos = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isRepositoryArray,
+      retry: "safe-read",
+    });
+    if (!repos.ok) {
+      return;
+    }
+    const validSlugs = new Set(repos.data.map(r => r.slug));
     const invalidSlugs = pipeline.filter(s => !validSlugs.has(s));
     if (invalidSlugs.length > 0) {
       vscode.window.showWarningMessage(
@@ -197,39 +203,48 @@ class PromotionProvider {
    * @param   {string} name       Package name.
    * @param   {string} version    Package version.
    * @param   {string} format     Package format.
-   * @returns {Array}             Array of { repo, found, status, pkg } for each pipeline repo.
+   * @returns {Object}            Structured status items and an optional error.
    */
   async getPromotionStatus(workspace, name, version, format) {
     const pipeline = this.getPipeline();
     if (pipeline.length === 0) {
-      return [];
+      return { items: [], error: null };
     }
     if (!name || !version || !format) {
-      return [];
+      return { items: [], error: new Error("Package identity is incomplete.") };
     }
 
     // Search workspace-wide for this package name+version
-    const query = encodeURIComponent(
-      this._buildExactPackageQuery(name, version, format)
-    );
+    let endpoint;
+    try {
+      const query = buildExactPackageQuery(name, version, format);
+      endpoint = apiEndpoint(["packages", workspace], {
+        query: { query, page_size: 100 },
+      });
+    } catch (error) {
+      return { items: [], error };
+    }
     const results = await this.api.get(
-      `packages/${workspace}/?query=${query}&page_size=100`
+      endpoint,
+      { responseType: "array", validate: isPromotionStatusArray, retry: "never" }
     );
 
+    if (!results.ok) {
+      return { items: [], error: results.error };
+    }
+
     // Build a map of repo slug -> package data
-    const repoMap = {};
-    if (Array.isArray(results)) {
-      const exactResults = results.filter(pkg =>
-        this._packageMatchesExpected(pkg, { name, version, format })
-      );
-      for (const pkg of exactResults) {
-        repoMap[pkg.repository] = pkg;
-      }
+    const repoMap = new Map();
+    const exactResults = results.data.filter(pkg =>
+      packageMatchesExactIdentity(pkg, { name, version, format })
+    );
+    for (const pkg of exactResults) {
+      repoMap.set(pkg.repository, pkg);
     }
 
     // Map pipeline repos to their status
-    return pipeline.map(repo => {
-      const pkg = repoMap[repo] || null;
+    return { items: pipeline.map(repo => {
+      const pkg = repoMap.get(repo) || null;
       return {
         repo,
         found: !!pkg,
@@ -238,7 +253,7 @@ class PromotionProvider {
         policyViolated: pkg ? (pkg.policy_violated || false) : false,
         pkg,
       };
-    });
+    }), error: null };
   }
 
   /**
@@ -257,25 +272,39 @@ class PromotionProvider {
     const templates = this.getTagTemplates();
     const dateStr = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
 
-    const sourcePackageResult = await this.api.get(
-      `packages/${workspace}/${sourceRepo}/${slugPerm}/`,
-      apiKey
-    );
+    let sourceEndpoint;
+    let copyEndpoint;
+    try {
+      sourceEndpoint = apiEndpoint(["packages", workspace, sourceRepo, slugPerm]);
+      copyEndpoint = apiEndpoint(["packages", workspace, sourceRepo, slugPerm, "copy"]);
+      encodeApiPathSegment(targetRepo);
+    } catch (error) {
+      return { success: false, error };
+    }
+    const sourcePackageResult = await this.api.get(sourceEndpoint, {
+      apiKey,
+      responseType: "object",
+      validate: isPackageIdentityRecord,
+      retry: "never",
+    });
     const sourcePackage = this._normalizePackage(
-      typeof sourcePackageResult === "string" ? null : sourcePackageResult
+      sourcePackageResult.ok ? sourcePackageResult.data : null
     );
 
     // Step 1: Copy the package to the target repo
-    const copyEndpoint = `packages/${workspace}/${sourceRepo}/${slugPerm}/copy/`;
-    const copyPayload = JSON.stringify({
+    const copyPayload = {
       destination: `${workspace}/${targetRepo}`,
+    };
+
+    const copyResult = await this.api.post(copyEndpoint, copyPayload, {
+      apiKey,
+      responseType: "object",
+      validate: isPackageWriteRecord,
     });
 
-    const copyResult = await this.api.post(copyEndpoint, copyPayload, apiKey);
-
-    if (typeof copyResult === "string") {
-      console.warn(`[Promotion] Copy failed: ${copyResult}`);
-      return { success: false, error: copyResult };
+    if (!copyResult.ok) {
+      console.warn(`[Promotion] Copy failed: ${formatApiError(copyResult.error)}`);
+      return { success: false, error: copyResult.error };
     }
 
     if (templates.onPromote && templates.onPromote.length > 0) {
@@ -286,7 +315,7 @@ class PromotionProvider {
     }
 
     if (templates.onReceive && templates.onReceive.length > 0) {
-      const copiedPackage = this._normalizePackage(copyResult) || sourcePackage;
+      const copiedPackage = this._normalizePackage(copyResult.data) || sourcePackage;
       const locatedPackage = await this._locateCopiedPackage(
         workspace,
         targetRepo,
@@ -309,6 +338,54 @@ class PromotionProvider {
 
     return { success: true, error: null };
   }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRecordArray(value) {
+  return Array.isArray(value) && value.every(isRecord);
+}
+
+function packageIdentifier(value) {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
+    ? value.value
+    : null;
+}
+
+function isPackageIdentityRecord(value) {
+  return isRecord(value)
+    && typeof value.name === "string" && value.name.length > 0
+    && (typeof value.version === "string" || typeof value.version === "number")
+    && String(value.version).length > 0
+    && typeof value.format === "string" && value.format.length > 0;
+}
+
+function isPackageWriteRecord(value) {
+  return isPackageIdentityRecord(value)
+    && Boolean(packageIdentifier(value.slug_perm || value.slug_perm_raw || value.slug));
+}
+
+function isPackageWriteArray(value) {
+  return Array.isArray(value) && value.every(isPackageWriteRecord);
+}
+
+function isPromotionStatusArray(value) {
+  return Array.isArray(value) && value.every(pkg => (
+    isPackageIdentityRecord(pkg)
+    && typeof pkg.repository === "string"
+    && pkg.repository.length > 0
+  ));
+}
+
+function isRepositoryArray(value) {
+  return isRecordArray(value) && value.every(repo => (
+    typeof repo.slug === "string" && repo.slug.length > 0
+  ));
 }
 
 module.exports = { PromotionProvider };

--- a/views/quarantineExplainProvider.js
+++ b/views/quarantineExplainProvider.js
@@ -5,6 +5,8 @@
 const crypto = require("crypto");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
+const { formatApiError } = require("../util/errorFormatter");
 const { buildPackageUrl } = require("../util/webAppUrls");
 
 class QuarantineExplainProvider {
@@ -63,10 +65,14 @@ class QuarantineExplainProvider {
       { enableScripts: true }
     );
     this._panel = panel;
+    const requestController = new AbortController();
     const nonce = this._getNonce();
 
     panel.onDidDispose(() => {
-      this._panel = null;
+      requestController.abort();
+      if (this._panel === panel) {
+        this._panel = null;
+      }
     });
 
     // Show loading state
@@ -74,7 +80,13 @@ class QuarantineExplainProvider {
 
     // Fetch policy decision trace
     const cloudsmithAPI = new CloudsmithAPI(this.context);
-    const policyTrace = await this._fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason);
+    const policyTrace = await this._fetchPolicyDecisionTrace(
+      cloudsmithAPI,
+      workspace,
+      slugPerm,
+      statusReason,
+      requestController.signal
+    );
 
     if (this._panel !== panel) {
       return;
@@ -108,7 +120,7 @@ class QuarantineExplainProvider {
    *
    * @returns {Object} { parsedReason, decisionLogs: [...], policyDetail: Object|null }
    */
-  async _fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason) {
+  async _fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason, signal) {
     const trace = {
       parsedReason: null,
       decisionLogs: [],
@@ -131,12 +143,18 @@ class QuarantineExplainProvider {
 
     // Fetch decision logs from v2 API
     try {
-      const logsResult = await cloudsmithAPI.getV2(
-        `workspaces/${workspace}/policies/decision/logs/?page_size=100`
-      );
+      const logsEndpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"], {
+        query: { page_size: 100 },
+      });
+      const logsResult = await cloudsmithAPI.getV2(logsEndpoint, {
+        responseType: "json",
+        validate: isArrayOrResultsEnvelope,
+        retry: "never",
+        signal,
+      });
 
-      if (typeof logsResult !== "string" && logsResult) {
-        const logs = Array.isArray(logsResult) ? logsResult : (logsResult.results || []);
+      if (logsResult.ok) {
+        const logs = Array.isArray(logsResult.data) ? logsResult.data : logsResult.data.results;
         trace.decisionLogs = logs.filter(entry => {
           if (entry.package && entry.package.identifier === slugPerm) {
             return true;
@@ -146,21 +164,34 @@ class QuarantineExplainProvider {
           }
           return false;
         });
+      } else if (logsResult.error.kind !== "cancelled") {
+        console.warn(`[Quarantine] Policy decision logs unavailable: ${formatApiError(logsResult.error)}`);
       }
-    } catch (e) { // eslint-disable-line no-unused-vars
+    } catch (error) { // eslint-disable-line no-unused-vars
       // v2 policy decision log endpoint may not be available
     }
 
     // If we have a policy slug, fetch the policy detail for the description
     if (trace.parsedReason && trace.parsedReason.policySlug) {
       try {
-        const policyResult = await cloudsmithAPI.getV2(
-          `workspaces/${workspace}/policies/${trace.parsedReason.policySlug}/`
-        );
-        if (typeof policyResult !== "string" && policyResult) {
-          trace.policyDetail = policyResult;
+        const policyEndpoint = apiEndpoint([
+          "workspaces",
+          workspace,
+          "policies",
+          trace.parsedReason.policySlug,
+        ]);
+        const policyResult = await cloudsmithAPI.getV2(policyEndpoint, {
+          responseType: "object",
+          validate: isRecord,
+          retry: "never",
+          signal,
+        });
+        if (policyResult.ok) {
+          trace.policyDetail = policyResult.data;
+        } else if (policyResult.error.kind !== "cancelled") {
+          console.warn(`[Quarantine] Policy detail unavailable: ${formatApiError(policyResult.error)}`);
         }
-      } catch (e) { // eslint-disable-line no-unused-vars
+      } catch (error) { // eslint-disable-line no-unused-vars
         // Policy detail may not be accessible
       }
     }
@@ -389,6 +420,17 @@ class QuarantineExplainProvider {
       this._panel = null;
     }
   }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isArrayOrResultsEnvelope(value) {
+  if (Array.isArray(value)) {
+    return value.every(isRecord);
+  }
+  return isRecord(value) && Array.isArray(value.results) && value.results.every(isRecord);
 }
 
 module.exports = { QuarantineExplainProvider };

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -2,6 +2,7 @@
 
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
 const { PaginatedFetch } = require("../util/paginatedFetch");
 const SearchResultNode = require("../models/searchResultNode");
 const LoadMoreNode = require("../models/loadMoreNode");
@@ -37,29 +38,48 @@ class SearchProvider {
      * @param   repo       Optional repo slug for repo-scoped search
      */
     async search(workspace, query, page = 1, repo = null) {
-        this.currentWorkspace = workspace;
-        this.currentQuery = query;
-        this.currentPage = page;
-        this.currentRepo = repo ? repo : null;
-
         const cloudsmithAPI = new CloudsmithAPI(this.context);
         const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
 
         const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
         const pageSize = config.get("searchPageSize") || 50;
 
-        const endpoint = repo
-            ? `packages/${workspace}/${repo}/`
-            : `packages/${workspace}/`;
+        let endpoint;
+        try {
+            endpoint = repo
+                ? apiEndpoint(["packages", workspace, repo])
+                : apiEndpoint(["packages", workspace]);
+        } catch {
+            vscode.window.showErrorMessage("Could not search packages. The search scope was invalid.");
+            return;
+        }
         const result = await vscode.window.withProgress(
-            { location: vscode.ProgressLocation.Notification, title: "Searching packages..." },
-            () => paginatedFetch.fetchPage(endpoint, page, pageSize, query)
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Searching packages...",
+                cancellable: true,
+            },
+            (_progress, token) => paginatedFetch.fetchPage(
+                endpoint,
+                page,
+                pageSize,
+                query,
+                { cancellationToken: token, retry: "never", validate: isPackageSearchArray }
+            )
         );
 
         if (result.error) {
+            if (result.error.kind === "cancelled") {
+                return;
+            }
             vscode.window.showErrorMessage(`Could not search packages. ${formatApiError(result.error)}`);
             return;
         }
+
+        this.currentWorkspace = workspace;
+        this.currentQuery = query;
+        this.currentPage = page;
+        this.currentRepo = repo ? repo : null;
 
         const newNodes = result.data.map(pkg => new SearchResultNode(pkg, this.context));
 
@@ -98,11 +118,6 @@ class SearchProvider {
      * @param   query      Cloudsmith search query string
      */
     async searchRepos(workspace, repos, query) {
-        this.currentWorkspace = workspace;
-        this.currentQuery = query;
-        this.currentPage = 1;
-        this.currentRepo = null;
-
         const cloudsmithAPI = new CloudsmithAPI(this.context);
         const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
 
@@ -111,8 +126,19 @@ class SearchProvider {
 
         // Fetch first page from each repo in parallel
         const promises = repos.map(repo => {
-            const endpoint = `packages/${workspace}/${repo}/`;
-            return paginatedFetch.fetchPage(endpoint, 1, pageSize, query);
+            let endpoint;
+            try {
+                endpoint = apiEndpoint(["packages", workspace, repo]);
+            } catch {
+                return Promise.resolve({
+                    data: [],
+                    error: { kind: "invalid_request", message: "The repository identifier was invalid." },
+                });
+            }
+            return paginatedFetch.fetchPage(endpoint, 1, pageSize, query, {
+                retry: "never",
+                validate: isPackageSearchArray,
+            });
         });
         const results = await Promise.all(promises);
 
@@ -132,6 +158,10 @@ class SearchProvider {
 
         this.searchResults = allNodes;
         this.pagination = null; // No unified pagination for multi-repo search
+        this.currentWorkspace = workspace;
+        this.currentQuery = query;
+        this.currentPage = 1;
+        this.currentRepo = null;
 
         if (failedRepos.length > 0) {
             vscode.window.showWarningMessage(`Could not search some repositories: ${failedRepos.join(", ")}.`);
@@ -218,6 +248,34 @@ class SearchProvider {
     refresh() {
         this._onDidChangeTreeData.fire();
     }
+}
+
+function unwrapIdentifier(value) {
+    if (typeof value === "string" && value.length > 0) {
+        return value;
+    }
+    return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
+        ? value.value
+        : null;
+}
+
+function isPackageSearchArray(value) {
+    return Array.isArray(value) && value.every(pkg => (
+        pkg
+        && typeof pkg === "object"
+        && !Array.isArray(pkg)
+        && typeof pkg.name === "string"
+        && pkg.name.length > 0
+        && typeof pkg.format === "string"
+        && pkg.format.length > 0
+        && (typeof pkg.version === "string" || typeof pkg.version === "number")
+        && String(pkg.version).length > 0
+        && typeof pkg.repository === "string"
+        && pkg.repository.length > 0
+        && typeof pkg.namespace === "string"
+        && pkg.namespace.length > 0
+        && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+    ));
 }
 
 module.exports = { SearchProvider };

--- a/views/vulnerabilityProvider.js
+++ b/views/vulnerabilityProvider.js
@@ -7,6 +7,8 @@
 const crypto = require("crypto");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { apiEndpoint } = require("../util/apiEndpoint");
+const { formatApiError } = require("../util/errorFormatter");
 const { fetchPackageVulnerabilities } = require("../util/packageVulnerabilities");
 
 class VulnerabilityProvider {
@@ -64,10 +66,14 @@ class VulnerabilityProvider {
       { enableScripts: true }
     );
     this._panel = panel;
+    const requestController = new AbortController();
     const nonce = this._getNonce();
 
     panel.onDidDispose(() => {
-      this._panel = null;
+      requestController.abort();
+      if (this._panel === panel) {
+        this._panel = null;
+      }
     });
 
     // Show loading state
@@ -76,8 +82,14 @@ class VulnerabilityProvider {
     // Fetch vulnerability data and policy decision logs in parallel
     const cloudsmithAPI = new CloudsmithAPI(this.context);
     const [vulnData, policyTrace] = await Promise.all([
-      this._fetchVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm),
-      this._fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason),
+      this._fetchVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm, requestController.signal),
+      this._fetchPolicyDecisionTrace(
+        cloudsmithAPI,
+        workspace,
+        slugPerm,
+        statusReason,
+        requestController.signal
+      ),
     ]);
 
     if (this._panel !== panel) {
@@ -116,8 +128,15 @@ class VulnerabilityProvider {
    * Two-step vulnerability fetch.
    * Returns { results: [...cveObjects], maxSeverity: string, numVulns: number }
    */
-  async _fetchVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm) {
-    return fetchPackageVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm);
+  async _fetchVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm, signal) {
+    return fetchPackageVulnerabilities(
+      cloudsmithAPI,
+      workspace,
+      repo,
+      slugPerm,
+      0,
+      { signal }
+    );
   }
 
   /**
@@ -126,7 +145,7 @@ class VulnerabilityProvider {
    *
    * @returns {Object} { parsedReason, decisionLogs: [...] }
    */
-  async _fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason) {
+  async _fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason, signal) {
     const trace = {
       parsedReason: null,
       decisionLogs: [],
@@ -149,12 +168,18 @@ class VulnerabilityProvider {
 
     // Fetch decision logs from v2 API
     try {
-      const logsResult = await cloudsmithAPI.getV2(
-        `workspaces/${workspace}/policies/decision/logs/?page_size=100`
-      );
+      const endpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"], {
+        query: { page_size: 100 },
+      });
+      const logsResult = await cloudsmithAPI.getV2(endpoint, {
+        responseType: "json",
+        validate: isArrayOrResultsEnvelope,
+        retry: "never",
+        signal,
+      });
 
-      if (typeof logsResult !== "string" && logsResult) {
-        const logs = Array.isArray(logsResult) ? logsResult : (logsResult.results || []);
+      if (logsResult.ok) {
+        const logs = Array.isArray(logsResult.data) ? logsResult.data : logsResult.data.results;
         // Filter for entries matching this package
         trace.decisionLogs = logs.filter(entry => {
           if (entry.package && entry.package.identifier === slugPerm) {
@@ -165,8 +190,10 @@ class VulnerabilityProvider {
           }
           return false;
         });
+      } else if (logsResult.error.kind !== "cancelled") {
+        console.warn(`[Vulnerabilities] Policy decision logs unavailable: ${formatApiError(logsResult.error)}`);
       }
-    } catch (e) { // eslint-disable-line no-unused-vars
+    } catch (error) { // eslint-disable-line no-unused-vars
       // v2 policy decision log endpoint may not be available
     }
 
@@ -470,6 +497,17 @@ class VulnerabilityProvider {
       this._panel = null;
     }
   }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isArrayOrResultsEnvelope(value) {
+  if (Array.isArray(value)) {
+    return value.every(isRecord);
+  }
+  return isRecord(value) && Array.isArray(value.results) && value.results.every(isRecord);
 }
 
 module.exports = { VulnerabilityProvider };


### PR DESCRIPTION
## Summary

- Added typed Cloudsmith API success/error envelopes and migrated production callers away from string-based transport failures.
- Added finite end-to-end deadlines, external cancellation propagation, bounded safe-read retries, and `Retry-After` handling.
- Hardened API and registry redirects, credential forwarding, endpoint construction, response validation, diagnostics, and body-size limits.
- Added deterministic transport, security, cancellation, pagination, promotion, vulnerability, upstream, and provider regression coverage.

## Validation

- `npm run lint` — passed with one pre-existing warning.
- `npm test` — passed: 617 passing, 7 credential-gated pending, 0 failing.
- `npm audit --omit=dev` — passed with 0 vulnerabilities.
- `npm run build` — passed; validated 85 runtime JavaScript files.
- `git diff --check` — passed.
- VSIX file listing, packaging, and archive integrity checks — passed.
- Extension Development Host activation, authentication, repositories, package search, package details, and dependency scan — passed.
