### PR TITLE
fix: avoid unnecessary diagnostic indexing

### DIFF
--- a/test/diagnosticsPublisher.test.js
+++ b/test/diagnosticsPublisher.test.js
@@ -21,7 +21,9 @@ const {
 const DependencyHealthNode = require("../models/dependencyHealthNode");
 const {
   buildDependencyDeclarationIndex,
+  validateDependencyDeclarationSourceContract,
 } = require("../util/dependencyDeclarationIndex");
+const { canonicalFormat } = require("../util/packageNameNormalizer");
 
 suite("DiagnosticsPublisher Test Suite", () => {
   let originalCreateDiagnosticCollection;
@@ -157,6 +159,80 @@ suite("DiagnosticsPublisher Test Suite", () => {
     });
     return { occurrence, prepared };
   }
+
+  test("derives dependency source contract fields from one normalized ecosystem", () => {
+    const cases = [
+      {
+        sourceType: "package.json",
+        ecosystem: "npm",
+        expectedSourceType: "package.json",
+        expectedEcosystem: "npm",
+        expectedFormat: "npm",
+      },
+      {
+        sourceType: " PACKAGE.JSON ",
+        ecosystem: " NPM ",
+        expectedSourceType: "package.json",
+        expectedEcosystem: "npm",
+        expectedFormat: "npm",
+      },
+      {
+        sourceType: "requirements.txt",
+        ecosystem: " PyPI ",
+        expectedSourceType: "requirements.txt",
+        expectedEcosystem: "pypi",
+        expectedFormat: "python",
+      },
+      {
+        sourceType: "build.gradle",
+        ecosystem: "Gradle",
+        expectedSourceType: "build.gradle",
+        expectedEcosystem: "gradle",
+        expectedFormat: "maven",
+      },
+    ];
+
+    for (const fixture of cases) {
+      const result = validateDependencyDeclarationSourceContract(
+        fixture.sourceType,
+        fixture.ecosystem
+      );
+
+      assert.strictEqual(result.sourceType, fixture.expectedSourceType);
+      assert.strictEqual(result.ecosystem, fixture.expectedEcosystem);
+      assert.strictEqual(result.format, fixture.expectedFormat);
+      assert.strictEqual(result.format, canonicalFormat(result.ecosystem));
+      assert.strictEqual(Object.isFrozen(result), true);
+    }
+  });
+
+  test("does not reuse stale ecosystem input after contract normalization", () => {
+    let coercions = 0;
+    const ecosystem = {
+      toString() {
+        coercions += 1;
+        return coercions === 1 ? " PyPI " : "npm";
+      },
+    };
+
+    const result = validateDependencyDeclarationSourceContract("requirements.txt", ecosystem);
+
+    assert.strictEqual(coercions, 1);
+    assert.strictEqual(result.ecosystem, "pypi");
+    assert.strictEqual(result.format, "python");
+    assert.strictEqual(result.format, canonicalFormat(result.ecosystem));
+  });
+
+  test("rejects incompatible dependency source ecosystem contracts", () => {
+    assert.throws(
+      () => validateDependencyDeclarationSourceContract("package.json", "maven"),
+      (error) => (
+        error
+        && error.code === "ERR_DEPENDENCY_DECLARATION_SOURCE_CONTRACT"
+        && /source type package\.json is incompatible with ecosystem maven/.test(error.message)
+      )
+    );
+  });
 
   test("uses npm provenance and never guesses across same-format manifests", async () => {
     const firstPath = "/project/app/package.json";

--- a/test/diagnosticsPublisher.test.js
+++ b/test/diagnosticsPublisher.test.js
@@ -543,7 +543,16 @@ suite("DiagnosticsPublisher Test Suite", () => {
       start: { line: 1, character: 21 },
       end: { line: 1, character: 27 },
     });
-    const { publisher, reads } = createMemoryPublisher(new Map([[filePath, content]]));
+    let buildIndexCalls = 0;
+    const { publisher, reads } = createMemoryPublisher(
+      new Map([[filePath, content]]),
+      {
+        buildIndex() {
+          buildIndexCalls += 1;
+          throw new Error("exact provenance must not require declaration indexing");
+        },
+      }
+    );
     const prepared = await publisher.prepare({
       workspaceFolder: "/project",
       candidates: [
@@ -553,11 +562,151 @@ suite("DiagnosticsPublisher Test Suite", () => {
     });
 
     assert.strictEqual(reads.length, 1);
+    assert.strictEqual(buildIndexCalls, 0);
     assert.strictEqual(prepared.entries[0][1].length, 2);
     assert.deepStrictEqual(
       prepared.entries[0][1].map((diagnostic) => diagnostic.range.start.character),
       [21, 21]
     );
+    assert.strictEqual(prepared.stats.indexedSources, 0);
+    assert.strictEqual(prepared.stats.truncatedSourceIndexes, 0);
+    assert.strictEqual(prepared.stats.exactRanges, 2);
+  });
+
+  test("rejects invalid exact provenance ranges without declaration indexing", async () => {
+    const filePath = "/project/package.json";
+    let buildIndexCalls = 0;
+    const { publisher } = createMemoryPublisher(
+      new Map([[filePath, '{"dependencies":{"alpha":"1.0.0"}}']]),
+      {
+        buildIndex() {
+          buildIndexCalls += 1;
+          throw new Error("invalid exact provenance must fail before declaration indexing");
+        },
+      }
+    );
+
+    await assert.rejects(
+      publisher.prepare({
+        workspaceFolder: "/project",
+        candidates: [candidate({
+          name: "alpha",
+          manifest: source(filePath, "package.json", {
+            start: { line: 4, character: 0 },
+            end: { line: 4, character: 5 },
+          }),
+        })],
+      }),
+      /source range exceeds its source file/
+    );
+    assert.strictEqual(buildIndexCalls, 0);
+  });
+
+  test("keeps exact provenance diagnostics when their JSON source is malformed", async () => {
+    const filePath = "/project/package.json";
+    const content = "{not-json";
+    let buildIndexCalls = 0;
+    const { publisher } = createMemoryPublisher(
+      new Map([[filePath, content]]),
+      {
+        buildIndex(options) {
+          buildIndexCalls += 1;
+          return buildDependencyDeclarationIndex(options);
+        },
+      }
+    );
+    const prepared = await publisher.prepare({
+      workspaceFolder: "/project",
+      candidates: [candidate({
+        name: "not",
+        manifest: source(filePath, "package.json", {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 4 },
+        }),
+      })],
+    });
+
+    assert.strictEqual(buildIndexCalls, 0);
+    assert.strictEqual(prepared.stats.indexedSources, 0);
+    assert.strictEqual(prepared.stats.truncatedSourceIndexes, 0);
+    assert.strictEqual(prepared.stats.diagnostics, 1);
+    assert.strictEqual(highlightedText(content, prepared.entries[0][1][0]), "not");
+  });
+
+  test("validates exact provenance source contracts without declaration indexing", async () => {
+    const filePath = "/project/package.json";
+    let buildIndexCalls = 0;
+    const { publisher } = createMemoryPublisher(
+      new Map([[filePath, '{"dependencies":{"alpha":"1.0.0"}}']]),
+      {
+        buildIndex() {
+          buildIndexCalls += 1;
+          throw new Error("exact provenance must not require declaration indexing");
+        },
+      }
+    );
+
+    await assert.rejects(
+      publisher.prepare({
+        workspaceFolder: "/project",
+        candidates: [candidate({
+          ecosystem: "maven",
+          name: "alpha",
+          manifest: source(filePath, "package.json", {
+            start: { line: 0, character: 18 },
+            end: { line: 0, character: 23 },
+          }),
+        })],
+      }),
+      /source type package\.json is incompatible with ecosystem maven/
+    );
+    assert.strictEqual(buildIndexCalls, 0);
+  });
+
+  test("indexes only missing provenance once for a mixed source", async () => {
+    const filePath = "/project/package.json";
+    const content = [
+      "{",
+      '  "dependencies": {',
+      '    "exact-package": "1.0.0",',
+      '    "indexed-package": "2.0.0"',
+      "  }",
+      "}",
+    ].join("\n");
+    let buildIndexCalls = 0;
+    let indexedNames = null;
+    const { publisher } = createMemoryPublisher(
+      new Map([[filePath, content]]),
+      {
+        buildIndex(options) {
+          buildIndexCalls += 1;
+          indexedNames = options.wantedNames.slice();
+          return buildDependencyDeclarationIndex(options);
+        },
+      }
+    );
+    const prepared = await publisher.prepare({
+      workspaceFolder: "/project",
+      candidates: [
+        candidate({
+          name: "exact-package",
+          manifest: source(filePath, "package.json", {
+            start: { line: 2, character: 5 },
+            end: { line: 2, character: 18 },
+          }),
+        }),
+        candidate({ name: "indexed-package", manifest: source(filePath) }),
+      ],
+    });
+    const diagnostics = prepared.entries[0][1];
+
+    assert.strictEqual(buildIndexCalls, 1);
+    assert.deepStrictEqual(indexedNames, ["indexed-package"]);
+    assert.strictEqual(prepared.stats.indexedSources, 1);
+    assert.strictEqual(prepared.stats.truncatedSourceIndexes, 0);
+    assert.strictEqual(prepared.stats.diagnostics, 2);
+    assert.strictEqual(highlightedText(content, diagnostics[0]), "exact-package");
+    assert.strictEqual(highlightedText(content, diagnostics[1]), "indexed-package");
   });
 
   test("uses a correct file-level fallback for unsupported precise locations", async () => {
@@ -655,10 +804,20 @@ suite("DiagnosticsPublisher Test Suite", () => {
       candidates.push(candidate({ name, manifest }));
     }
     const content = JSON.stringify({ dependencies });
-    const { publisher, reads } = createMemoryPublisher(new Map([[filePath, content]]));
+    let buildIndexCalls = 0;
+    const { publisher, reads } = createMemoryPublisher(
+      new Map([[filePath, content]]),
+      {
+        buildIndex(options) {
+          buildIndexCalls += 1;
+          return buildDependencyDeclarationIndex(options);
+        },
+      }
+    );
     const prepared = await publisher.prepare({ workspaceFolder: "/project", candidates });
 
     assert.strictEqual(reads.length, 1);
+    assert.strictEqual(buildIndexCalls, 1);
     assert.strictEqual(prepared.stats.sourceReads, 1);
     assert.strictEqual(prepared.stats.indexedSources, 1);
     assert.strictEqual(prepared.stats.diagnostics, 1000);
@@ -720,7 +879,16 @@ suite("DiagnosticsPublisher Test Suite", () => {
       { length: 10001 },
       (_, index) => `repeated-package==${index}`
     ).join("\n");
-    const { publisher, reads } = createMemoryPublisher(new Map([[filePath, content]]));
+    let buildIndexCalls = 0;
+    const { publisher, reads } = createMemoryPublisher(
+      new Map([[filePath, content]]),
+      {
+        buildIndex(options) {
+          buildIndexCalls += 1;
+          return buildDependencyDeclarationIndex(options);
+        },
+      }
+    );
     const prepared = await publisher.prepare({
       workspaceFolder: "/project",
       candidates: [candidate({
@@ -733,6 +901,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
     const range = prepared.entries[0][1][0].range;
 
     assert.strictEqual(reads.length, 1);
+    assert.strictEqual(buildIndexCalls, 1);
     assert.deepStrictEqual(
       [range.start.line, range.start.character, range.end.line, range.end.character],
       [0, 0, 0, 0]

--- a/util/dependencyDeclarationIndex.js
+++ b/util/dependencyDeclarationIndex.js
@@ -113,18 +113,19 @@ function buildDependencyDeclarationIndex({
 /** Validate source/ecosystem compatibility without parsing the source text. */
 function validateDependencyDeclarationSourceContract(sourceType, ecosystem) {
   const normalizedType = String(sourceType || "").trim().toLowerCase();
-  const rawEcosystem = String(ecosystem || "").trim().toLowerCase();
+  const normalizedEcosystem = String(ecosystem || "").trim().toLowerCase();
+  const format = canonicalFormat(normalizedEcosystem);
   const requiredEcosystem = EXACT_SOURCE_ECOSYSTEMS.get(normalizedType);
-  if (requiredEcosystem && rawEcosystem !== requiredEcosystem) {
+  if (requiredEcosystem && normalizedEcosystem !== requiredEcosystem) {
     throw new DependencyDeclarationIndexError(
-      `Dependency source type ${normalizedType} is incompatible with ecosystem ${rawEcosystem || "<missing>"}.`,
+      `Dependency source type ${normalizedType} is incompatible with ecosystem ${normalizedEcosystem || "<missing>"}.`,
       "ERR_DEPENDENCY_DECLARATION_SOURCE_CONTRACT"
     );
   }
   return Object.freeze({
     sourceType: normalizedType,
-    ecosystem: rawEcosystem,
-    format: canonicalFormat(ecosystem),
+    ecosystem: normalizedEcosystem,
+    format,
   });
 }
 

--- a/util/dependencyDeclarationIndex.js
+++ b/util/dependencyDeclarationIndex.js
@@ -43,16 +43,9 @@ function buildDependencyDeclarationIndex({
   maxDeclarations = MAX_INDEXED_DECLARATIONS,
 }) {
   const text = String(content || "");
-  const rawEcosystem = String(ecosystem || "").trim().toLowerCase();
-  const format = canonicalFormat(ecosystem);
-  const normalizedType = String(sourceType || "").trim().toLowerCase();
-  const requiredEcosystem = EXACT_SOURCE_ECOSYSTEMS.get(normalizedType);
-  if (requiredEcosystem && rawEcosystem !== requiredEcosystem) {
-    throw new DependencyDeclarationIndexError(
-      `Dependency source type ${normalizedType} is incompatible with ecosystem ${rawEcosystem || "<missing>"}.`,
-      "ERR_DEPENDENCY_DECLARATION_SOURCE_CONTRACT"
-    );
-  }
+  const contract = validateDependencyDeclarationSourceContract(sourceType, ecosystem);
+  const format = contract.format;
+  const normalizedType = contract.sourceType;
   const wantedKeys = new Set();
   for (const name of Array.isArray(wantedNames) ? wantedNames : []) {
     const key = declarationKey(name, format);
@@ -114,6 +107,24 @@ function buildDependencyDeclarationIndex({
     bySelector: state.bySelector,
     truncated: state.truncated,
     declarationCount: state.count,
+  });
+}
+
+/** Validate source/ecosystem compatibility without parsing the source text. */
+function validateDependencyDeclarationSourceContract(sourceType, ecosystem) {
+  const normalizedType = String(sourceType || "").trim().toLowerCase();
+  const rawEcosystem = String(ecosystem || "").trim().toLowerCase();
+  const requiredEcosystem = EXACT_SOURCE_ECOSYSTEMS.get(normalizedType);
+  if (requiredEcosystem && rawEcosystem !== requiredEcosystem) {
+    throw new DependencyDeclarationIndexError(
+      `Dependency source type ${normalizedType} is incompatible with ecosystem ${rawEcosystem || "<missing>"}.`,
+      "ERR_DEPENDENCY_DECLARATION_SOURCE_CONTRACT"
+    );
+  }
+  return Object.freeze({
+    sourceType: normalizedType,
+    ecosystem: rawEcosystem,
+    format: canonicalFormat(ecosystem),
   });
 }
 
@@ -1126,5 +1137,6 @@ module.exports = {
   buildDependencyDeclarationIndex,
   findDependencyDeclarationOffsets,
   offsetRangesToSourceRanges,
+  validateDependencyDeclarationSourceContract,
   validateSourceRanges,
 };

--- a/util/diagnosticsPublisher.js
+++ b/util/diagnosticsPublisher.js
@@ -12,6 +12,7 @@ const {
   buildDependencyDeclarationIndex,
   findDependencyDeclarationOffsets,
   offsetRangesToSourceRanges,
+  validateDependencyDeclarationSourceContract,
   validateSourceRanges,
 } = require("./dependencyDeclarationIndex");
 const { readUtf8 } = require("./lockfileParsers/shared");
@@ -254,31 +255,40 @@ class DiagnosticsPublisher {
       if (typeof content !== "string") {
         throw new TypeError("Dependency source readers must return UTF-8 text.");
       }
+      validateDependencyDeclarationSourceContract(
+        group.source.type,
+        group.indexingContract.ecosystem
+      );
 
       const rangedCandidates = group.candidates.filter((candidate) => (
         candidate.occurrence.sourceManifest.range
       ));
-      validateSourceRanges(
-        content,
-        rangedCandidates.map((candidate) => candidate.occurrence.sourceManifest.range),
-        isCancelled
-      );
+      if (rangedCandidates.length > 0) {
+        validateSourceRanges(
+          content,
+          rangedCandidates.map((candidate) => candidate.occurrence.sourceManifest.range),
+          isCancelled
+        );
+      }
       const candidatesNeedingIndex = group.candidates.filter((candidate) => (
         !candidate.occurrence.sourceManifest.range
       ));
-      const wantedNames = candidatesNeedingIndex.map((candidate) => (
-        candidate.occurrence.declarationName
-      ));
-      const index = this._buildIndex({
-        content,
-        sourceType: group.source.type,
-        ecosystem: group.indexingContract.ecosystem,
-        wantedNames,
-        shouldCancel: isCancelled,
-      });
-      indexedSources += 1;
-      if (index.truncated) {
-        truncatedSourceIndexes += 1;
+      let index = null;
+      if (candidatesNeedingIndex.length > 0) {
+        const wantedNames = candidatesNeedingIndex.map((candidate) => (
+          candidate.occurrence.declarationName
+        ));
+        index = this._buildIndex({
+          content,
+          sourceType: group.source.type,
+          ecosystem: group.indexingContract.ecosystem,
+          wantedNames,
+          shouldCancel: isCancelled,
+        });
+        indexedSources += 1;
+        if (index.truncated) {
+          truncatedSourceIndexes += 1;
+        }
       }
 
       const plans = [];
@@ -293,6 +303,9 @@ class DiagnosticsPublisher {
           continue;
         }
 
+        if (!index) {
+          throw new TypeError("A dependency declaration index is required for missing source ranges.");
+        }
         const offsets = findDependencyDeclarationOffsets(index, candidate.occurrence);
         if (offsets.length === 0) {
           plans.push({ candidate, range: fileLevelRange(), precision: "file" });


### PR DESCRIPTION
### Summary

- Skip empty exact-range validation and declaration indexing when source candidates already provide validated exact provenance.
- Prevent irrelevant declaration-parser failures and index accounting for exact-range-only sources while preserving source/ecosystem contract checks.
- Derive source-contract format values from the stored normalized ecosystem and protect the cross-field invariant for case, whitespace, and ecosystem aliases.
- Add exact-only, malformed-source, mixed, index-required, and truncated-index regression coverage.

### Validation

- `npm run lint` - passed
- `npm test` - passed
- `./node_modules/.bin/vscode-test --run test/diagnosticsPublisher.test.js` - passed
- `git diff --check` - passed
