### PR TITLE
fix: make authentication and provider state atomic

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,12 @@ const { helpProvider } = require("./views/helpProvider");
 const { SearchProvider } = require("./views/searchProvider");
 const { CloudsmithAPI } = require("./util/cloudsmithAPI");
 const { apiEndpoint } = require("./util/apiEndpoint");
-const { CredentialManager } = require("./util/credentialManager");
+const { CredentialManager, runCLIAutoDetect } = require("./util/credentialManager");
+const {
+  ConnectionManager,
+  bindConnectionManager,
+  getConnectionManager,
+} = require("./util/connectionManager");
 const { RecentSearches } = require("./util/recentSearches");
 const { RemediationHelper } = require("./util/remediationHelper");
 const {
@@ -33,6 +38,11 @@ const { fetchRepositoryUpstreams, generateTerraformConfig } = require("./util/te
 const { SUPPORTED_UPSTREAM_FORMATS } = require("./util/upstreamFormats");
 const { buildPackageGroupUrl, buildPackageUrl } = require("./util/webAppUrls");
 const recentPackages = require("./util/recentPackages");
+const filterState = require("./util/filterState");
+const { clearVulnerabilityCache } = require("./util/dependencyVulnEnricher");
+const { WorkspaceCache } = require("./util/workspaceCache");
+const { getWorkspaceContextProjector } = require("./util/workspaceContextProjector");
+const { captureAccount, isAccountCurrent } = require("./util/accountOperation");
 
 let exportTerraformAbortController = null;
 
@@ -308,11 +318,6 @@ const FILTER_PRESETS = [
 const FORMAT_OPTIONS = SUPPORTED_UPSTREAM_FORMATS;
 
 /**
- * Helper: get workspaces from cache or fetch fresh.
- */
-const WORKSPACE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-
-/**
  * Helper: read the defaultWorkspace setting.
  * Returns the slug string if set, or empty string if not.
  */
@@ -321,16 +326,66 @@ function getDefaultWorkspace() {
   return config.get("defaultWorkspace") || "";
 }
 
-async function setConnectedContext(isConnected) {
-  await vscode.commands.executeCommand("setContext", "cloudsmith.connected", Boolean(isConnected));
+async function setHasMultipleWorkspacesContext(context, hasMultipleWorkspaces, options = {}) {
+  const projector = options.workspaceContextProjector
+    || getWorkspaceContextProjector(context);
+  return projector.project(hasMultipleWorkspaces, options);
 }
 
-async function setHasMultipleWorkspacesContext(hasMultipleWorkspaces) {
-  await vscode.commands.executeCommand(
-    "setContext",
-    "cloudsmith.hasMultipleWorkspaces",
-    Boolean(hasMultipleWorkspaces)
+async function evictPersistedUpstreamCaches(context) {
+  const accountCacheKeys = typeof context?.globalState?.keys === "function"
+    ? context.globalState.keys().filter(key => key.startsWith("cloudsmith-upstreams:"))
+    : [];
+  const evictions = await Promise.allSettled(
+    accountCacheKeys.map(key => context.globalState.update(key, undefined))
   );
+  const complete = evictions.every(result => result.status === "fulfilled");
+  if (!complete) {
+    console.warn("[Cloudsmith] Some stale account cache entries could not be evicted.");
+  }
+  return complete;
+}
+
+async function resetAccountScopedState(context, options = {}) {
+  const synchronousInvalidators = [
+    () => options.workspaceCache?.clear?.(),
+    () => options.searchProvider?.clear?.(),
+    () => (options.filterState || filterState).clear(),
+    () => (options.recentPackages || recentPackages).clear(),
+    () => (options.clearVulnerabilityCache || clearVulnerabilityCache)(),
+  ];
+  const syncFailures = [];
+  for (const invalidate of synchronousInvalidators) {
+    try {
+      invalidate();
+    } catch (error) {
+      syncFailures.push(error);
+    }
+  }
+
+  // Start each fallible authority projection independently. A rejected tree or
+  // context update must not retain another cache from the previous account.
+  const asynchronousInvalidators = [
+    () => options.dependencyHealthProvider?.resetForAccountChange?.(),
+    () => (options.projectHasMultipleWorkspaces
+      ? options.projectHasMultipleWorkspaces(false)
+      : setHasMultipleWorkspacesContext(context, false, {
+        workspaceContextProjector: options.workspaceContextProjector,
+      })),
+    () => (options.evictPersistedUpstreamCaches || evictPersistedUpstreamCaches)(context),
+  ];
+  const pending = asynchronousInvalidators.map(invalidate => {
+    try {
+      return Promise.resolve(invalidate());
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+  const asyncResults = await Promise.allSettled(pending);
+  return Object.freeze({
+    syncFailures: Object.freeze([...syncFailures]),
+    asyncResults: Object.freeze(asyncResults),
+  });
 }
 
 async function updateDefaultWorkspaceContext() {
@@ -341,28 +396,39 @@ async function updateDefaultWorkspaceContext() {
   );
 }
 
-async function getWorkspaces(context) {
-    const cache = context.globalState.get('CloudsmithCache');
-    if (cache && cache.name === 'Workspaces' && cache.workspaces) {
-        // Check TTL — treat as stale if older than 30 minutes
-        if (cache.lastSync && (Date.now() - cache.lastSync) < WORKSPACE_CACHE_TTL_MS) {
-            await setHasMultipleWorkspacesContext(cache.workspaces.length > 1);
-            return cache.workspaces;
-        }
+async function getWorkspaces(context, options = {}) {
+    const connectionManager = options.connectionManager || getConnectionManager(context);
+    const workspaceContextProjector = options.workspaceContextProjector
+      || getWorkspaceContextProjector(context);
+    const account = captureAccount(connectionManager);
+    if (!account) {
+        await setHasMultipleWorkspacesContext(context, false, { workspaceContextProjector });
+        return null;
     }
-    const cloudsmithAPI = new CloudsmithAPI(context);
+    const projection = workspaceContextProjector.begin({
+      isCurrent: () => isAccountCurrent(connectionManager, account),
+    });
+    const cloudsmithAPI = options.createCloudsmithAPI
+      ? options.createCloudsmithAPI()
+      : new CloudsmithAPI(context);
     const result = await cloudsmithAPI.get("namespaces/?sort=slug", {
         responseType: "array",
         validate: isWorkspaceArray,
         retry: "safe-read",
     });
+    if (!isAccountCurrent(connectionManager, account)) {
+        await workspaceContextProjector.project(true, { operation: projection });
+        return null;
+    }
     if (!result.ok) {
-        await setHasMultipleWorkspacesContext(false);
+        await workspaceContextProjector.project(false, { operation: projection });
+        if (!isAccountCurrent(connectionManager, account)) return null;
         vscode.window.showErrorMessage(`Failed to load workspaces: ${formatApiError(result.error)}`);
         return null;
     }
     if (result.data.length === 0) {
-        await setHasMultipleWorkspacesContext(false);
+        await workspaceContextProjector.project(false, { operation: projection });
+        if (!isAccountCurrent(connectionManager, account)) return null;
         return [];
     }
     const workspaces = result.data.map(workspace => ({
@@ -371,7 +437,11 @@ async function getWorkspaces(context) {
             ? workspace.name
             : workspace.slug,
     }));
-    await setHasMultipleWorkspacesContext(workspaces.length > 1);
+    await workspaceContextProjector.project(workspaces.length > 1, { operation: projection });
+    if (!isAccountCurrent(connectionManager, account)) {
+        await workspaceContextProjector.project(true, { operation: projection });
+        return null;
+    }
     return workspaces;
 }
 
@@ -403,6 +473,70 @@ function buildPresetQuery(preset, customQuery) {
     return maybeString;
   }
   return builder.build();
+}
+
+function searchDescriptorFromRecent(entry) {
+  const scope = entry && entry.scope;
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) return null;
+  const scopeKeys = Object.keys(scope).sort().join(",");
+  if (
+    scope.kind === "repository"
+    && scopeKeys === "kind,repository"
+    && typeof scope.repository === "string"
+  ) {
+    return {
+      kind: "repository",
+      workspace: entry.workspace,
+      repository: scope.repository,
+      query: entry.query,
+      page: 1,
+    };
+  }
+  if (
+    scope.kind === "repositories"
+    && scopeKeys === "kind,repositories"
+    && Array.isArray(scope.repositories)
+  ) {
+    return {
+      kind: "repositories",
+      workspace: entry.workspace,
+      repositories: scope.repositories,
+      query: entry.query,
+      page: 1,
+    };
+  }
+  return scope.kind === "workspace" && scopeKeys === "kind"
+    ? {
+      kind: "workspace",
+      workspace: entry.workspace,
+      query: entry.query,
+      page: 1,
+    }
+    : null;
+}
+
+async function executeSearchIntent(searchProvider, descriptor, options = {}) {
+  const operation = searchProvider.beginSearch(descriptor);
+  const execution = searchProvider.executeSearch(operation);
+  if (options.recentSearches && options.record) {
+    const ownedDescriptor = operation.descriptor;
+    let scope = { kind: "workspace" };
+    if (ownedDescriptor.kind === "repository") {
+      scope = { kind: "repository", repository: ownedDescriptor.repository };
+    } else if (ownedDescriptor.kind === "repositories") {
+      scope = { kind: "repositories", repositories: ownedDescriptor.repositories };
+    }
+    // History persistence is deliberately detached: it must never delay or
+    // supersede execution of the synchronously owned search operation.
+    Promise.resolve().then(() => options.recentSearches.add({
+      workspace: ownedDescriptor.workspace,
+      query: ownedDescriptor.query,
+      scope,
+    })).catch(() => {
+      console.warn("[Cloudsmith] Could not save the recent search.");
+    });
+  }
+  return execution;
 }
 
 async function resolveDependencyScanTarget(context, options = {}) {
@@ -661,15 +795,27 @@ async function showDependencySortFilterPicker(provider) {
  * @param {vscode.ExtensionContext} context
  */
 async function activate(context) {
+  const connectionManager = new ConnectionManager(context);
+  const connectionBinding = bindConnectionManager(context, connectionManager);
+  context.subscriptions.push(connectionBinding, connectionManager);
 
-  await context.secrets.store("cloudsmith-vsc.isConnected", "false");
-  await setConnectedContext(false);
-  await setHasMultipleWorkspacesContext(false);
+  // Persisted upstream summaries are account-bound. Purge them before the
+  // initial SecretStorage read so an indeterminate startup cannot retain data
+  // from a prior activation or account.
+  await evictPersistedUpstreamCaches(context);
+  const workspaceContextProjector = getWorkspaceContextProjector(context);
+  context.subscriptions.push(workspaceContextProjector);
+  await setHasMultipleWorkspacesContext(context, false, { workspaceContextProjector });
   await updateDefaultWorkspaceContext();
 
-
   // Define main view provider which populates with data
-  const cloudsmithProvider = new CloudsmithProvider(context);
+  const workspaceCache = new WorkspaceCache(connectionManager);
+  const cloudsmithProvider = new CloudsmithProvider(context, {
+    connectionManager,
+    workspaceCache,
+    workspaceContextProjector,
+  });
+  context.subscriptions.push({ dispose: () => cloudsmithProvider.dispose() });
   const treeView = vscode.window.createTreeView("cloudsmithView", {
     treeDataProvider: cloudsmithProvider,
     showCollapseAll: true,
@@ -708,7 +854,7 @@ async function activate(context) {
   vscode.window.registerTreeDataProvider("helpView", provider);
 
   // Set Package Search view.
-  const searchProvider = new SearchProvider(context);
+  const searchProvider = new SearchProvider(context, { connectionManager });
   vscode.window.createTreeView("cloudsmithSearchView", {
     treeDataProvider: searchProvider,
     showCollapseAll: true,
@@ -717,31 +863,40 @@ async function activate(context) {
   // Set Dependency Health view with diagnostics publisher.
   const diagnosticsPublisher = new DiagnosticsPublisher();
   context.subscriptions.push(diagnosticsPublisher);
-  const dependencyHealthProvider = new DependencyHealthProvider(context, diagnosticsPublisher);
+  const dependencyHealthProvider = new DependencyHealthProvider(context, diagnosticsPublisher, {
+    connectionManager,
+  });
+  context.subscriptions.push(
+    { dispose: () => searchProvider.dispose() },
+    { dispose: () => dependencyHealthProvider.dispose() }
+  );
   vscode.window.createTreeView("cloudsmithDependencyHealthView", {
     treeDataProvider: dependencyHealthProvider,
     showCollapseAll: false,
   });
 
-  context.subscriptions.push(
-    context.secrets.onDidChange(async (e) => {
-      if (e.key !== "cloudsmith-vsc.authToken") {
-        return;
-      }
+  let projectedAccountEpoch = connectionManager.getState().accountEpoch;
+  const handleConnectionStateChange = async (state) => {
+    if (state.accountEpoch !== projectedAccountEpoch) {
+      projectedAccountEpoch = state.accountEpoch;
+      await resetAccountScopedState(context, {
+        workspaceCache,
+        searchProvider,
+        dependencyHealthProvider,
+        workspaceContextProjector,
+      });
+    }
 
-      const apiKey = await context.secrets.get("cloudsmith-vsc.authToken");
-      if (apiKey) {
-        return;
-      }
-
-      await context.secrets.store("cloudsmith-vsc.isConnected", "false");
-      await setConnectedContext(false);
-      await setHasMultipleWorkspacesContext(false);
-      cloudsmithProvider.refresh({ suppressMissingCredentialsWarning: true });
-      searchProvider.refresh();
-      dependencyHealthProvider.refresh();
-    })
-  );
+    cloudsmithProvider.refresh({ suppressMissingCredentialsWarning: !state.credentialPresent });
+    searchProvider.refresh();
+    dependencyHealthProvider.refresh();
+  };
+  const connectionSubscription = connectionManager.onDidChange(state => {
+    void handleConnectionStateChange(state).catch(error => {
+      console.warn("[Cloudsmith] Could not refresh all account-scoped state:", error);
+    });
+  });
+  context.subscriptions.push(connectionSubscription);
 
   // Create vulnerability WebView provider
   const vulnerabilityProvider = new VulnerabilityProvider(context);
@@ -766,40 +921,45 @@ async function activate(context) {
   // Create promotion provider
   const promotionProvider = new PromotionProvider(context);
 
-  const initializeConnectionContext = async () => {
-    const credentialManager = new CredentialManager(context);
-    const apiKey = await credentialManager.getApiKey();
-    if (!apiKey) {
-      return;
+  const credentialManager = new CredentialManager(context, { connectionManager });
+  const ssoManager = new SSOAuthManager(context, { connectionManager });
+
+  async function handleAuthenticationResult(result, options = {}) {
+    if (!result || result.status === "stale" || result.status === "cancelled") {
+      return result;
     }
 
-    try {
-      const { ConnectionManager } = require("./util/connectionManager");
-      const connectionManager = new ConnectionManager(context);
-      await connectionManager.checkConnectivity(apiKey);
-    } catch {
-      await context.secrets.store("cloudsmith-vsc.isConnected", "false");
-      await setConnectedContext(false);
+    const state = connectionManager.getState();
+    if (result.partial && result.committed) {
+      const outcome = state.credentialPresent === false
+        ? "Credentials were cleared"
+        : "Credentials were saved and validated";
+      const detail = result.error && result.error.message
+        ? ` ${result.error.message}`
+        : "";
+      vscode.window.showWarningMessage(
+        `${outcome}, but the connection indicator could not be updated.${detail}`
+      );
+      return result;
     }
-  };
+    if (!result.ok || !state.sessionConnected) {
+      if (result.committed && state.credentialPresent === false) {
+        vscode.window.showInformationMessage("Credentials cleared.");
+      } else if (options.reportFailure !== false && result.error && result.error.message) {
+        if (state.sessionConnected) {
+          vscode.window.showWarningMessage(result.error.message);
+        } else {
+          vscode.window.showErrorMessage(result.error.message);
+        }
+      }
+      return result;
+    }
 
-  void initializeConnectionContext();
-
-
-  // Shared post-authentication handler: connect, refresh all views, and prompt
-  // to set default workspace if only one workspace is available.
-  async function postAuthSuccess() {
-    const { ConnectionManager } = require("./util/connectionManager");
-    const connectionManager = new ConnectionManager(context);
-    const status = await connectionManager.connect();
-
-    // Refresh all three sidebar views
-    cloudsmithProvider.refresh();
-    searchProvider.refresh();
-    dependencyHealthProvider.refresh();
-
-    // If connected and no default workspace, offer to set the single workspace as default
-    if (status === "true" && !getDefaultWorkspace()) {
+    if (options.showSuccess !== false) {
+      vscode.window.showInformationMessage("Connected to Cloudsmith.");
+    }
+    // If connected and no default workspace, offer to set the single workspace as default.
+    if (options.offerDefault !== false && !getDefaultWorkspace()) {
       const workspaces = await getWorkspaces(context);
       if (Array.isArray(workspaces) && workspaces.length === 1) {
         const ws = workspaces[0];
@@ -817,42 +977,42 @@ async function activate(context) {
         }
       }
     }
-
-    return status;
+    return result;
   }
+
+  const initializationResult = await connectionManager.initialize();
+  await handleAuthenticationResult(initializationResult, {
+    showSuccess: false,
+    offerDefault: false,
+    reportFailure: false,
+  });
 
   // Auto-detect Cloudsmith CLI credentials on activation.
   // If no API key is stored but CLI credentials exist, offer to import them.
-  setTimeout(async () => {
-    const existingKey = await context.secrets.get("cloudsmith-vsc.authToken");
-    if (!existingKey) {
-      const ssoManager = new SSOAuthManager(context);
-      if (ssoManager.hasCLICredentials()) {
-        const choice = await vscode.window.showInformationMessage(
-          "Cloudsmith CLI credentials detected. Import them?",
-          "Import", "Dismiss"
-        );
-        if (choice === "Import") {
-          const success = await ssoManager.importFromCLI();
-          if (success) {
-            await postAuthSuccess();
-          }
-        }
-      }
-    }
+  const cliAutoDetectTimer = setTimeout(() => {
+    void runCLIAutoDetect({
+      connectionManager,
+      secrets: context.secrets,
+      ssoManager,
+      showInformationMessage: (...args) => vscode.window.showInformationMessage(...args),
+      handleAuthenticationResult,
+    }).catch(() => {
+      console.warn("[Cloudsmith] CLI credential auto-detection failed.");
+    });
   }, 3000);
+  context.subscriptions.push({ dispose: () => clearTimeout(cliAutoDetectTimer) });
 
   // register general commands. Will move this over to command Manager in future release.
   context.subscriptions.push(
     // Register command to clear credentials
-    vscode.commands.registerCommand("cloudsmith-vsc.clearCredentials", () => {
-      
-      const credentialManager = new CredentialManager(context);
-      credentialManager.clearCredentials();
+    vscode.commands.registerCommand("cloudsmith-vsc.clearCredentials", async () => {
+      const result = await credentialManager.clearCredentials();
+      await handleAuthenticationResult(result, { offerDefault: false });
     }),
 
     // Register command to set credentials — QuickPick with four auth methods
     vscode.commands.registerCommand("cloudsmith-vsc.configureCredentials", async () => {
+      const operation = connectionManager.beginCredentialOperation();
       const authOptions = [
         { label: "$(key) Enter API key", description: "Paste a personal API key", _method: "apikey" },
         { label: "$(server) Enter service account API key", description: "Paste a service account API key", _method: "apikey" },
@@ -864,25 +1024,24 @@ async function activate(context) {
         placeHolder: "Select an authentication method",
       });
       if (!selected) {
+        await connectionManager.cancelCredentialOperation(operation);
         return;
       }
 
       if (selected._method === "sso-terminal") {
-        await vscode.commands.executeCommand("cloudsmith-vsc.ssoLogin");
+        await vscode.commands.executeCommand("cloudsmith-vsc.ssoLogin", operation);
       } else if (selected._method === "import") {
-        await vscode.commands.executeCommand("cloudsmith-vsc.importCLICredentials");
+        await vscode.commands.executeCommand("cloudsmith-vsc.importCLICredentials", operation);
       } else {
-        const credentialManager = new CredentialManager(context);
-        const stored = await credentialManager.storeApiKey();
-        if (stored) {
-          await postAuthSuccess();
-        }
+        const result = await credentialManager.storeApiKey(operation);
+        await handleAuthenticationResult(result);
       }
     }),
 
     // Register command to connect to Cloudsmith
     vscode.commands.registerCommand("cloudsmith-vsc.connectCloudsmith", async () => {
-      await postAuthSuccess();
+      const result = await connectionManager.initialize();
+      await handleAuthenticationResult(result);
     }),
 
     // Register set default workspace command
@@ -1163,7 +1322,7 @@ async function activate(context) {
         recentSearches = new RecentSearches(context, workspaceSlug);
       }
 
-      const recent = recentSearches.getAll();
+      const recent = await recentSearches.getAll();
       if (recent.length > 0) {
         const items = [
           { label: "Recent searches", kind: vscode.QuickPickItemKind.Separator },
@@ -1185,7 +1344,10 @@ async function activate(context) {
           return;
         }
         if (selected._recent) {
-          await searchProvider.search(selected._recent.workspace, selected._recent.query);
+          await executeSearchIntent(
+            searchProvider,
+            searchDescriptorFromRecent(selected._recent)
+          );
           return;
         }
       }
@@ -1200,8 +1362,12 @@ async function activate(context) {
       }
 
       const builtQuery = buildRawSearchQuery(query);
-      recentSearches.add({ workspace: workspaceSlug, query: builtQuery, scope: 'workspace' });
-      await searchProvider.search(workspaceSlug, builtQuery);
+      await executeSearchIntent(searchProvider, {
+        kind: "workspace",
+        workspace: workspaceSlug,
+        query: builtQuery,
+        page: 1,
+      }, { recentSearches, record: true });
     }),
 
     // Register clear search command
@@ -1238,8 +1404,12 @@ async function activate(context) {
 
       const recentSearches = new RecentSearches(context, workspace);
       const builtQuery = buildRawSearchQuery(query);
-      recentSearches.add({ workspace: workspace, query: builtQuery, scope: 'workspace' });
-      await searchProvider.search(workspace, builtQuery);
+      await executeSearchIntent(searchProvider, {
+        kind: "workspace",
+        workspace,
+        query: builtQuery,
+        page: 1,
+      }, { recentSearches, record: true });
     }),
 
     // Register guided search command
@@ -1274,7 +1444,7 @@ async function activate(context) {
         recentSearches = new RecentSearches(context, workspaceSlug);
       }
 
-      const recent = recentSearches.getAll();
+      const recent = await recentSearches.getAll();
       if (recent.length > 0) {
         const recentItems = [
           { label: "Recent searches", kind: vscode.QuickPickItemKind.Separator },
@@ -1296,7 +1466,10 @@ async function activate(context) {
           return;
         }
         if (selectedRecent._recent) {
-          await searchProvider.search(selectedRecent._recent.workspace, selectedRecent._recent.query);
+          await executeSearchIntent(
+            searchProvider,
+            searchDescriptorFromRecent(selectedRecent._recent)
+          );
           return;
         }
       }
@@ -1403,19 +1576,13 @@ async function activate(context) {
       }
       const finalQuery = finalBuilder.build() || '*';
 
-      // Save to recent searches
-      recentSearches.add({
+      await executeSearchIntent(searchProvider, {
+        kind: selectedRepos ? "repositories" : "workspace",
         workspace: workspaceSlug,
         query: finalQuery,
-        scope: selectedRepos ? 'repository' : 'workspace',
-      });
-
-      // Execute search
-      if (selectedRepos) {
-        await searchProvider.searchRepos(workspaceSlug, selectedRepos, finalQuery);
-      } else {
-        await searchProvider.search(workspaceSlug, finalQuery);
-      }
+        page: 1,
+        ...(selectedRepos ? { repositories: selectedRepos } : {}),
+      }, { recentSearches, record: true });
     }),
 
     // Register filter packages command (right-click repo in main tree)
@@ -1961,8 +2128,12 @@ async function activate(context) {
 
       const query = selectedLicense.query || LicenseClassifier.buildLicenseQuery(selectedLicense.label);
       const recentSearches = new RecentSearches(context, workspaceSlug);
-      recentSearches.add({ workspace: workspaceSlug, query: query, scope: "workspace" });
-      await searchProvider.search(workspaceSlug, query);
+      await executeSearchIntent(searchProvider, {
+        kind: "workspace",
+        workspace: workspaceSlug,
+        query,
+        page: 1,
+      }, { recentSearches, record: true });
     }),
 
     // Register open license URL command
@@ -1992,39 +2163,38 @@ async function activate(context) {
 
     // Register SSO login command — uses terminal flow by default,
     // experimental browser flow if the setting is enabled
-    vscode.commands.registerCommand("cloudsmith-vsc.ssoLogin", async () => {
+    vscode.commands.registerCommand("cloudsmith-vsc.ssoLogin", async (suppliedOperation = null) => {
+      const operation = suppliedOperation || connectionManager.beginCredentialOperation();
+      if (!connectionManager.isOperationCurrent(operation)) {
+        return;
+      }
       const workspaceSlug = await vscode.window.showInputBox({
         placeHolder: "my-org",
         prompt: "Enter the Cloudsmith workspace slug for SSO",
         ignoreFocusOut: true,
       });
       if (!workspaceSlug) {
+        await connectionManager.cancelCredentialOperation(operation);
         return;
       }
 
-      const ssoManager = new SSOAuthManager(context);
       const ssoConfig = vscode.workspace.getConfiguration("cloudsmith-vsc");
       const useExperimental = ssoConfig.get("experimentalSSOBrowser");
 
-      let success;
+      let result;
       if (useExperimental) {
-        success = await ssoManager.loginViaBrowser(workspaceSlug.trim());
+        result = await ssoManager.loginViaBrowser(workspaceSlug.trim(), operation);
       } else {
-        success = await ssoManager.loginViaTerminal(workspaceSlug.trim());
+        result = await ssoManager.loginViaTerminal(workspaceSlug.trim(), operation);
       }
-
-      if (success) {
-        await postAuthSuccess();
-      }
+      await handleAuthenticationResult(result);
     }),
 
     // Register import CLI credentials command
-    vscode.commands.registerCommand("cloudsmith-vsc.importCLICredentials", async () => {
-      const ssoManager = new SSOAuthManager(context);
-      const success = await ssoManager.importFromCLI();
-      if (success) {
-        await postAuthSuccess();
-      }
+    vscode.commands.registerCommand("cloudsmith-vsc.importCLICredentials", async (suppliedOperation = null) => {
+      const operation = suppliedOperation || connectionManager.beginCredentialOperation();
+      const result = await ssoManager.importFromCLI(operation);
+      await handleAuthenticationResult(result);
     }),
 
     // Register show install command (opens in new document)
@@ -2568,6 +2738,11 @@ function deactivate() {}
 module.exports = {
   activate,
   deactivate,
+  evictPersistedUpstreamCaches,
+  executeSearchIntent,
   FORMAT_OPTIONS,
+  getWorkspaces,
+  resetAccountScopedState,
   runDependencyScan,
+  searchDescriptorFromRecent,
 };

--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -465,7 +465,7 @@ class DependencyHealthNode {
         slug_perm: this.cloudsmithMatch.slug_perm,
         num_vulnerabilities: vulnerabilities.count,
         max_severity: vulnerabilities.maxSeverity,
-      }, this.context));
+      }, this.context, { connectionManager: this.options.connectionManager }));
     }
 
     const policy = this._getPolicyData();

--- a/models/packageNode.js
+++ b/models/packageNode.js
@@ -6,8 +6,9 @@ const { getFormatIconPath } = require("../util/formatIcons");
 const { getPackageVulnerabilityCount } = require("../util/packageVulnerabilities");
 
 class PackageNode {
-  constructor(pkg, context) {
+  constructor(pkg, context, options = {}) {
     this.context = context;
+    this._connectionManager = options.connectionManager || null;
     this.slug = { id: "Slug", value: pkg.slug };
     this.slug_perm = { id: "Slug", value: pkg.slug_perm };
     this.name = pkg.name;
@@ -213,7 +214,7 @@ class PackageNode {
         slug_perm: this.slug_perm_raw,
         num_vulnerabilities: this.num_vulnerabilities,
         max_severity: this.max_severity,
-      }, this.context));
+      }, this.context, { connectionManager: this._connectionManager }));
     }
 
     // 5. Quarantine Reason (if quarantined)

--- a/models/repositoryNode.js
+++ b/models/repositoryNode.js
@@ -12,10 +12,19 @@ const UpstreamIndicatorNode = require("./upstreamIndicatorNode");
 const { activeFilters } = require("../util/filterState");
 const InfoNode = require("./infoNode");
 const { EntitlementSummaryNode } = require("./entitlementNode");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
 
 class RepositoryNode {
-  constructor(repo, workspace, context) {
+  constructor(repo, workspace, context, options = {}) {
     this.context = context;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._createCloudsmithAPI = options.createCloudsmithAPI
+      || (() => new CloudsmithAPI(this.context));
+    this._upstreamChecker = options.upstreamChecker || upstreamChecker;
     this.slug = repo.slug;
     this.slug_perm = repo.slug_perm;
     this.name = repo.name;
@@ -105,7 +114,9 @@ class RepositoryNode {
   }
 
   async getPackages() {
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
+    const cloudsmithAPI = this._createCloudsmithAPI();
     let packages = '';
     
 
@@ -116,6 +127,7 @@ class RepositoryNode {
     const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
     const maxPackages = await config.get("showMaxPackages"); // get legacy app setting from configuration settings
     const groupByPackageGroup = await config.get("groupByPackageGroups");
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
 
     const activeFilter = this._getActiveFilter();
     const filterQuery = activeFilter ? (activeFilter.query || activeFilter) : null;
@@ -154,9 +166,11 @@ class RepositoryNode {
         }
       }
     } catch {
+      if (!isAccountCurrent(this._connectionManager, account)) return [];
       apiFailed = true;
       packages = [];
     }
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
     this._lastApiFailed = apiFailed;
 
     const PackageNodes = [];
@@ -164,7 +178,9 @@ class RepositoryNode {
       for (const pkg of packages) {
         if (!groupByPackageGroup) {
           const packageNode = require("./packageNode");
-          let packageNodeInst = new packageNode(pkg, this.context);
+          let packageNodeInst = new packageNode(pkg, this.context, {
+            connectionManager: this._connectionManager,
+          });
           PackageNodes.push(packageNodeInst);
         } else {
           const packageGroupsNode = require("./packageGroupsNode");
@@ -186,27 +202,43 @@ class RepositoryNode {
    * @returns {Array} Array of upstream config objects (may be empty).
    */
   async getUpstreams(packageNodes = []) {
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
     const inferredFormats = this._inferUpstreamFormats(packageNodes);
     if (inferredFormats.length === 0) {
-      return this._getUpstreamList(
-        await upstreamChecker.getAllUpstreamData(this.context, this.workspace, this.slug)
+      const result = await this._upstreamChecker.getAllUpstreamData(
+        this.context,
+        this.workspace,
+        this.slug,
+        { account, connectionManager: this._connectionManager }
       );
+      return isAccountCurrent(this._connectionManager, account)
+        ? this._getUpstreamList(result)
+        : [];
     }
 
-    const hintedResult = await upstreamChecker.getUpstreamDataForFormats(
+    const hintedResult = await this._upstreamChecker.getUpstreamDataForFormats(
       this.context,
       this.workspace,
       this.slug,
-      inferredFormats
+      inferredFormats,
+      { account, connectionManager: this._connectionManager }
     );
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
 
     if (this._hasCompleteUpstreamCoverage(inferredFormats)) {
       return this._getUpstreamList(hintedResult);
     }
 
-    return this._getUpstreamList(
-      await upstreamChecker.getAllUpstreamData(this.context, this.workspace, this.slug)
+    const result = await this._upstreamChecker.getAllUpstreamData(
+      this.context,
+      this.workspace,
+      this.slug,
+      { account, connectionManager: this._connectionManager }
     );
+    return isAccountCurrent(this._connectionManager, account)
+      ? this._getUpstreamList(result)
+      : [];
   }
 
   _getUpstreamList(result) {
@@ -252,7 +284,9 @@ class RepositoryNode {
    * @returns {Array} Array of entitlement objects.
    */
   async getEntitlements() {
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
+    const cloudsmithAPI = this._createCloudsmithAPI();
     let endpoint;
     try {
       endpoint = apiEndpoint(["entitlements", this.workspace, this.slug], {
@@ -266,6 +300,7 @@ class RepositoryNode {
       validate: isEntitlementArray,
       retry: "safe-read",
     });
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
     if (!result.ok) {
       throw result.error;
     }
@@ -273,7 +308,10 @@ class RepositoryNode {
   }
 
   async getChildren() {
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
     const packages = await this.getPackages();
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
     const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
     const showEntitlements = config.get("showEntitlements");
 
@@ -282,6 +320,7 @@ class RepositoryNode {
     // Fetch upstreams lazily (only when repo is expanded)
     if (packages.length > 0) {
       const upstreams = await this.getUpstreams(packages);
+      if (!isAccountCurrent(this._connectionManager, account)) return [];
       if (upstreams.length > 0) {
         children.push(new UpstreamIndicatorNode(
           upstreams,
@@ -314,10 +353,12 @@ class RepositoryNode {
     if (showEntitlements) {
       try {
         const entitlements = await this.getEntitlements();
+        if (!isAccountCurrent(this._connectionManager, account)) return [];
         if (entitlements.length > 0) {
           children.push(new EntitlementSummaryNode(entitlements, this.context));
         }
       } catch (e) {
+        if (!isAccountCurrent(this._connectionManager, account)) return [];
         children.push(new InfoNode(
           "Entitlements: failed to load",
           "",
@@ -364,7 +405,7 @@ class RepositoryNode {
       children.push(node);
     }
 
-    return children;
+    return isAccountCurrent(this._connectionManager, account) ? children : [];
   }
 }
 

--- a/models/searchResultNode.js
+++ b/models/searchResultNode.js
@@ -8,8 +8,9 @@ const { LicenseClassifier } = require("../util/licenseClassifier");
 const { getPackageVulnerabilityCount } = require("../util/packageVulnerabilities");
 
 class SearchResultNode {
-    constructor(pkg, context) {
+    constructor(pkg, context, options = {}) {
         this.context = context;
+        this._connectionManager = options.connectionManager || null;
 
         // Store fields matching PackageNode's shape so existing commands work
         this.name = pkg.name;
@@ -54,14 +55,14 @@ class SearchResultNode {
         this.security_scan_status = pkg.security_scan_status || null;
 
         // License fields from API response (may be absent in list endpoint)
-        this.licenseInfo = LicenseClassifier.inspect(pkg);
+        this.licenseInfo = cloneCanonicalValue(LicenseClassifier.inspect(pkg));
         this.spdx_license = this.licenseInfo.spdxLicense;
         this.raw_license = this.licenseInfo.rawLicense;
         this.license = this.licenseInfo.displayValue;
         this.license_url = this.licenseInfo.licenseUrl;
 
         // Raw tags for upstream origin detection
-        this.tags_raw = pkg.tags || {};
+        this.tags_raw = cloneCanonicalValue(pkg.tags) || {};
 
         // Determine upstream origin from tags
         this.upstreamSource = this._detectUpstreamSource();
@@ -71,15 +72,15 @@ class SearchResultNode {
         };
 
         // Tags handling (same pattern as PackageNode)
-        if (pkg.tags && pkg.tags.info) {
-            if (pkg.tags.version) {
-                this.tags = { id: "Tags", value: String([pkg.tags.info, pkg.tags.version]) };
+        if (this.tags_raw.info) {
+            if (this.tags_raw.version) {
+                this.tags = { id: "Tags", value: String([this.tags_raw.info, this.tags_raw.version]) };
             } else {
-                this.tags = { id: "Tags", value: pkg.tags.info };
+                this.tags = { id: "Tags", value: this.tags_raw.info };
             }
         } else {
-            if (pkg.tags && pkg.tags.version) {
-                this.tags = { id: "Tags", value: pkg.tags.version };
+            if (this.tags_raw.version) {
+                this.tags = { id: "Tags", value: this.tags_raw.version };
             } else {
                 this.tags = { id: "Tags", value: "" };
             }
@@ -210,7 +211,7 @@ class SearchResultNode {
                 slug_perm: this.slug_perm_raw,
                 num_vulnerabilities: this.num_vulnerabilities,
                 max_severity: this.max_severity,
-            }, this.context));
+            }, this.context, { connectionManager: this._connectionManager }));
         }
 
         // 5. Quarantine Reason (if quarantined)
@@ -254,6 +255,30 @@ class SearchResultNode {
 
         return children;
     }
+}
+
+function cloneCanonicalValue(value, depth = 0) {
+    if (
+        value === null
+        || typeof value === "string"
+        || typeof value === "number"
+        || typeof value === "boolean"
+    ) {
+        return value;
+    }
+    if (depth >= 10) return null;
+    if (Array.isArray(value)) {
+        return value.map(item => cloneCanonicalValue(item, depth + 1));
+    }
+    if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+        const clone = {};
+        for (const [key, nested] of Object.entries(value)) {
+            const cloned = cloneCanonicalValue(nested, depth + 1);
+            if (cloned !== undefined) clone[key] = cloned;
+        }
+        return clone;
+    }
+    return undefined;
 }
 
 module.exports = SearchResultNode;

--- a/models/vulnerabilitySummaryNode.js
+++ b/models/vulnerabilitySummaryNode.js
@@ -11,16 +11,26 @@ const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { fetchPackageVulnerabilities } = require("../util/packageVulnerabilities");
 const { formatApiError } = require("../util/errorFormatter");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
 const VulnerabilityNode = require("./vulnerabilityNode");
 const InfoNode = require("./infoNode");
+
+const MAX_CACHED_VULNERABILITIES = 5000;
 
 class VulnerabilitySummaryNode {
   /**
    * @param {Object} pkgInfo
    * @param {vscode.ExtensionContext} context
    */
-  constructor(pkgInfo, context) {
+  constructor(pkgInfo, context, options = {}) {
     this.context = context;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._createCloudsmithAPI = options.createCloudsmithAPI
+      || (() => new CloudsmithAPI(this.context));
     this.workspace = pkgInfo.namespace;
     this.repo = pkgInfo.repository;
     this.slugPerm = pkgInfo.slug_perm || pkgInfo.slug_perm_raw;
@@ -97,7 +107,7 @@ class VulnerabilitySummaryNode {
    * @returns {Promise<Array>} Array of raw CVE result objects.
    */
   async _fetchVulnerabilities() {
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
+    const cloudsmithAPI = this._createCloudsmithAPI();
 
     const data = await fetchPackageVulnerabilities(
       cloudsmithAPI,
@@ -107,23 +117,38 @@ class VulnerabilitySummaryNode {
       this.numVulns
     );
 
-    this.numVulns = data.numVulns;
-    this.maxSeverity = data.maxSeverity;
-
     if (data.error) {
       throw new Error(formatApiError(data.error));
     }
 
-    return data.results;
+    return data;
   }
 
   async getChildren() {
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
     try {
+      if (
+        this._cachedChildren
+        && (
+          this._cachedChildren.activationId !== account.activationId
+          || this._cachedChildren.accountEpoch !== account.accountEpoch
+        )
+      ) {
+        this._cachedChildren = null;
+      }
       if (!this._cachedChildren) {
-        const vulnResults = await this._fetchVulnerabilities();
+        const fetched = await this._fetchVulnerabilities();
+        if (!isAccountCurrent(this._connectionManager, account)) return [];
+        const vulnResults = Array.isArray(fetched) ? fetched : fetched.results;
+        if (!Array.isArray(vulnResults)) {
+          throw new Error("Cloudsmith returned invalid vulnerability data.");
+        }
 
         // Create VulnerabilityNode for each and sort once, then filter in-memory.
-        const nodes = vulnResults.map(vuln => new VulnerabilityNode(vuln, this.context));
+        const nodes = vulnResults
+          .slice(0, MAX_CACHED_VULNERABILITIES)
+          .map(vuln => new VulnerabilityNode(vuln, this.context));
 
         nodes.sort((a, b) => {
           if (a.severityOrder !== b.severityOrder) {
@@ -134,10 +159,20 @@ class VulnerabilitySummaryNode {
           return scoreB - scoreA;
         });
 
-        this._cachedChildren = nodes;
+        if (!isAccountCurrent(this._connectionManager, account)) return [];
+        if (!Array.isArray(fetched)) {
+          this.numVulns = fetched.numVulns;
+          this.maxSeverity = fetched.maxSeverity;
+        }
+        this._cachedChildren = Object.freeze({
+          activationId: account.activationId,
+          accountEpoch: account.accountEpoch,
+          nodes: Object.freeze(nodes),
+        });
       }
 
-      let filteredNodes = this._cachedChildren.slice();
+      if (!isAccountCurrent(this._connectionManager, account)) return [];
+      let filteredNodes = this._cachedChildren.nodes.slice();
 
       if (Array.isArray(this.severityFilter)) {
         filteredNodes = filteredNodes.filter(vuln =>
@@ -163,6 +198,7 @@ class VulnerabilitySummaryNode {
 
       return filteredNodes;
     } catch (e) {
+      if (!isAccountCurrent(this._connectionManager, account)) return [];
       // Don't cache error results — allow retry on next expansion
       return [new InfoNode(
         "Could not load vulnerabilities",
@@ -173,5 +209,7 @@ class VulnerabilitySummaryNode {
     }
   }
 }
+
+VulnerabilitySummaryNode.MAX_CACHED_VULNERABILITIES = MAX_CACHED_VULNERABILITIES;
 
 module.exports = VulnerabilitySummaryNode;

--- a/models/workspaceNode.js
+++ b/models/workspaceNode.js
@@ -9,10 +9,20 @@ const InfoNode = require("./infoNode");
 const repositoryNode = require("./repositoryNode");
 const { WorkspaceInfoNode } = require("./workspaceInfoNode");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
 
 class WorkspaceNode {
-  constructor(item, context) {
+  constructor(item, context, options = {}) {
     this.context = context;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._createCloudsmithAPI = options.createCloudsmithAPI
+      || (() => new CloudsmithAPI(this.context));
+    this._fetchWorkspaceRepositories = options.fetchWorkspaceRepositories
+      || workspaceRepositoryFetcher.fetchWorkspaceRepositories;
     this.name = item.name;
     this.slug = item.slug;
     this.workspace = item.slug;
@@ -34,12 +44,14 @@ class WorkspaceNode {
   }
 
   async getRepositories() {
-    const context = this.context;
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
     const workspace = this.workspace;
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      context,
-      workspace
-    );
+    const result = await this._fetchWorkspaceRepositories(this.context, workspace, {
+      account,
+      connectionManager: this._connectionManager,
+    });
+    if (!isAccountCurrent(this._connectionManager, account) || result.stale) return [];
 
     if (result.error) {
       return [new InfoNode(
@@ -57,24 +69,21 @@ class WorkspaceNode {
       const repositoryNodeInst = new repositoryNode(
         repo,
         this.slug,
-        this.context
+        this.context,
+        { connectionManager: this._connectionManager, createCloudsmithAPI: this._createCloudsmithAPI }
       );
       RepositoryNodes.push(repositoryNodeInst);
     }
-
-    context.globalState.update("CloudsmithCache", {
-      name: "Repositories",
-      lastSync: Date.now(),
-      workspaces: repositories,
-    });
     return RepositoryNodes;
   }
 
   async getChildren() {
+    const account = captureAccount(this._connectionManager);
+    if (!account) return [];
     let quotaData = null;
 
     try {
-      const cloudsmithAPI = new CloudsmithAPI(this.context);
+      const cloudsmithAPI = this._createCloudsmithAPI();
       const result = await cloudsmithAPI.get(apiEndpoint(["quota", this.workspace]), {
         responseType: "object",
         retry: "safe-read",
@@ -86,11 +95,13 @@ class WorkspaceNode {
     } catch {
       // Quota access is optional for this node.
     }
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
 
     const children = [];
     children.push(new WorkspaceInfoNode(this.name || this.workspace, quotaData));
 
     const repos = await this.getRepositories();
+    if (!isAccountCurrent(this._connectionManager, account)) return [];
     children.push(...repos);
 
     return children;

--- a/test/cloudsmithProvider.test.js
+++ b/test/cloudsmithProvider.test.js
@@ -1,142 +1,264 @@
 const assert = require("assert");
 const vscode = require("vscode");
 const { CloudsmithProvider } = require("../views/cloudsmithProvider");
-const { CloudsmithAPI } = require("../util/cloudsmithAPI");
-const { ConnectionManager } = require("../util/connectionManager");
+const { getWorkspaces } = require("../extension");
+const { getWorkspaceContextProjector } = require("../util/workspaceContextProjector");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
-suite("CloudsmithProvider Test Suite", () => {
+function deferred() {
+  let resolve;
+  const promise = new Promise(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+function createConnectionManager(overrides = {}) {
+  let state = {
+    activationId: "activation-a",
+    accountEpoch: 1,
+    sessionConnected: true,
+    ...overrides,
+  };
+  return {
+    getState() { return Object.freeze({ ...state }); },
+    setState(next) { state = { ...state, ...next }; },
+  };
+}
+
+suite("CloudsmithProvider", () => {
   let originalExecuteCommand;
   let originalGetConfiguration;
   let originalShowWarningMessage;
-  let commandCalls;
-  let warningCalls;
+  let commands;
   let defaultWorkspace;
-  let treeView;
-  let provider;
-  let originalApiGet;
-  let originalConnect;
-
-  const context = {
-    secrets: {
-      onDidChange() {},
-      async get(key) {
-        if (key === "cloudsmith-vsc.isConnected") {
-          return "false";
-        }
-        return null;
-      },
-      async store() {},
-    },
-    globalState: {
-      get() {
-        return undefined;
-      },
-      async update() {},
-    },
-  };
+  let manager;
+  let context;
 
   setup(() => {
-    commandCalls = [];
-    warningCalls = [];
-    defaultWorkspace = "";
-    treeView = { message: "ready" };
-    provider = new CloudsmithProvider(context);
-    provider.setTreeView(treeView);
-
     originalExecuteCommand = vscode.commands.executeCommand;
     originalGetConfiguration = vscode.workspace.getConfiguration;
     originalShowWarningMessage = vscode.window.showWarningMessage;
-    originalApiGet = CloudsmithAPI.prototype.get;
-    originalConnect = ConnectionManager.prototype.connect;
-
-    vscode.commands.executeCommand = async (...args) => {
-      commandCalls.push(args);
-    };
-    vscode.workspace.getConfiguration = () => ({
-      get(key) {
-        if (key === "defaultWorkspace") {
-          return defaultWorkspace;
-        }
-        return "";
+    commands = [];
+    defaultWorkspace = "";
+    manager = createConnectionManager();
+    context = {
+      globalState: {
+        get() { return undefined; },
+        async update() { throw new Error("main-tree workspace data must not persist"); },
       },
-    });
-    vscode.window.showWarningMessage = async (...args) => {
-      warningCalls.push(args);
-      return undefined;
     };
+    vscode.commands.executeCommand = async (...args) => { commands.push(args); };
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "defaultWorkspace" ? defaultWorkspace : ""; },
+    });
+    vscode.window.showWarningMessage = async () => undefined;
   });
 
   teardown(() => {
     vscode.commands.executeCommand = originalExecuteCommand;
     vscode.workspace.getConfiguration = originalGetConfiguration;
     vscode.window.showWarningMessage = originalShowWarningMessage;
-    CloudsmithAPI.prototype.get = originalApiGet;
-    ConnectionManager.prototype.connect = originalConnect;
   });
 
-  test("silent refresh shows the signed-out root state without warning after credentials are cleared", async () => {
-    provider.refresh({ suppressMissingCredentialsWarning: true });
+  function createProvider(apiGet, options = {}) {
+    return new CloudsmithProvider(context, {
+      connectionManager: manager,
+      createCloudsmithAPI: () => ({ get: apiGet }),
+      ...options,
+    });
+  }
+
+  test("fails closed to the signed-out root without making an API request", async () => {
+    manager.setState({ sessionConnected: false });
+    let requests = 0;
+    const provider = createProvider(async () => { requests += 1; });
+    const treeView = { message: "old" };
+    provider.setTreeView(treeView);
 
     const nodes = await provider.getChildren();
 
-    assert.strictEqual(warningCalls.length, 0);
-    assert.strictEqual(treeView.message, undefined);
+    assert.strictEqual(requests, 0);
     assert.strictEqual(nodes.length, 1);
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
-    assert.ok(
-      commandCalls.some((call) => (
-        call[0] === "setContext" &&
-        call[1] === "cloudsmith.hasMultipleWorkspaces" &&
-        call[2] === false
-      ))
-    );
-  });
-
-  test("silent refresh also shows the signed-out state when a default workspace is configured", async () => {
-    defaultWorkspace = "workspace-a";
-    provider.refresh({ suppressMissingCredentialsWarning: true });
-
-    const nodes = await provider.getChildren();
-
-    assert.strictEqual(warningCalls.length, 0);
-    assert.strictEqual(nodes.length, 1);
-    assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
-  });
-
-  test("a malformed workspace payload is an explicit load failure, not an empty workspace list", async () => {
-    ConnectionManager.prototype.connect = async () => "true";
-    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
-      const malformed = [{ name: "Missing stable slug" }];
-      assert.strictEqual(options.validate(malformed), false);
-      return apiFailure("invalid_response", {
-        status: 200,
-        message: "Cloudsmith returned an unexpected response.",
-      });
-    };
-
-    const nodes = await provider.getWorkspaces();
-
-    assert.strictEqual(nodes.length, 1);
-    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
-    assert.ok(commandCalls.some(call => (
+    assert.ok(commands.some(call => (
       call[0] === "setContext"
       && call[1] === "cloudsmith.hasMultipleWorkspaces"
       && call[2] === false
     )));
   });
 
-  test("a validated workspace array produces workspace nodes", async () => {
-    ConnectionManager.prototype.connect = async () => "true";
-    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
-      const payload = [{ slug: "workspace-a", name: "Workspace A" }];
-      assert.strictEqual(options.validate(payload), true);
-      return apiSuccess(payload);
-    };
+  test("reports malformed workspace payloads as load failures", async () => {
+    const provider = createProvider(async (_endpoint, options) => {
+      const malformed = [{ name: "Missing stable slug" }];
+      assert.strictEqual(options.validate(malformed), false);
+      return apiFailure("invalid_response", { status: 200 });
+    });
 
     const nodes = await provider.getWorkspaces();
 
     assert.strictEqual(nodes.length, 1);
-    assert.strictEqual(nodes[0].workspace, "workspace-a");
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
+  });
+
+  test("always clears Loading when the workspace API factory throws", async () => {
+    const provider = createProvider(async () => apiSuccess([]), {
+      createCloudsmithAPI() {
+        throw new Error("unexpected factory failure");
+      },
+    });
+    const treeView = {};
+    provider.setTreeView(treeView);
+
+    const nodes = await provider.getWorkspaces();
+
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
+    assert.strictEqual(treeView.message, undefined);
+  });
+
+  test("always clears Loading when workspace projection rejects", async () => {
+    const workspaceContextProjector = {
+      begin() { return Object.freeze({}); },
+      async project() { throw new Error("projection failed"); },
+    };
+    const provider = createProvider(async () => apiSuccess([
+      { slug: "workspace-a", name: "Workspace A" },
+      { slug: "workspace-b", name: "Workspace B" },
+    ]), { workspaceContextProjector });
+    const treeView = {};
+    provider.setTreeView(treeView);
+
+    const nodes = await provider.getWorkspaces();
+
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
+    assert.strictEqual(treeView.message, undefined);
+  });
+
+  test("always clears Loading when the repository fetcher throws", async () => {
+    const provider = createProvider(async () => apiSuccess({ usage: {} }), {
+      fetchWorkspaceRepositories: async () => {
+        throw new Error("unexpected repository failure");
+      },
+    });
+    const treeView = {};
+    provider.setTreeView(treeView);
+
+    const nodes = await provider.getRepositories("workspace-a");
+
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load repositories");
+    assert.strictEqual(treeView.message, undefined);
+  });
+
+  test("publishes validated workspace nodes from an account-scoped memory cache", async () => {
+    let requests = 0;
+    const provider = createProvider(async (_endpoint, options) => {
+      requests += 1;
+      const payload = [{ slug: "workspace-a", name: "Workspace A", api_key: "not persisted" }];
+      assert.strictEqual(options.validate(payload), true);
+      return apiSuccess(payload);
+    });
+
+    const first = await provider.getWorkspaces();
+    const second = await provider.getWorkspaces();
+
+    assert.strictEqual(requests, 1);
+    assert.strictEqual(first[0].workspace, "workspace-a");
+    assert.strictEqual(second[0].workspace, "workspace-a");
+  });
+
+  test("discards a workspace response completed after the account changes", async () => {
+    const pending = deferred();
+    const provider = createProvider(async () => pending.promise);
+    const resultPromise = provider.getWorkspaces();
+    await new Promise(resolve => setImmediate(resolve));
+    manager.setState({ accountEpoch: 2 });
+    pending.resolve(apiSuccess([{ slug: "old-account", name: "Old Account" }]));
+
+    assert.deepStrictEqual(await resultPromise, []);
+    assert.strictEqual(commands.some(call => call[2] === true), false);
+  });
+
+  test("guards repository and quota publication with one captured account", async () => {
+    defaultWorkspace = "workspace-a";
+    const quota = deferred();
+    const provider = createProvider(async () => quota.promise, {
+      fetchWorkspaceRepositories: async () => ({
+        repositories: [{ slug: "repo-a", name: "Repo A" }],
+        error: null,
+        stale: false,
+      }),
+    });
+    const resultPromise = provider.getChildren();
+    await new Promise(resolve => setImmediate(resolve));
+    manager.setState({ accountEpoch: 2 });
+    quota.resolve(apiSuccess({ usage: {} }));
+
+    assert.deepStrictEqual(await resultPromise, []);
+  });
+
+  test("serializes context projection and clears Loading after a stale completion", async () => {
+    let releaseTrue;
+    const trueProjection = new Promise(resolve => { releaseTrue = resolve; });
+    const applied = [];
+    vscode.commands.executeCommand = async (_command, key, value) => {
+      if (key === "cloudsmith.hasMultipleWorkspaces" && value === true) {
+        await trueProjection;
+      }
+      applied.push(value);
+    };
+    const provider = createProvider(async () => apiSuccess([
+      { slug: "workspace-a", name: "Workspace A" },
+      { slug: "workspace-b", name: "Workspace B" },
+    ]));
+    const treeView = {};
+    provider.setTreeView(treeView);
+    const pending = provider.getWorkspaces();
+    while (treeView.message !== "Loading...") {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    await new Promise(resolve => setImmediate(resolve));
+    manager.setState({ accountEpoch: 2 });
+    provider.refresh();
+    releaseTrue();
+
+    assert.deepStrictEqual(await pending, []);
+    await provider._workspaceContextProjector.whenIdle();
+    assert.strictEqual(applied.at(-1), false);
+    assert.strictEqual(treeView.message, undefined);
+  });
+
+  test("shares projection ordering with extension helpers across an account change", async () => {
+    const trueStarted = deferred();
+    const releaseTrue = deferred();
+    const applied = [];
+    vscode.commands.executeCommand = async (_command, key, value) => {
+      if (key === "cloudsmith.hasMultipleWorkspaces" && value === true) {
+        trueStarted.resolve();
+        await releaseTrue.promise;
+      }
+      applied.push(value);
+    };
+    const workspaceContextProjector = getWorkspaceContextProjector(context);
+    const provider = createProvider(async () => apiSuccess([]), {
+      workspaceContextProjector,
+    });
+    const pending = getWorkspaces(context, {
+      connectionManager: manager,
+      workspaceContextProjector,
+      createCloudsmithAPI: () => ({
+        get: async () => apiSuccess([
+          { slug: "old-a", name: "Old A" },
+          { slug: "old-b", name: "Old B" },
+        ]),
+      }),
+    });
+
+    await trueStarted.promise;
+    manager.setState({ accountEpoch: 2 });
+    provider.refresh();
+    releaseTrue.resolve();
+
+    assert.strictEqual(await pending, null);
+    await workspaceContextProjector.whenIdle();
+    assert.deepStrictEqual(applied, [true, false]);
+    assert.strictEqual(applied.at(-1), false);
   });
 });

--- a/test/connectionManager.test.js
+++ b/test/connectionManager.test.js
@@ -1,105 +1,1014 @@
 const assert = require("assert");
-const vscode = require("vscode");
-const { ConnectionManager } = require("../util/connectionManager");
+const {
+  AUTH_TOKEN_KEY,
+  CONNECTION_STATUSES,
+  ConnectionManager,
+  bindConnectionManager,
+  getAccountEpoch,
+  getConnectionManager,
+  unbindConnectionManager,
+} = require("../util/connectionManager");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function nextTurn() {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+class FakeSecrets {
+  constructor(value = null) {
+    this.value = value;
+    this.listeners = new Set();
+    this.deletedKeys = [];
+    this.storeHook = null;
+    this.deleteHook = null;
+    this.getHook = null;
+  }
+
+  onDidChange(listener) {
+    this.listeners.add(listener);
+    return { dispose: () => this.listeners.delete(listener) };
+  }
+
+  async get(key) {
+    if (this.getHook) return this.getHook(key, this);
+    return key === AUTH_TOKEN_KEY ? this.value : null;
+  }
+
+  async store(key, value) {
+    if (this.storeHook) return this.storeHook(key, value, this);
+    if (key === AUTH_TOKEN_KEY) {
+      this.value = value;
+      this.emit(key);
+    }
+  }
+
+  async delete(key) {
+    this.deletedKeys.push(key);
+    if (this.deleteHook) return this.deleteHook(key, this);
+    if (key === AUTH_TOKEN_KEY) {
+      this.value = null;
+      this.emit(key);
+    }
+  }
+
+  externalSet(value) {
+    this.value = value;
+    this.emit(AUTH_TOKEN_KEY);
+  }
+
+  emit(key) {
+    for (const listener of [...this.listeners]) listener({ key });
+  }
+}
+
+function createHarness(initialCredential, validate) {
+  const secrets = new FakeSecrets(initialCredential);
+  const projections = [];
+  const context = { secrets };
+  const manager = new ConnectionManager(context, {
+    activationId: "test-activation",
+    createCloudsmithAPI: () => ({
+      get: (_endpoint, options) => validate(options.apiKey, options),
+    }),
+    executeCommand: async (...args) => projections.push(args),
+  });
+  return { context, manager, projections, secrets };
+}
+
 suite("ConnectionManager Test Suite", () => {
-  let originalShowWarningMessage;
-  let originalExecuteCommand;
-  let warningCalls;
-  let commandCalls;
-  let originalApiGet;
-
-  const context = {
-    secrets: {
-      async get() {
-        return null;
-      },
-      async store() {},
-    },
-  };
-
-  setup(() => {
-    warningCalls = [];
-    commandCalls = [];
-
-    originalShowWarningMessage = vscode.window.showWarningMessage;
-    originalExecuteCommand = vscode.commands.executeCommand;
-    originalApiGet = CloudsmithAPI.prototype.get;
-
-    vscode.window.showWarningMessage = async (...args) => {
-      warningCalls.push(args);
-      return undefined;
-    };
-    vscode.commands.executeCommand = async (...args) => {
-      commandCalls.push(args);
-    };
-  });
-
-  teardown(() => {
-    vscode.window.showWarningMessage = originalShowWarningMessage;
-    vscode.commands.executeCommand = originalExecuteCommand;
-    CloudsmithAPI.prototype.get = originalApiGet;
-  });
-
-  test("connect() warns for missing credentials in interactive flows", async () => {
-    const manager = new ConnectionManager(context);
-
-    const status = await manager.connect();
-
-    assert.strictEqual(status, "false");
-    assert.strictEqual(warningCalls.length, 1);
-    assert.strictEqual(warningCalls[0][0], "No credentials configured!");
-    assert.deepStrictEqual(commandCalls, [
-      ["setContext", "cloudsmith.connected", false],
-    ]);
-  });
-
-  test("connect() can skip the missing credentials warning for non-interactive flows", async () => {
-    const manager = new ConnectionManager(context);
-
-    const status = await manager.connect({ promptOnMissingCredentials: false });
-
-    assert.strictEqual(status, "false");
-    assert.strictEqual(warningCalls.length, 0);
-    assert.deepStrictEqual(commandCalls, [
-      ["setContext", "cloudsmith.connected", false],
-    ]);
-  });
-
-  test("checkConnectivity handles authenticated, negative, and typed failure responses", async () => {
-    const stored = [];
-    const connectivityContext = {
-      secrets: {
-        async get() { return null; },
-        async store(key, value) { stored.push([key, value]); },
-      },
-    };
-    const manager = new ConnectionManager(connectivityContext);
-
-    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
-      assert.strictEqual(options.apiKey, "candidate-key");
+  test("startup derives immutable connected state from the authoritative token", async () => {
+    const calls = [];
+    const { manager, projections, secrets } = createHarness("stored-key", async (candidate, options) => {
+      calls.push([candidate, options]);
       return apiSuccess({ authenticated: true });
+    });
+
+    const result = await manager.initialize();
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.status, CONNECTION_STATUSES.CONNECTED);
+    assert.deepStrictEqual(manager.getState(), {
+      activationId: "test-activation",
+      status: CONNECTION_STATUSES.CONNECTED,
+      operationId: 1,
+      accountEpoch: 1,
+      credentialPresent: true,
+      sessionConnected: true,
+      error: null,
+    });
+    assert.ok(Object.isFrozen(manager.getState()));
+    assert.strictEqual(calls[0][0], "stored-key");
+    assert.strictEqual(calls[0][1].apiKey, "stored-key");
+    assert.deepStrictEqual(projections.at(-1), ["setContext", "cloudsmith.connected", true]);
+    assert.ok(secrets.deletedKeys.includes("cloudsmith-vsc.isConnected"));
+  });
+
+  test("an event during the startup read prevents the pre-event snapshot from validating or publishing", async () => {
+    const startupRead = deferred();
+    const releaseStartupRead = deferred();
+    const validated = [];
+    const { manager, secrets } = createHarness("old-key", async candidate => {
+      validated.push(candidate);
+      return apiSuccess({ authenticated: true });
+    });
+    let authReads = 0;
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      authReads += 1;
+      const captured = store.value;
+      if (authReads === 1) {
+        startupRead.resolve();
+        await releaseStartupRead.promise;
+      }
+      return captured;
     };
-    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "true");
 
-    CloudsmithAPI.prototype.get = async () => apiSuccess({ authenticated: false });
-    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "false");
+    const pending = manager.initialize();
+    await startupRead.promise;
+    secrets.externalSet("new-key");
+    releaseStartupRead.resolve();
+    const result = await pending;
+    await nextTurn();
 
-    CloudsmithAPI.prototype.get = async () => apiFailure("unauthorized", {
-      status: 401,
-      message: "Authentication failed. Check the API key.",
+    assert.strictEqual(result.status, "stale");
+    assert.deepStrictEqual(validated, ["new-key"]);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().operationId, 2);
+  });
+
+  test("an event during startup validation prevents the pre-event credential from publishing", async () => {
+    const oldValidation = deferred();
+    const { manager, secrets } = createHarness("old-key", candidate => (
+      candidate === "old-key"
+        ? oldValidation.promise
+        : Promise.resolve(apiSuccess({ authenticated: true }))
+    ));
+    const states = [];
+    manager.onDidChange(state => states.push(state));
+
+    const pending = manager.initialize();
+    await nextTurn();
+    secrets.externalSet("new-key");
+    oldValidation.resolve(apiSuccess({ authenticated: true }));
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "stale");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().operationId, 2);
+    assert.strictEqual(
+      states.some(state => state.status === CONNECTION_STATUSES.CONNECTED && state.operationId === 1),
+      false
+    );
+  });
+
+  test("a same-value external event is an idempotent no-op", async () => {
+    let validations = 0;
+    let rejectFurtherValidation = false;
+    const { manager, projections, secrets } = createHarness("same-key", async () => {
+      validations += 1;
+      return rejectFurtherValidation
+        ? apiFailure("unauthorized", { message: "must not run" })
+        : apiSuccess({ authenticated: true });
     });
-    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "error");
-    assert.strictEqual(manager._lastError.kind, "unauthorized");
+    await manager.initialize();
+    const before = manager.getState();
+    const projectionCount = projections.length;
+    rejectFurtherValidation = true;
 
-    CloudsmithAPI.prototype.get = async () => apiFailure("invalid_response", {
-      status: 200,
-      message: "Cloudsmith returned an unexpected response.",
+    secrets.externalSet("same-key");
+    await nextTurn();
+    await nextTurn();
+
+    assert.strictEqual(validations, 1);
+    assert.strictEqual(manager.getState(), before);
+    assert.strictEqual(manager.getState().accountEpoch, before.accountEpoch);
+    assert.strictEqual(projections.length, projectionCount);
+  });
+
+  test("a failed replacement preserves the prior connected session and secret", async () => {
+    const { manager, secrets } = createHarness("old-key", async candidate => (
+      candidate === "old-key"
+        ? apiSuccess({ authenticated: true })
+        : apiFailure("unauthorized", { message: "Rejected." })
+    ));
+    await manager.initialize();
+    const epoch = manager.getState().accountEpoch;
+
+    const result = await manager.replaceCredential("bad-key");
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.preserved, true);
+    assert.strictEqual(secrets.value, "old-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().sessionConnected, true);
+    assert.strictEqual(manager.getState().accountEpoch, epoch);
+  });
+
+  test("the newest replacement wins even when an older validation finishes later", async () => {
+    const validations = new Map();
+    const { manager, secrets } = createHarness("old-key", candidate => {
+      if (candidate === "old-key") return Promise.resolve(apiSuccess({ authenticated: true }));
+      const pending = deferred();
+      validations.set(candidate, pending);
+      return pending.promise;
     });
-    assert.strictEqual(await manager.checkConnectivity("candidate-key"), "error");
-    assert.strictEqual(manager._lastError.kind, "invalid_response");
-    assert.deepStrictEqual(stored.map(([, value]) => value), ["true", "false", "error", "error"]);
+    await manager.initialize();
+
+    const first = manager.replaceCredential("first-key");
+    const second = manager.replaceCredential("second-key");
+    validations.get("second-key").resolve(apiSuccess({ authenticated: true }));
+    const secondResult = await second;
+    validations.get("first-key").resolve(apiSuccess({ authenticated: true }));
+    const firstResult = await first;
+
+    assert.strictEqual(secondResult.ok, true);
+    assert.strictEqual(firstResult.status, "stale");
+    assert.strictEqual(secrets.value, "second-key");
+    assert.strictEqual(manager.getState().sessionConnected, true);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("a completed older store becomes the baseline after a newer replacement fails", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const { manager, secrets } = createHarness("old-key", async candidate => (
+      candidate === "bad-newer-key"
+        ? apiFailure("unauthorized", { message: "Rejected." })
+        : apiSuccess({ authenticated: true })
+    ));
+    await manager.initialize();
+    secrets.storeHook = async (key, value, store) => {
+      store.value = value;
+      store.emit(key);
+      storeStarted.resolve();
+      await releaseStore.promise;
+    };
+
+    const older = manager.replaceCredential("committed-key");
+    await storeStarted.promise;
+    const newer = await manager.replaceCredential("bad-newer-key");
+    assert.strictEqual(newer.ok, false);
+    releaseStore.resolve();
+    const olderResult = await older;
+
+    assert.strictEqual(olderResult.status, "stale");
+    assert.strictEqual(secrets.value, "committed-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().sessionConnected, true);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("a self SecretStorage event before store settlement does not cancel or double-advance", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+
+    const result = await manager.replaceCredential("  new-key  ");
+    await nextTurn();
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(secrets.value, "new-key");
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("a delayed self store event after settlement is ignored without double-advancing", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async (_key, value, store) => {
+      store.value = value;
+    };
+
+    const result = await manager.replaceCredential("new-key");
+    const epoch = manager.getState().accountEpoch;
+    secrets.emit(AUTH_TOKEN_KEY);
+    await nextTurn();
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().accountEpoch, epoch);
+  });
+
+  test("an external replacement during an internal store is restored and the candidate never publishes", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    const states = [];
+    manager.onDidChange(state => states.push(state));
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-key");
+    releaseStore.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(result.error.kind, "credential_changed");
+    assert.ok(result.error.message.length > 0);
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(states.filter(state => state.status === CONNECTION_STATUSES.CONNECTED).length, 1);
+  });
+
+  test("restoration retires every raw external snapshot reference", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const rawExternal = "external-secret-must-not-remain";
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet(rawExternal);
+    releaseStore.resolve();
+    const result = await pending;
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(manager._expectedSecretIntent, null);
+  });
+
+  test("infrastructure errors containing a candidate never leak through state or results", async () => {
+    const candidate = "candidate-secret-never-display";
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async () => {
+      throw Object.assign(new Error(`storage failed for ${candidate}`), { kind: "storage_error" });
+    };
+
+    const result = await manager.replaceCredential(candidate);
+    const publicSurface = JSON.stringify({ result, state: manager.getState() });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(publicSurface.includes(candidate), false);
+    assert.strictEqual(result.error.message, "Could not save credentials.");
+    assert.strictEqual(manager._lastError, undefined);
+  });
+
+  test("typed SecretStorage delete errors never leak their message", async () => {
+    const secret = "delete-error-secret-must-not-leak";
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.deleteHook = async key => {
+      if (key === AUTH_TOKEN_KEY) {
+        throw Object.assign(new Error(`delete failed for ${secret}`), { kind: "storage_error" });
+      }
+    };
+
+    const result = await manager.disconnect();
+    const publicSurface = JSON.stringify({ result, state: manager.getState() });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.error.message, "Could not delete credentials.");
+    assert.strictEqual(publicSurface.includes(secret), false);
+    assert.strictEqual(manager._lastError, undefined);
+  });
+
+  test("typed SecretStorage read errors fail closed without leaking their message", async () => {
+    const secret = "read-error-secret-must-not-leak";
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    secrets.getHook = async () => {
+      throw Object.assign(new Error(`read failed for ${secret}`), { kind: "storage_error" });
+    };
+
+    const result = await manager.initialize();
+    const publicSurface = JSON.stringify({ result, state: manager.getState() });
+
+    assert.strictEqual(result.status, CONNECTION_STATUSES.INDETERMINATE);
+    assert.strictEqual(result.error.message, "Could not read stored credentials.");
+    assert.strictEqual(publicSurface.includes(secret), false);
+    assert.strictEqual(manager._lastError, undefined);
+  });
+
+  test("typed API failure messages are rebuilt and never retained internally", async () => {
+    const secret = "api-error-secret-must-not-leak";
+    const { manager } = createHarness(null, async () => (
+      apiFailure("network_error", { message: `request failed for ${secret}` })
+    ));
+
+    const connectivity = await manager.checkConnectivity("candidate-key");
+
+    assert.strictEqual(connectivity, "error");
+    assert.strictEqual(manager._lastError, undefined);
+    assert.strictEqual(JSON.stringify(manager.getState()).includes(secret), false);
+  });
+
+  test("an external deletion during an internal store remains authoritative", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet(null);
+    releaseStore.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, null);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.ABSENT);
+    assert.strictEqual(manager.getState().sessionConnected, false);
+  });
+
+  test("an external replacement during internal deletion is restored", async () => {
+    const deleteStarted = deferred();
+    const releaseDelete = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let authDeletes = 0;
+    secrets.deleteHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return;
+      authDeletes += 1;
+      if (authDeletes === 1) {
+        deleteStarted.resolve();
+        await releaseDelete.promise;
+      }
+      store.value = null;
+      store.emit(key);
+    };
+
+    const pending = manager.disconnect();
+    await deleteStarted.promise;
+    secrets.externalSet("external-key");
+    releaseDelete.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("a delayed self delete event after settlement does not create a new operation", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.deleteHook = async (key, store) => {
+      if (key === AUTH_TOKEN_KEY) store.value = null;
+    };
+
+    const result = await manager.disconnect();
+    const operationId = manager.getState().operationId;
+    const epoch = manager.getState().accountEpoch;
+    secrets.emit(AUTH_TOKEN_KEY);
+    await nextTurn();
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(manager.getState().operationId, operationId);
+    assert.strictEqual(manager.getState().accountEpoch, epoch);
+  });
+
+  test("a higher external event during restoration wins even if an older restore writes later", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const restoreStarted = deferred();
+    const releaseRestore = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      } else if (stores === 2) {
+        restoreStarted.resolve();
+        await releaseRestore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-one");
+    releaseStore.resolve();
+    await restoreStarted.promise;
+    secrets.externalSet("external-two");
+    releaseRestore.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "external-two");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("a consumed self fingerprint cannot swallow a later external event during restoration", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const restoreStarted = deferred();
+    const releaseRestore = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      store.value = value;
+      store.emit(key);
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      } else if (stores === 2) {
+        restoreStarted.resolve();
+        await releaseRestore.promise;
+      }
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-one");
+    releaseStore.resolve();
+    await restoreStarted.promise;
+
+    // The original internal-key self notification has already consumed its
+    // one-shot expectation. This later event must therefore be external.
+    secrets.externalSet("internal-key");
+    releaseRestore.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "internal-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager._expectedSecretIntent, null);
+  });
+
+  test("an event between the final restore barrier and publication is reconciled", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const validated = [];
+    const { manager, secrets } = createHarness("old-key", async candidate => {
+      validated.push(candidate);
+      return apiSuccess({ authenticated: true });
+    });
+    await manager.initialize();
+    let stores = 0;
+    let restoreWriteCompleted = false;
+    let armBarrierInjection = false;
+    let injected = false;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+      if (stores === 2) restoreWriteCompleted = true;
+    };
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      if (restoreWriteCompleted && !injected) armBarrierInjection = true;
+      return store.value;
+    };
+    const originalBarrier = manager._awaitSecretEventBarrier.bind(manager);
+    manager._awaitSecretEventBarrier = async () => {
+      const sequence = await originalBarrier();
+      if (armBarrierInjection && !injected) {
+        injected = true;
+        armBarrierInjection = false;
+        queueMicrotask(() => secrets.externalSet("external-two"));
+      }
+      return sequence;
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-one");
+    releaseStore.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "external-two");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.ok(validated.includes("external-two"));
+  });
+
+  test("restoration publishes after a newer invalid operation ends", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const restoreStarted = deferred();
+    const releaseRestore = deferred();
+    const { manager, secrets } = createHarness("old-key", async candidate => (
+      candidate === "bad-newer-key"
+        ? apiFailure("unauthorized", { message: "Rejected." })
+        : apiSuccess({ authenticated: true })
+    ));
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      } else if (stores === 2) {
+        restoreStarted.resolve();
+        await releaseRestore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-key");
+    releaseStore.resolve();
+    await restoreStarted.promise;
+    const newerResult = await manager.replaceCredential("bad-newer-key");
+    assert.strictEqual(newerResult.ok, false);
+    releaseRestore.resolve();
+    await pending;
+
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().sessionConnected, true);
+  });
+
+  test("retired restoration fingerprints do not swallow later external rollback values", async () => {
+    const storeStarted = deferred();
+    const releaseStore = deferred();
+    const validated = [];
+    const { manager, secrets } = createHarness("old-key", async candidate => {
+      validated.push(candidate);
+      return apiSuccess({ authenticated: true });
+    });
+    await manager.initialize();
+    let stores = 0;
+    secrets.storeHook = async (key, value, store) => {
+      stores += 1;
+      if (stores === 1) {
+        storeStarted.resolve();
+        await releaseStore.promise;
+      }
+      store.value = value;
+      store.emit(key);
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await storeStarted.promise;
+    secrets.externalSet("external-key");
+    releaseStore.resolve();
+    await pending;
+    const validationCount = validated.length;
+
+    secrets.externalSet("internal-key");
+    await nextTurn();
+    await nextTurn();
+
+    assert.strictEqual(validated.length, validationCount + 1);
+    assert.strictEqual(validated.at(-1), "internal-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("an external replacement during the final store reread prevents stale success", async () => {
+    const finalReadStarted = deferred();
+    const releaseFinalRead = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let authReads = 0;
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      authReads += 1;
+      const captured = store.value;
+      if (authReads === 2) {
+        finalReadStarted.resolve();
+        await releaseFinalRead.promise;
+      }
+      return captured;
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await finalReadStarted.promise;
+    secrets.externalSet("external-key");
+    releaseFinalRead.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("an external replacement during the final delete reread prevents stale disconnect", async () => {
+    const finalReadStarted = deferred();
+    const releaseFinalRead = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let authReads = 0;
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      authReads += 1;
+      const captured = store.value;
+      if (authReads === 2) {
+        finalReadStarted.resolve();
+        await releaseFinalRead.promise;
+      }
+      return captured;
+    };
+
+    const pending = manager.disconnect();
+    await finalReadStarted.promise;
+    secrets.externalSet("external-key");
+    releaseFinalRead.resolve();
+    const result = await pending;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+  });
+
+  test("a newer completed intent during the final store reread forces fresh reconciliation", async () => {
+    const finalReadStarted = deferred();
+    const releaseFinalRead = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let authReads = 0;
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      authReads += 1;
+      const captured = store.value;
+      if (authReads === 2) {
+        finalReadStarted.resolve();
+        await releaseFinalRead.promise;
+      }
+      return captured;
+    };
+
+    const pending = manager.replaceCredential("internal-key");
+    await finalReadStarted.promise;
+    const newer = manager.beginCredentialOperation();
+    await manager.cancelCredentialOperation(newer);
+    releaseFinalRead.resolve();
+    const result = await pending;
+
+    assert.strictEqual(result.status, "stale");
+    assert.strictEqual(secrets.value, "internal-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.ok(manager.getState().operationId > newer.id);
+  });
+
+  test("a newer completed intent during the final delete reread forces fresh reconciliation", async () => {
+    const finalReadStarted = deferred();
+    const releaseFinalRead = deferred();
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    let authReads = 0;
+    secrets.getHook = async (key, store) => {
+      if (key !== AUTH_TOKEN_KEY) return null;
+      authReads += 1;
+      const captured = store.value;
+      if (authReads === 2) {
+        finalReadStarted.resolve();
+        await releaseFinalRead.promise;
+      }
+      return captured;
+    };
+
+    const pending = manager.disconnect();
+    await finalReadStarted.promise;
+    const newer = manager.beginCredentialOperation();
+    await manager.cancelCredentialOperation(newer);
+    releaseFinalRead.resolve();
+    const result = await pending;
+
+    assert.strictEqual(result.status, "stale");
+    assert.strictEqual(secrets.value, null);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.ABSENT);
+    assert.ok(manager.getState().operationId > newer.id);
+  });
+
+  test("a store rejection is success when authoritative reread contains the candidate", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async (key, value, store) => {
+      store.value = value;
+      store.emit(key);
+      throw new Error("ambiguous store rejection");
+    };
+
+    const result = await manager.replaceCredential("new-key");
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.committed, true);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("a store rejection that leaves the old token restores the old session", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async () => {
+      throw new Error("store failed");
+    };
+
+    const result = await manager.replaceCredential("new-key");
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.preserved, true);
+    assert.strictEqual(secrets.value, "old-key");
+    assert.strictEqual(manager.getState().accountEpoch, 1);
+  });
+
+  test("a store that resolves without changing the secret reports a safe persistence mismatch", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async () => {};
+
+    const result = await manager.replaceCredential("new-key");
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(result.error.kind, "persistence_mismatch");
+    assert.ok(result.error.message.length > 0);
+    assert.strictEqual(secrets.value, "old-key");
+  });
+
+  test("a delete that resolves without changing the secret reports a safe persistence mismatch", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.deleteHook = async () => {};
+
+    const result = await manager.disconnect();
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.status, "superseded");
+    assert.strictEqual(result.error.kind, "persistence_mismatch");
+    assert.ok(result.error.message.length > 0);
+    assert.strictEqual(secrets.value, "old-key");
+  });
+
+  test("an unreadable post-write outcome fails closed and advances the epoch conservatively", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+    secrets.storeHook = async () => {
+      throw new Error("write outcome unknown");
+    };
+    secrets.getHook = async () => {
+      throw new Error("read failed");
+    };
+
+    const result = await manager.replaceCredential("new-key");
+
+    assert.strictEqual(result.status, CONNECTION_STATUSES.INDETERMINATE);
+    assert.strictEqual(manager.getState().sessionConnected, false);
+    assert.strictEqual(manager.getState().credentialPresent, null);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("an external replacement supersedes an in-flight candidate", async () => {
+    const pendingCandidate = deferred();
+    const { manager, secrets } = createHarness("old-key", candidate => {
+      if (candidate === "candidate-key") return pendingCandidate.promise;
+      return Promise.resolve(apiSuccess({ authenticated: true }));
+    });
+    await manager.initialize();
+
+    const replacement = manager.replaceCredential("candidate-key");
+    secrets.externalSet("external-key");
+    await nextTurn();
+    pendingCandidate.resolve(apiSuccess({ authenticated: true }));
+    const result = await replacement;
+    await nextTurn();
+
+    assert.strictEqual(result.status, "stale");
+    assert.strictEqual(secrets.value, "external-key");
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.CONNECTED);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("external deletion invalidates the session once", async () => {
+    const { manager, secrets } = createHarness("old-key", async () => apiSuccess({ authenticated: true }));
+    await manager.initialize();
+
+    secrets.externalSet(null);
+    await nextTurn();
+    await nextTurn();
+
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.ABSENT);
+    assert.strictEqual(manager.getState().sessionConnected, false);
+    assert.strictEqual(manager.getState().accountEpoch, 2);
+  });
+
+  test("malformed stored credentials are present but fail closed", async () => {
+    const { manager } = createHarness(" bad-key\n", async () => {
+      throw new Error("malformed values must not reach the API");
+    });
+
+    const result = await manager.initialize();
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(manager.getState().status, CONNECTION_STATUSES.FAILED);
+    assert.strictEqual(manager.getState().credentialPresent, true);
+    assert.strictEqual(manager.getState().sessionConnected, false);
+  });
+
+  test("registry access is activation-bound and fails closed after unbind", async () => {
+    const { context, manager } = createHarness(null, async () => apiSuccess({ authenticated: true }));
+    const binding = bindConnectionManager(context, manager, manager.activationId);
+    await manager.initialize();
+
+    assert.strictEqual(getConnectionManager(context), manager);
+    assert.strictEqual(getConnectionManager(context, "wrong-activation"), null);
+    assert.strictEqual(getAccountEpoch(context, manager.activationId), 1);
+    binding.dispose();
+    assert.strictEqual(getConnectionManager(context), null);
+    assert.strictEqual(getAccountEpoch(context), null);
+    assert.strictEqual(unbindConnectionManager(context), false);
+  });
+
+  test("context projection retries and reports partial success without changing authority", async () => {
+    let attempts = 0;
+    const secrets = new FakeSecrets(null);
+    const manager = new ConnectionManager({ secrets }, {
+      activationId: "projection-test",
+      createCloudsmithAPI: () => ({ get: async () => apiSuccess({ authenticated: true }) }),
+      executeCommand: async () => {
+        attempts += 1;
+        throw new Error("projection unavailable");
+      },
+    });
+    await manager.initialize();
+    attempts = 0;
+
+    const result = await manager.replaceCredential("new-key");
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(attempts, 2);
+    assert.strictEqual(manager.getState().sessionConnected, true);
+  });
+
+  test("an explicit API candidate bypasses stored credential lookup", async () => {
+    let credentialReads = 0;
+    const api = new CloudsmithAPI({ secrets: new FakeSecrets("stored-key") }, {
+      credentialManager: {
+        async getApiKey() {
+          credentialReads += 1;
+          throw new Error("stored credentials must not be read");
+        },
+      },
+      fetchImpl: async (_requestUrl, options) => {
+        assert.strictEqual(options.headers["X-Api-Key"], "candidate-key");
+        return new Response(JSON.stringify({ authenticated: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+      randomUUID: () => "request-id",
+    });
+
+    const result = await api.get("user/self", {
+      apiKey: "candidate-key",
+      responseType: "object",
+      validate: value => value.authenticated === true,
+    });
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(credentialReads, 0);
   });
 });

--- a/test/credentialManager.test.js
+++ b/test/credentialManager.test.js
@@ -1,0 +1,217 @@
+const assert = require("assert");
+const { CredentialManager, runCLIAutoDetect } = require("../util/credentialManager");
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+function createManagerHarness() {
+  const calls = [];
+  let current = null;
+  let nextId = 0;
+  const connectionManager = {
+    beginCredentialOperation() {
+      calls.push("begin");
+      const controller = new AbortController();
+      current = Object.freeze({ id: ++nextId, controller, signal: controller.signal });
+      return current;
+    },
+    isOperationCurrent(token) {
+      return token === current && !token.signal.aborted;
+    },
+    cancelCredentialOperation(token) {
+      calls.push(["cancel", token.id]);
+      if (token === current) token.controller.abort();
+      return Object.freeze({ ok: false, status: "cancelled" });
+    },
+    async replaceCredential(value, token) {
+      calls.push(["replace", value, token.id]);
+      return Object.freeze({ ok: true, status: "connected", committed: true });
+    },
+    async disconnect(token) {
+      calls.push(["disconnect", token.id]);
+      return Object.freeze({ ok: true, status: "absent", committed: true });
+    },
+    getState() {
+      return Object.freeze({ credentialPresent: true });
+    },
+  };
+  return { calls, connectionManager, getCurrent: () => current };
+}
+
+suite("CredentialManager Test Suite", () => {
+  test("manual input begins an auth operation before awaiting the secret prompt", async () => {
+    const input = deferred();
+    const { calls, connectionManager } = createManagerHarness();
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showInputBox: () => {
+        calls.push("prompt");
+        return input.promise;
+      },
+    });
+
+    const pending = manager.storeApiKey();
+    assert.deepStrictEqual(calls, ["begin", "prompt"]);
+    input.resolve(" candidate-key ");
+    const result = await pending;
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(calls[2].slice(0, 2), ["replace", " candidate-key "]);
+  });
+
+  test("a supplied operation is reused instead of allocating a second token", async () => {
+    const { calls, connectionManager } = createManagerHarness();
+    const operation = connectionManager.beginCredentialOperation();
+    calls.length = 0;
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showInputBox: async () => "candidate-key",
+    });
+
+    const result = await manager.storeApiKey(operation);
+
+    assert.strictEqual(result.ok, true);
+    assert.ok(!calls.includes("begin"));
+    assert.deepStrictEqual(calls[0], ["replace", "candidate-key", operation.id]);
+  });
+
+  test("cancelling manual input cancels the exact operation without storing", async () => {
+    const { calls, connectionManager } = createManagerHarness();
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showInputBox: async () => undefined,
+    });
+
+    const result = await manager.storeApiKey();
+
+    assert.strictEqual(result.status, "cancelled");
+    assert.strictEqual(calls.some(call => Array.isArray(call) && call[0] === "replace"), false);
+  });
+
+  test("manual prompt failures return a fixed message without leaking typed error details", async () => {
+    const secret = "prompt-error-secret-must-not-leak";
+    const { calls, connectionManager, getCurrent } = createManagerHarness();
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showInputBox: async () => {
+        throw Object.assign(new Error(`prompt failed for ${secret}`), { kind: "input_error" });
+      },
+    });
+
+    const result = await manager.storeApiKey();
+
+    assert.strictEqual(result.status, "failed");
+    assert.strictEqual(result.error.message, "Could not read the API key. Try again.");
+    assert.strictEqual(connectionManager.isOperationCurrent(getCurrent()), false);
+    assert.strictEqual(JSON.stringify({ result, calls }).includes(secret), false);
+  });
+
+  test("confirmed clearing delegates deletion to the authoritative manager", async () => {
+    const { calls, connectionManager } = createManagerHarness();
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showWarningMessage: async () => "Delete",
+    });
+
+    const result = await manager.clearCredentials();
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.status, "absent");
+    assert.ok(calls.some(call => Array.isArray(call) && call[0] === "disconnect"));
+  });
+
+  test("confirmation failures return a fixed message without leaking typed error details", async () => {
+    const secret = "confirmation-error-secret-must-not-leak";
+    const { calls, connectionManager, getCurrent } = createManagerHarness();
+    const manager = new CredentialManager({ secrets: {} }, {
+      connectionManager,
+      showWarningMessage: async () => {
+        throw Object.assign(new Error(`confirmation failed for ${secret}`), { kind: "ui_error" });
+      },
+    });
+
+    const result = await manager.clearCredentials();
+
+    assert.strictEqual(result.status, "failed");
+    assert.strictEqual(result.error.message, "Could not confirm credential deletion. Try again.");
+    assert.strictEqual(connectionManager.isOperationCurrent(getCurrent()), false);
+    assert.strictEqual(JSON.stringify({ result, calls }).includes(secret), false);
+  });
+
+  test("raw reads remain available for authenticated API requests", async () => {
+    const manager = new CredentialManager({
+      secrets: { async get(key) { return key === "cloudsmith-vsc.authToken" ? "stored-key" : null; } },
+    });
+
+    assert.strictEqual(await manager.getApiKey(), "stored-key");
+  });
+
+  test("CLI auto-detect owns the operation before reading and cannot supersede manual configure", async () => {
+    const read = deferred();
+    const { calls, connectionManager } = createManagerHarness();
+    connectionManager.getState = () => Object.freeze({
+      status: "absent",
+      credentialPresent: false,
+      sessionConnected: false,
+    });
+    let prompts = 0;
+    const pending = runCLIAutoDetect({
+      connectionManager,
+      secrets: {
+        get() {
+          calls.push("read");
+          return read.promise;
+        },
+      },
+      ssoManager: {
+        hasCLICredentials() { return true; },
+        async importFromCLI() { throw new Error("must not import"); },
+      },
+      showInformationMessage: async () => {
+        prompts += 1;
+        return "Import";
+      },
+      handleAuthenticationResult: async () => {},
+    });
+    assert.deepStrictEqual(calls.slice(0, 2), ["begin", "read"]);
+
+    const manualOperation = connectionManager.beginCredentialOperation();
+    read.resolve(null);
+    const result = await pending;
+
+    assert.strictEqual(result.status, "stale");
+    assert.strictEqual(prompts, 0);
+    assert.strictEqual(connectionManager.isOperationCurrent(manualOperation), true);
+  });
+
+  test("CLI auto-detect cancels its operation when the stored credential read fails", async () => {
+    const secret = "candidate-secret-must-not-leak";
+    const { calls, connectionManager, getCurrent } = createManagerHarness();
+    connectionManager.getState = () => Object.freeze({
+      status: "absent",
+      credentialPresent: false,
+      sessionConnected: false,
+    });
+
+    const result = await runCLIAutoDetect({
+      connectionManager,
+      secrets: {
+        async get() { throw new Error(`read failed for ${secret}`); },
+      },
+      ssoManager: {
+        hasCLICredentials() { throw new Error("must not inspect CLI credentials"); },
+      },
+      showInformationMessage: async () => { throw new Error("must not prompt"); },
+      handleAuthenticationResult: async () => {},
+    });
+
+    assert.strictEqual(result.status, "failed");
+    assert.strictEqual(result.committed, false);
+    assert.strictEqual(connectionManager.isOperationCurrent(getCurrent()), false);
+    assert.deepStrictEqual(calls, ["begin", ["cancel", 1]]);
+    assert.ok(!JSON.stringify(result).includes(secret));
+  });
+});

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -22,6 +22,7 @@ const {
   createDependencySource,
 } = require("../util/dependencyRecord");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+const { bindConnectionManager } = require("../util/connectionManager");
 
 suite("DependencyHealthProvider Test Suite", () => {
   let originalWithProgress;
@@ -30,15 +31,9 @@ suite("DependencyHealthProvider Test Suite", () => {
   let originalShowErrorMessage;
 
   function createContext(isConnected = "true") {
-    return {
+    const context = {
       secrets: {
         onDidChange() {},
-        async get(key) {
-          if (key === "cloudsmith-vsc.isConnected") {
-            return isConnected;
-          }
-          return null;
-        },
       },
       workspaceState: {
         get() {
@@ -47,6 +42,20 @@ suite("DependencyHealthProvider Test Suite", () => {
         async update() {},
       },
     };
+    const connected = isConnected === "true";
+    const connectionManager = {
+      activationId: "dependency-health-tests",
+      getState() {
+        return Object.freeze({
+          activationId: this.activationId,
+          accountEpoch: 1,
+          sessionConnected: connected,
+          status: connected ? "connected" : "absent",
+        });
+      },
+    };
+    bindConnectionManager(context, connectionManager);
+    return context;
   }
 
   function createDependency(name, version, format = "npm") {
@@ -141,6 +150,9 @@ suite("DependencyHealthProvider Test Suite", () => {
       replace(snapshot) {
         this.current = snapshot;
         this.replacements.push(snapshot);
+      },
+      clear() {
+        this.current = [];
       },
     };
   }
@@ -371,6 +383,38 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(nodes[0].getTreeItem().label, "Dependency scan canceled");
   });
 
+  test("account epoch change cancels in-flight work and prevents old-account publication", async () => {
+    let accountEpoch = 1;
+    const connectionManager = {
+      getState() {
+        return Object.freeze({
+          activationId: "dependency-account-race",
+          accountEpoch,
+          sessionConnected: true,
+          status: "connected",
+        });
+      },
+    };
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics, {
+      connectionManager,
+    });
+    const scanStarted = deferred();
+    const scanGate = deferred();
+    installScanSteps(provider, [{ name: "old-account-result", started: scanStarted, gate: scanGate }]);
+
+    const scanPromise = provider.scan("workspace-a", "repo-a", "/project-a");
+    await scanStarted.promise;
+    accountEpoch = 2;
+    await provider.resetForAccountChange();
+    scanGate.resolve();
+
+    assert.strictEqual((await scanPromise).status, "superseded");
+    assert.strictEqual(provider.hasSuccessfulScan(), false);
+    assert.deepStrictEqual(provider.dependencies, []);
+    assert.deepStrictEqual(diagnostics.current, []);
+  });
+
   test("successful rescan leaves prior results visible while running and replaces them on commit", async () => {
     const diagnostics = createDiagnosticsPublisher();
     const provider = new DependencyHealthProvider(createContext(), diagnostics);
@@ -555,11 +599,17 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.deepStrictEqual(provider._warnings, ["previous successful warning"]);
     assert.match(scanWorker._warnings[0], /capped at 10000 direct occurrences/);
 
+    provider._scanOperation = {
+      ...provider._scanOperation,
+      id: 1,
+      accountEpoch: 1,
+      status: SCAN_STATES.RUNNING,
+    };
     provider._commitSuccessfulScan(scanWorker, {
       workspace: "workspace-a",
       repository: "repo-a",
       projectFolder: "/project",
-    }, 1);
+    }, 1, 1);
     assert.match(provider._warnings[0], /capped at 10000 direct occurrences/);
   });
 

--- a/test/dependencyVulnEnricher.test.js
+++ b/test/dependencyVulnEnricher.test.js
@@ -1,13 +1,26 @@
 const assert = require("assert");
 const {
   clearVulnerabilityCache,
-  enrichVulnerabilities,
+  enrichVulnerabilities: enrichVulnerabilitiesImpl,
   getVulnerabilityCacheSize,
 } = require("../util/dependencyVulnEnricher");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 
 suite("dependencyVulnEnricher", () => {
+  let accountState;
+  const connectionManager = {
+    getState() { return { ...accountState }; },
+    setState(next) { accountState = { ...accountState, ...next }; },
+  };
+
+  function enrichVulnerabilities(dependencies, workspace, options = {}) {
+    return enrichVulnerabilitiesImpl(dependencies, workspace, {
+      connectionManager,
+      ...options,
+    });
+  }
+
   function createFoundDependency(slug, count = 1) {
     return {
       name: `pkg-${slug}`,
@@ -28,6 +41,11 @@ suite("dependencyVulnEnricher", () => {
 
   setup(() => {
     clearVulnerabilityCache();
+    accountState = {
+      activationId: "activation-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
   });
 
   test("hydrates vulnerability summaries from the detail endpoint", async () => {
@@ -178,6 +196,18 @@ suite("dependencyVulnEnricher", () => {
 
       assert.strictEqual(getVulnerabilityCacheSize(), 5000);
 
+      await enrichVulnerabilities([createFoundDependency("pkg-over-cap")], "workspace-a", {
+        cloudsmithAPI: {
+          async getV2() {
+            return apiSuccess({
+              results: [{ vulnerability_id: "CVE-2024-9999", severity: "Low" }],
+            });
+          },
+        },
+      });
+
+      assert.strictEqual(getVulnerabilityCacheSize(), 5000);
+
       now += 20 * 60 * 1000;
 
       await enrichVulnerabilities([createFoundDependency("pkg-fresh")], "workspace-a", {
@@ -236,6 +266,25 @@ suite("dependencyVulnEnricher", () => {
     assert.strictEqual(fetchSignal.aborted, true);
     assert.strictEqual(disposedListeners, 1);
     assert.strictEqual(enriched[0].vulnerabilities.detailsLoaded, false);
+    assert.strictEqual(getVulnerabilityCacheSize(), 0);
+  });
+
+  test("does not cache or publish vulnerability details completed by an old account", async () => {
+    let release;
+    const response = new Promise(resolve => { release = resolve; });
+    const dependencies = [createFoundDependency("pkg-old")];
+    const pending = enrichVulnerabilities(dependencies, "workspace-a", {
+      cloudsmithAPI: { async getV2() { return response; } },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    connectionManager.setState({ accountEpoch: 2 });
+    release(apiSuccess({
+      results: [{ vulnerability_id: "CVE-OLD", severity: "Critical" }],
+    }));
+
+    const result = await pending;
+    assert.strictEqual(result, dependencies);
+    assert.strictEqual(result[0].vulnerabilities, undefined);
     assert.strictEqual(getVulnerabilityCacheSize(), 0);
   });
 });

--- a/test/paginatedFetch.test.js
+++ b/test/paginatedFetch.test.js
@@ -70,6 +70,26 @@ suite("PaginatedFetch typed API boundary", () => {
     }
   });
 
+  test("rejects a response whose authoritative page differs from the request", async () => {
+    const paginated = new PaginatedFetch({
+      async get() {
+        return apiSuccess([{ name: "artifact" }], {
+          headers: {
+            "x-pagination-page": "1",
+            "x-pagination-pagetotal": "2",
+            "x-pagination-count": "3",
+            "x-pagination-pagesize": "2",
+          },
+        });
+      },
+    });
+
+    const result = await paginated.fetchPage("packages/workspace/", 2, 2);
+
+    assert.strictEqual(result.error.kind, "invalid_response");
+    assert.deepStrictEqual(result.data, []);
+  });
+
   test("forwards a domain validator so blank records cannot cross pagination", async () => {
     let capturedValidator;
     const paginated = new PaginatedFetch({

--- a/test/recentSearches.test.js
+++ b/test/recentSearches.test.js
@@ -1,114 +1,203 @@
-const assert = require('assert');
-const { RecentSearches } = require('../util/recentSearches');
+const assert = require("assert");
+const vscode = require("vscode");
+const {
+  RecentSearches,
+  STORAGE_KEY_PREFIX,
+  STORAGE_VERSION,
+} = require("../util/recentSearches");
 
-suite('RecentSearches Test Suite', () => {
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
 
-    let mockContext;
+suite("RecentSearches", () => {
+  let originalGetConfiguration;
+  let store;
+  let updates;
+  let context;
+  let timestamp;
 
-    setup(() => {
-        // Create a mock context with in-memory globalState
-        const store = {};
-        mockContext = {
-            globalState: {
-                get(key) { return store[key]; },
-                update(key, value) { store[key] = value; },
-            },
-        };
+  setup(() => {
+    originalGetConfiguration = vscode.workspace.getConfiguration;
+    vscode.workspace.getConfiguration = () => ({ get: () => 10 });
+    store = new Map();
+    updates = [];
+    context = {
+      globalState: {
+        get(key) { return store.get(key); },
+        async update(key, value) {
+          updates.push({ key, value });
+          if (value === undefined) store.delete(key);
+          else store.set(key, value);
+        },
+      },
+    };
+    timestamp = 1_000;
+  });
+
+  teardown(() => {
+    vscode.workspace.getConfiguration = originalGetConfiguration;
+  });
+
+  function recent(workspace = "workspace-a") {
+    return new RecentSearches(context, workspace, { now: () => timestamp++ });
+  }
+
+  function descriptor(overrides = {}) {
+    return {
+      workspace: "workspace-a",
+      query: "name:flask",
+      scope: { kind: "workspace" },
+      ...overrides,
+    };
+  }
+
+  test("stores only the exact versioned replay descriptor", async () => {
+    const searches = recent();
+    await searches.add(descriptor({ secret: "must-not-persist" }));
+
+    const stored = store.get(`${STORAGE_KEY_PREFIX}:workspace-a`);
+    assert.strictEqual(stored.version, STORAGE_VERSION);
+    assert.deepStrictEqual(Object.keys(stored).sort(), ["items", "version"]);
+    assert.deepStrictEqual(Object.keys(stored.items[0]).sort(), [
+      "query", "scope", "timestamp", "workspace",
+    ]);
+    assert.strictEqual(JSON.stringify(stored).includes("must-not-persist"), false);
+    assert.deepStrictEqual(await searches.getAll(), [
+      descriptor({ timestamp: 1_000 }),
+    ]);
+  });
+
+  test("deduplicates exact descriptors while retaining different scopes", async () => {
+    const searches = recent();
+    await searches.add(descriptor({ timestamp: 1_000 }));
+    await searches.add(descriptor({
+      timestamp: 2_000,
+      scope: { kind: "repositories", repositories: ["repo-b", "repo-a", "repo-a"] },
+    }));
+    await searches.add(descriptor({ timestamp: 3_000 }));
+
+    const all = await searches.getAll();
+    assert.strictEqual(all.length, 2);
+    assert.strictEqual(all[0].timestamp, 3_000);
+    assert.deepStrictEqual(all[1].scope.repositories, ["repo-a", "repo-b"]);
+  });
+
+  test("stores, validates, and deduplicates exact single-repository scopes", async () => {
+    const searches = recent();
+    await searches.add(descriptor({
+      timestamp: 1_000,
+      scope: { kind: "repository", repository: "repo-a" },
+    }));
+    await searches.add(descriptor({
+      timestamp: 2_000,
+      scope: { kind: "repository", repository: "repo-b" },
+    }));
+    await searches.add(descriptor({
+      timestamp: 3_000,
+      scope: { kind: "repository", repository: "repo-a" },
+    }));
+
+    const all = await searches.getAll();
+    assert.strictEqual(all.length, 2);
+    assert.deepStrictEqual(all.map(item => item.scope), [
+      { kind: "repository", repository: "repo-a" },
+      { kind: "repository", repository: "repo-b" },
+    ]);
+    assert.deepStrictEqual(Object.keys(all[0].scope).sort(), ["kind", "repository"]);
+  });
+
+  test("rejects ambiguous or inexact repository identifiers", async () => {
+    const searches = recent();
+    await assert.rejects(searches.add(descriptor({
+      scope: { kind: "repository", repository: " repo-a" },
+    })), /descriptor is invalid/);
+    await assert.rejects(searches.add(descriptor({
+      scope: { kind: "repository", repository: "repo-a", repositories: ["repo-b"] },
+    })), /descriptor is invalid/);
+  });
+
+  test("caps entries and keeps newest-first order", async () => {
+    const searches = recent();
+    for (let index = 0; index < 12; index += 1) {
+      await searches.add(descriptor({ query: `query-${index}`, timestamp: index + 1 }));
+    }
+    const all = await searches.getAll();
+    assert.strictEqual(all.length, 10);
+    assert.strictEqual(all[0].query, "query-11");
+    assert.strictEqual(all[9].query, "query-2");
+  });
+
+  test("isolates workspace storage keys", async () => {
+    const first = recent("workspace-a");
+    const second = recent("workspace-b");
+    await Promise.all([
+      first.add(descriptor()),
+      second.add(descriptor({ workspace: "workspace-b", query: "name:django" })),
+    ]);
+    assert.strictEqual((await first.getAll())[0].query, "name:flask");
+    assert.strictEqual((await second.getAll())[0].query, "name:django");
+  });
+
+  test("ignores and evicts malformed or unversioned state", async () => {
+    const searches = recent();
+    store.set(searches.storageKey, [descriptor({ timestamp: 1_000 })]);
+    assert.deepStrictEqual(await searches.getAll(), []);
+    assert.strictEqual(store.has(searches.storageKey), false);
+
+    store.set(searches.storageKey, { version: 0, items: [] });
+    assert.deepStrictEqual(await searches.getAll(), []);
+    assert.strictEqual(store.has(searches.storageKey), false);
+  });
+
+  test("clear writes an empty versioned envelope and is awaited", async () => {
+    const searches = recent();
+    await searches.add(descriptor());
+    await searches.clear();
+    assert.deepStrictEqual(store.get(searches.storageKey), {
+      version: STORAGE_VERSION,
+      items: [],
     });
+  });
 
-    test('add() stores a search entry', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'my-ws', query: 'name:flask' });
-        const all = recent.getAll();
-        assert.strictEqual(all.length, 1);
-        assert.strictEqual(all[0].workspace, 'my-ws');
-        assert.strictEqual(all[0].query, 'name:flask');
-    });
+  test("serializes updates across instances sharing the same Memento and key", async () => {
+    const gate = deferred();
+    let updateCount = 0;
+    context.globalState.update = async (key, value) => {
+      updateCount += 1;
+      if (updateCount === 1) await gate.promise;
+      store.set(key, value);
+    };
+    const first = recent();
+    const second = recent();
+    const firstAdd = first.add(descriptor({ query: "first", timestamp: 1 }));
+    await new Promise(resolve => setImmediate(resolve));
+    const secondAdd = second.add(descriptor({ query: "second", timestamp: 2 }));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(updateCount, 1);
+    gate.resolve();
+    await Promise.all([firstAdd, secondAdd]);
+    assert.deepStrictEqual((await first.getAll()).map(item => item.query), ["second", "first"]);
+  });
 
-    test('add() deduplicates by workspace+query', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws', query: 'name:flask' });
-        recent.add({ workspace: 'ws', query: 'name:django' });
-        recent.add({ workspace: 'ws', query: 'name:flask' }); // duplicate
-        const all = recent.getAll();
-        assert.strictEqual(all.length, 2);
-        // Most recent first
-        assert.strictEqual(all[0].query, 'name:flask');
-        assert.strictEqual(all[1].query, 'name:django');
-    });
+  test("propagates persistence failure to the caller", async () => {
+    context.globalState.update = async () => {
+      throw new Error("quota exceeded");
+    };
+    await assert.rejects(recent().add(descriptor()), /quota exceeded/);
+    await assert.rejects(recent().clear(), /quota exceeded/);
+  });
 
-    test('add() caps at max entries', () => {
-        const recent = new RecentSearches(mockContext);
-        // Default max is 10, add 12 entries
-        for (let i = 0; i < 12; i++) {
-            recent.add({ workspace: 'ws', query: `query-${i}` });
-        }
-        const all = recent.getAll();
-        assert.ok(all.length <= 10);
-        // Most recent should be query-11
-        assert.strictEqual(all[0].query, 'query-11');
-    });
-
-    test('getAll() returns entries sorted by most recent first', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws', query: 'first', timestamp: 1000 });
-        recent.add({ workspace: 'ws', query: 'second', timestamp: 2000 });
-        recent.add({ workspace: 'ws', query: 'third', timestamp: 3000 });
-        const all = recent.getAll();
-        assert.strictEqual(all[0].query, 'third');
-        assert.strictEqual(all[1].query, 'second');
-        assert.strictEqual(all[2].query, 'first');
-    });
-
-    test('clear() removes all entries', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws', query: 'name:flask' });
-        recent.add({ workspace: 'ws', query: 'name:django' });
-        recent.clear();
-        const all = recent.getAll();
-        assert.strictEqual(all.length, 0);
-    });
-
-    test('getAll() returns empty array when nothing stored', () => {
-        const recent = new RecentSearches(mockContext);
-        const all = recent.getAll();
-        assert.ok(Array.isArray(all));
-        assert.strictEqual(all.length, 0);
-    });
-
-    test('add() sets default scope and timestamp', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws', query: 'name:flask' });
-        const all = recent.getAll();
-        assert.strictEqual(all[0].scope, 'workspace');
-        assert.ok(all[0].timestamp > 0);
-    });
-
-    test('add() preserves custom scope', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws', query: 'name:flask', scope: 'repository' });
-        const all = recent.getAll();
-        assert.strictEqual(all[0].scope, 'repository');
-    });
-
-    test('different workspaces are not deduped', () => {
-        const recent = new RecentSearches(mockContext);
-        recent.add({ workspace: 'ws1', query: 'name:flask' });
-        recent.add({ workspace: 'ws2', query: 'name:flask' });
-        const all = recent.getAll();
-        assert.strictEqual(all.length, 2);
-    });
-
-    test('workspace slug scopes storage keys', () => {
-        const recentA = new RecentSearches(mockContext, 'workspace-a');
-        const recentB = new RecentSearches(mockContext, 'workspace-b');
-
-        recentA.add({ workspace: 'workspace-a', query: 'name:flask' });
-        recentB.add({ workspace: 'workspace-b', query: 'name:django' });
-
-        assert.strictEqual(recentA.getAll().length, 1);
-        assert.strictEqual(recentA.getAll()[0].query, 'name:flask');
-        assert.strictEqual(recentB.getAll().length, 1);
-        assert.strictEqual(recentB.getAll()[0].query, 'name:django');
-    });
+  test("rejects ambiguous legacy scope strings", async () => {
+    await assert.rejects(
+      recent().add(descriptor({ scope: "workspace" })),
+      /descriptor is invalid/
+    );
+  });
 });

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -2,6 +2,10 @@ const assert = require("assert");
 const vscode = require("vscode");
 const UpstreamIndicatorNode = require("../models/upstreamIndicatorNode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const {
+  bindConnectionManager,
+  unbindConnectionManager,
+} = require("../util/connectionManager");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
@@ -14,6 +18,8 @@ suite("RepositoryNode Test Suite", () => {
   let originalGetAllUpstreamData;
   let originalGetUpstreamDataForFormats;
   let originalApiGet;
+  let managerBinding;
+  let accountState;
   const terraformExporterPath = require.resolve("../util/terraformExporter");
 
   const context = {
@@ -23,6 +29,13 @@ suite("RepositoryNode Test Suite", () => {
       },
       async update() {},
     },
+  };
+  const connectionManager = {
+    activationId: "activation-a",
+    getState() {
+      return { ...accountState };
+    },
+    setState(next) { accountState = { ...accountState, ...next }; },
   };
 
   setup(() => {
@@ -35,6 +48,13 @@ suite("RepositoryNode Test Suite", () => {
     originalGetAllUpstreamData = upstreamChecker.getAllUpstreamData;
     originalGetUpstreamDataForFormats = upstreamChecker.getUpstreamDataForFormats;
     originalApiGet = CloudsmithAPI.prototype.get;
+    accountState = {
+      activationId: connectionManager.activationId,
+      accountEpoch: 1,
+      sessionConnected: true,
+      status: "connected",
+    };
+    managerBinding = bindConnectionManager(context, connectionManager);
 
     vscode.workspace.getConfiguration = () => ({
       get(key) {
@@ -51,6 +71,8 @@ suite("RepositoryNode Test Suite", () => {
     upstreamChecker.getAllUpstreamData = originalGetAllUpstreamData;
     upstreamChecker.getUpstreamDataForFormats = originalGetUpstreamDataForFormats;
     CloudsmithAPI.prototype.get = originalApiGet;
+    managerBinding.dispose();
+    unbindConnectionManager(context, connectionManager);
     delete require.cache[terraformExporterPath];
     delete require.cache[repositoryNodePath];
     delete require.cache[upstreamCheckerPath];
@@ -95,7 +117,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "example-repo", slug_perm: "example-repo", name: "Example Repo" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     repositoryNode.getPackages = async () => [
@@ -138,7 +161,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "grouped-repo", slug_perm: "grouped-repo", name: "Grouped Repo" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     const upstreams = await repositoryNode.getUpstreams([{ name: "package-group-without-format" }]);
@@ -167,7 +191,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "complete-repo", slug_perm: "complete-repo", name: "Complete Repo" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     const upstreams = await repositoryNode.getUpstreams([{ formats: SUPPORTED_UPSTREAM_FORMATS }]);
@@ -182,7 +207,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "indicator-repo", slug_perm: "indicator-repo", name: "Indicator Repo" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     repositoryNode.getPackages = async () => [{ format: "python" }];
@@ -230,7 +256,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "packages", slug_perm: "packages", name: "Packages" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     const packages = await repositoryNode.getPackages();
@@ -259,7 +286,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "packages", slug_perm: "packages", name: "Packages" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     const packages = await repositoryNode.getPackages();
@@ -291,7 +319,8 @@ suite("RepositoryNode Test Suite", () => {
     const repositoryNode = new RepositoryNode(
       { slug: "packages", slug_perm: "packages", name: "Packages" },
       "acme",
-      context
+      context,
+      { connectionManager }
     );
 
     assert.deepStrictEqual(await repositoryNode.getPackages(), []);
@@ -299,5 +328,33 @@ suite("RepositoryNode Test Suite", () => {
       () => repositoryNode.getEntitlements(),
       error => error && error.kind === "invalid_response"
     );
+  });
+
+  test("does not publish packages completed after an account change", async () => {
+    let release;
+    const response = new Promise(resolve => { release = resolve; });
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context,
+      {
+        connectionManager,
+        createCloudsmithAPI: () => ({ get: async () => response }),
+      }
+    );
+    const pending = repositoryNode.getPackages();
+    await new Promise(resolve => setImmediate(resolve));
+    connectionManager.setState({ accountEpoch: 2 });
+    release(apiSuccess([{
+      namespace: "acme",
+      repository: "packages",
+      name: "old-package",
+      format: "npm",
+      slug: "old-package",
+      slug_perm: "old-package",
+      version: "1.0.0",
+    }]));
+
+    assert.deepStrictEqual(await pending, []);
   });
 });

--- a/test/searchIntent.test.js
+++ b/test/searchIntent.test.js
@@ -1,0 +1,215 @@
+const assert = require("assert");
+const {
+  evictPersistedUpstreamCaches,
+  executeSearchIntent,
+  resetAccountScopedState,
+  searchDescriptorFromRecent,
+} = require("../extension");
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+suite("search intent command boundary", () => {
+  test("account reset invalidates every cache before independently settled projections", async () => {
+    const order = [];
+    const cleared = new Set();
+    const clear = name => () => {
+      order.push(name);
+      cleared.add(name);
+    };
+
+    const outcome = await resetAccountScopedState({ globalState: {} }, {
+      workspaceCache: { clear: clear("workspace") },
+      searchProvider: { clear: clear("search") },
+      filterState: { clear: clear("filter") },
+      recentPackages: { clear: clear("recent") },
+      clearVulnerabilityCache: clear("vulnerability"),
+      dependencyHealthProvider: {
+        async resetForAccountChange() {
+          order.push("dependency");
+          throw new Error("diagnostics failed");
+        },
+      },
+      async projectHasMultipleWorkspaces(value) {
+        order.push(`projection:${value}`);
+        throw new Error("setContext failed");
+      },
+      async evictPersistedUpstreamCaches() {
+        order.push("upstream");
+        cleared.add("upstream");
+      },
+    });
+
+    assert.deepStrictEqual(order.slice(0, 5), [
+      "workspace",
+      "search",
+      "filter",
+      "recent",
+      "vulnerability",
+    ]);
+    assert.deepStrictEqual([...cleared].sort(), [
+      "filter",
+      "recent",
+      "search",
+      "upstream",
+      "vulnerability",
+      "workspace",
+    ]);
+    assert.deepStrictEqual(order.slice(5), ["dependency", "projection:false", "upstream"]);
+    assert.deepStrictEqual(outcome.asyncResults.map(result => result.status), [
+      "rejected",
+      "rejected",
+      "fulfilled",
+    ]);
+  });
+
+  test("evicts persisted upstream state before account availability is known", async () => {
+    const store = new Map([
+      ["cloudsmith-upstreams:v3:stale", { version: 3 }],
+      ["unrelated", { keep: true }],
+    ]);
+    const complete = await evictPersistedUpstreamCaches({
+      globalState: {
+        keys: () => [...store.keys()],
+        async update(key, value) {
+          if (value === undefined) store.delete(key);
+        },
+      },
+    });
+
+    assert.strictEqual(complete, true);
+    assert.strictEqual(store.has("cloudsmith-upstreams:v3:stale"), false);
+    assert.strictEqual(store.has("unrelated"), true);
+  });
+
+  test("owns and launches search before detached history persistence", async () => {
+    const execution = deferred();
+    const history = deferred();
+    const calls = [];
+    const provider = {
+      beginSearch(descriptor) {
+        calls.push("begin");
+        return { descriptor };
+      },
+      executeSearch() {
+        calls.push("execute");
+        return execution.promise;
+      },
+    };
+    const recentSearches = {
+      add() {
+        calls.push("history");
+        return history.promise;
+      },
+    };
+
+    const pending = executeSearchIntent(provider, {
+      kind: "workspace",
+      workspace: "workspace-a",
+      query: "name:artifact",
+      page: 1,
+    }, { recentSearches, record: true });
+
+    assert.deepStrictEqual(calls, ["begin", "execute"]);
+    await Promise.resolve();
+    assert.deepStrictEqual(calls, ["begin", "execute", "history"]);
+    execution.resolve("searched");
+    assert.strictEqual(await pending, "searched");
+    history.resolve();
+  });
+
+  test("records and replays an exact single-repository descriptor", async () => {
+    let recorded;
+    const provider = {
+      beginSearch(descriptor) { return { descriptor }; },
+      async executeSearch() {},
+    };
+    await executeSearchIntent(provider, {
+      kind: "repository",
+      workspace: "workspace-a",
+      repository: "repo-a",
+      query: "name:artifact",
+      page: 1,
+    }, {
+      record: true,
+      recentSearches: { async add(value) { recorded = value; } },
+    });
+    await Promise.resolve();
+
+    assert.deepStrictEqual(recorded, {
+      workspace: "workspace-a",
+      query: "name:artifact",
+      scope: { kind: "repository", repository: "repo-a" },
+    });
+    assert.deepStrictEqual(searchDescriptorFromRecent(recorded), {
+      kind: "repository",
+      workspace: "workspace-a",
+      repository: "repo-a",
+      query: "name:artifact",
+      page: 1,
+    });
+    assert.strictEqual(searchDescriptorFromRecent({
+      ...recorded,
+      scope: { kind: "repository", repository: "repo-a", extra: true },
+    }), null);
+  });
+
+  test("handles detached history rejection without rejecting search", async () => {
+    const result = await executeSearchIntent({
+      beginSearch(descriptor) { return { descriptor }; },
+      async executeSearch() { return "searched"; },
+    }, {
+      kind: "workspace",
+      workspace: "workspace-a",
+      query: "artifact",
+    }, {
+      record: true,
+      recentSearches: { async add() { throw new Error("quota"); } },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(result, "searched");
+  });
+
+  test("persists the owned normalized descriptor instead of mutable caller input", async () => {
+    const raw = {
+      kind: "repository",
+      workspace: " raw-workspace ",
+      repository: " raw-repo ",
+      query: "raw-query",
+    };
+    const owned = Object.freeze({
+      kind: "repository",
+      workspace: "workspace-a",
+      repository: "repo-a",
+      query: "normalized-query",
+      page: 1,
+    });
+    let recorded;
+    const pending = executeSearchIntent({
+      beginSearch() { return Object.freeze({ descriptor: owned }); },
+      async executeSearch() {},
+    }, raw, {
+      record: true,
+      recentSearches: { async add(value) { recorded = value; } },
+    });
+    raw.workspace = "mutated-workspace";
+    raw.repository = "mutated-repo";
+    raw.query = "mutated-query";
+    await pending;
+    await Promise.resolve();
+
+    assert.deepStrictEqual(recorded, {
+      workspace: "workspace-a",
+      query: "normalized-query",
+      scope: { kind: "repository", repository: "repo-a" },
+    });
+  });
+});

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -1,134 +1,779 @@
 const assert = require("assert");
-const vscode = require("vscode");
 const { SearchProvider } = require("../views/searchProvider");
-const { PaginatedFetch } = require("../util/paginatedFetch");
 
-suite("SearchProvider Test Suite", () => {
-  let originalWithProgress;
-  let originalShowErrorMessage;
-  let originalShowInformationMessage;
-  let originalShowWarningMessage;
-  let originalGetConfiguration;
-  let originalFetchPage;
-  let provider;
-
-  const context = {
-    secrets: {
-      onDidChange() {},
-      async get() {
-        return "true";
-      },
-    },
-  };
+suite("SearchProvider atomic search state", () => {
+  let providers;
 
   setup(() => {
-    provider = new SearchProvider(context);
-
-    originalWithProgress = vscode.window.withProgress;
-    originalShowErrorMessage = vscode.window.showErrorMessage;
-    originalShowInformationMessage = vscode.window.showInformationMessage;
-    originalShowWarningMessage = vscode.window.showWarningMessage;
-    originalGetConfiguration = vscode.workspace.getConfiguration;
-    originalFetchPage = PaginatedFetch.prototype.fetchPage;
-
-    vscode.window.withProgress = async (_options, task) => task();
-    vscode.window.showErrorMessage = async () => {};
-    vscode.window.showInformationMessage = async () => {};
-    vscode.window.showWarningMessage = async () => {};
-    vscode.workspace.getConfiguration = () => ({
-      get() {
-        return 50;
-      },
-    });
-    PaginatedFetch.prototype.fetchPage = async () => ({
-      data: [{
-        name: "artifact",
-        format: "raw",
-        repository: "repo-a",
-        namespace: "workspace-a",
-        status_str: "Completed",
-        slug: "artifact-1",
-        slug_perm: "artifact-1-perm",
-        downloads: 0,
-        version: "1.0.0",
-        uploaded_at: "2026-03-25T00:00:00Z",
-      }],
-      pagination: {
-        page: 1,
-        pageTotal: 1,
-        count: 1,
-      },
-    });
+    providers = [];
   });
 
   teardown(() => {
-    vscode.window.withProgress = originalWithProgress;
-    vscode.window.showErrorMessage = originalShowErrorMessage;
-    vscode.window.showInformationMessage = originalShowInformationMessage;
-    vscode.window.showWarningMessage = originalShowWarningMessage;
-    vscode.workspace.getConfiguration = originalGetConfiguration;
-    PaginatedFetch.prototype.fetchPage = originalFetchPage;
+    for (const provider of providers) {
+      provider.dispose();
+    }
   });
 
-  test("search() clears repo scope when repo is omitted", async () => {
-    provider.currentRepo = "repo-a";
-    await provider.search("workspace-a", "vulnerabilities:>0");
-    assert.strictEqual(provider.currentRepo, null);
-  });
-
-  test("searchRepos() clears stale repo scope", async () => {
-    provider.currentRepo = "repo-a";
-    await provider.searchRepos("workspace-a", ["repo-a", "repo-b"], "vulnerabilities:>0");
-    assert.strictEqual(provider.currentRepo, null);
-  });
-
-  test("search cancellation reaches pagination and preserves the prior result snapshot", async () => {
-    const priorResults = [{ marker: "prior" }];
-    const token = { isCancellationRequested: true };
-    let progressOptions;
-    let requestOptions;
-    provider.searchResults = priorResults;
-    provider.currentWorkspace = "workspace-before";
-    provider.currentQuery = "before";
-
-    vscode.window.withProgress = async (options, task) => {
-      progressOptions = options;
-      return task({ report() {} }, token);
-    };
-    PaginatedFetch.prototype.fetchPage = async (_endpoint, _page, _pageSize, _query, options) => {
-      requestOptions = options;
-      return {
-        data: [],
-        pagination: null,
-        error: { kind: "cancelled", message: "The request was canceled." },
-      };
-    };
+  test("commits one deeply frozen canonical snapshot", async () => {
+    const { provider } = createProvider({
+      fetchPage: async () => page([pkg("artifact")]),
+    });
 
     await provider.search("workspace-a", "name:artifact");
 
-    assert.strictEqual(progressOptions.cancellable, true);
-    assert.strictEqual(requestOptions.cancellationToken, token);
-    assert.strictEqual(provider.searchResults, priorResults);
-    assert.strictEqual(provider.currentWorkspace, "workspace-before");
-    assert.strictEqual(provider.currentQuery, "before");
+    assert.strictEqual(provider.currentWorkspace, "workspace-a");
+    assert.strictEqual(provider.currentQuery, "name:artifact");
+    assert.strictEqual(provider.currentRepo, null);
+    assert.strictEqual(provider.searchResults.length, 1);
+    assert(Object.isFrozen(provider.state));
+    assert(Object.isFrozen(provider.state.committed));
+    assert(Object.isFrozen(provider.state.committed.descriptor));
+    assert(Object.isFrozen(provider.state.committed.results));
+    assert(Object.isFrozen(provider.state.committed.results[0]));
+    assert(Object.isFrozen(provider.state.committed.diagnostics));
   });
 
-  test("getChildren() shows the signed-out state when disconnected and idle", async () => {
-    provider = new SearchProvider({
-      secrets: {
-        onDidChange() {},
-        async get(key) {
-          if (key === "cloudsmith-vsc.isConnected") {
-            return "false";
-          }
-          return null;
-        },
+  test("freezes the node snapshot without freezing its injected connection manager", async () => {
+    const connectionManager = createConnectionManager();
+    connectionManager.callerOwned = { mutable: true };
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => page([pkg("artifact")]),
+    });
+
+    await provider.search("workspace-a", "artifact");
+
+    const committedNode = provider.searchResults[0];
+    assert.strictEqual(Object.isFrozen(committedNode), true);
+    assert.strictEqual(committedNode._connectionManager, connectionManager);
+    assert.strictEqual(Object.isFrozen(connectionManager), false);
+    assert.strictEqual(Object.isFrozen(connectionManager.callerOwned), false);
+    connectionManager.callerOwned.mutable = false;
+    connectionManager.additionalCallerState = "still mutable";
+    assert.strictEqual(connectionManager.callerOwned.mutable, false);
+    assert.strictEqual(connectionManager.additionalCallerState, "still mutable");
+  });
+
+  test("canonicalizes every retained field without freezing the API response", async () => {
+    const responsePackage = pkg("artifact", {
+      tags: { info: ["upstream"], nested: { source: "api" } },
+      license: "MIT",
+      licenseInfo: { metadata: { label: "caller-owned", nested: { secret: true } } },
+      status_str: { nested: { value: "Quarantined" } },
+      slug: { nested: "caller-owned" },
+      uploaded_at: { nested: "caller-owned" },
+      status_reason: { nested: "caller-owned" },
+      policy_violated: { nested: true },
+      max_severity: { nested: "Critical" },
+      vulnerability_scan_results_url: { nested: "https://example.invalid" },
+      cdn_url: { nested: "https://example.invalid" },
+    });
+    const { provider } = createProvider({
+      fetchPage: async () => page([responsePackage]),
+    });
+
+    await provider.search("workspace-a", "artifact");
+
+    const committedNode = provider.searchResults[0];
+    assert.notStrictEqual(committedNode.tags_raw, responsePackage.tags);
+    assert.notStrictEqual(committedNode.licenseInfo, responsePackage.licenseInfo);
+    assert.deepStrictEqual(committedNode.tags_raw, { info: ["upstream"] });
+    assert.strictEqual(committedNode.tags_raw.nested, undefined);
+    assert.strictEqual(Object.isFrozen(committedNode.licenseInfo.metadata), true);
+    assert.strictEqual(committedNode.licenseInfo.metadata.label, "Permissive");
+    assert.strictEqual(committedNode.status_str.value, null);
+    assert.strictEqual(committedNode.slug.value, null);
+    assert.strictEqual(committedNode.uploaded_at.value, null);
+    assert.strictEqual(committedNode.status_reason, null);
+    assert.strictEqual(committedNode.policy_violated, false);
+    assert.strictEqual(committedNode.max_severity, null);
+    assert.strictEqual(committedNode.vulnerability_scan_results_url, null);
+    assert.strictEqual(committedNode.cdn_url, null);
+    assert.strictEqual(Object.isFrozen(responsePackage), false);
+    assert.strictEqual(Object.isFrozen(responsePackage.tags), false);
+    assert.strictEqual(Object.isFrozen(responsePackage.tags.info), false);
+    assert.strictEqual(Object.isFrozen(responsePackage.licenseInfo), false);
+    assert.strictEqual(Object.isFrozen(responsePackage.status_str.nested), false);
+    responsePackage.tags.info.push("caller-remains-mutable");
+    responsePackage.licenseInfo.metadata.label = "mutated";
+    responsePackage.status_str.nested.value = "mutated";
+    assert.deepStrictEqual(committedNode.tags_raw.info, ["upstream"]);
+    assert.strictEqual(committedNode.status_str.value, null);
+  });
+
+  test("beginSearch synchronously supersedes the prior intent before either executes", async () => {
+    let fetchCount = 0;
+    const { provider } = createProvider({
+      fetchPage: async () => {
+        fetchCount += 1;
+        return page([pkg("artifact")]);
+      },
+    });
+    const first = provider.beginSearch({ kind: "workspace", workspace: "workspace-a", query: "first" });
+    const second = provider.beginSearch({ kind: "workspace", workspace: "workspace-a", query: "second" });
+
+    await provider.executeSearch(first);
+    await provider.executeSearch(second);
+
+    assert.strictEqual(fetchCount, 1);
+    assert.strictEqual(provider.currentQuery, "second");
+  });
+
+  test("a stale root success cannot replace or refresh over the latest result", async () => {
+    const slow = deferred();
+    const fast = deferred();
+    const { provider, messages } = createProvider({
+      fetchPage: async (_endpoint, _page, _size, query) => (
+        query === "slow" ? slow.promise : fast.promise
+      ),
+    });
+    let changeCount = 0;
+    provider.onDidChangeTreeData(() => { changeCount += 1; });
+
+    const slowSearch = provider.search("workspace-a", "slow");
+    const fastSearch = provider.search("workspace-a", "fast");
+    fast.resolve(page([pkg("new-result")]));
+    await fastSearch;
+    const changesAfterLatestCommit = changeCount;
+    slow.resolve(page([pkg("old-result")]));
+    await slowSearch;
+
+    assert.strictEqual(provider.currentQuery, "fast");
+    assert.strictEqual(provider.searchResults[0].name, "new-result");
+    assert.deepStrictEqual(messages.error, []);
+    assert.strictEqual(changeCount, changesAfterLatestCommit);
+  });
+
+  test("a stale root failure publishes no notification or failure state", async () => {
+    const slow = deferred();
+    const { provider, messages } = createProvider({
+      fetchPage: async (_endpoint, _page, _size, query) => {
+        if (query === "slow") {
+          return slow.promise;
+        }
+        return page([pkg("new-result")]);
       },
     });
 
-    const nodes = await provider.getChildren();
+    const slowSearch = provider.search("workspace-a", "slow");
+    await provider.search("workspace-a", "fast");
+    slow.resolve(failedPage("forbidden"));
+    await slowSearch;
 
-    assert.strictEqual(nodes.length, 1);
+    assert.strictEqual(provider.currentQuery, "fast");
+    assert.strictEqual(provider.state.failure, null);
+    assert.deepStrictEqual(messages.error, []);
+  });
+
+  test("unexpected search exceptions never reach user-facing diagnostics", async () => {
+    const secret = "csa_secret-value-from-thrown-exception";
+    const { provider, messages } = createProvider({
+      fetchPage: async () => { throw new Error(`${secret}${"x".repeat(10000)}`); },
+    });
+
+    await provider.search("workspace-a", "artifact");
+
+    assert.strictEqual(messages.error.length, 1);
+    assert.strictEqual(messages.error[0].includes(secret), false);
+    assert(messages.error[0].length < 200);
+    assert.strictEqual(provider.state.failure.message, messages.error[0]);
+  });
+
+  test("current failure preserves the previously committed session", async () => {
+    let shouldFail = false;
+    const { provider, messages } = createProvider({
+      fetchPage: async () => shouldFail ? failedPage("rate_limited") : page([pkg("prior")]),
+    });
+    await provider.search("workspace-a", "prior");
+    const prior = provider.state.committed;
+    shouldFail = true;
+
+    await provider.search("workspace-a", "replacement");
+
+    assert.strictEqual(provider.state.committed, prior);
+    assert.strictEqual(provider.state.failure.descriptor.query, "replacement");
+    assert.strictEqual(messages.error.length, 1);
+    const children = await provider.getChildren();
+    assert(children.some(node => node.getTreeItem().label === "Search failed"));
+  });
+
+  test("cancellation preserves the committed snapshot without a failure notification", async () => {
+    let cancelled = false;
+    const { provider, messages } = createProvider({
+      fetchPage: async () => cancelled ? failedPage("cancelled") : page([pkg("prior")]),
+    });
+    await provider.search("workspace-a", "prior");
+    const prior = provider.state.committed;
+    cancelled = true;
+
+    await provider.search("workspace-a", "cancelled");
+
+    assert.strictEqual(provider.state.committed, prior);
+    assert.strictEqual(provider.state.failure, null);
+    assert.deepStrictEqual(messages.error, []);
+  });
+
+  test("account epoch change aborts and clears in-flight account data", async () => {
+    const pending = deferred();
+    const connectionManager = createConnectionManager();
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => pending.promise,
+    });
+    const search = provider.search("workspace-a", "slow");
+
+    connectionManager.update({ accountEpoch: 1, sessionConnected: true });
+    pending.resolve(page([pkg("stale")]));
+    await search;
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.pending, null);
+  });
+
+  test("a same-epoch session disconnect aborts and suppresses root publication", async () => {
+    const pending = deferred();
+    const connectionManager = createConnectionManager();
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => pending.promise,
+    });
+    const search = provider.search("workspace-a", "slow");
+
+    connectionManager.update({ sessionConnected: false, status: "absent" });
+    pending.resolve(page([pkg("stale")]));
+    await search;
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.pending, null);
+    assert.deepStrictEqual(provider.searchResults, []);
+    const nodes = await provider.getChildren();
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
   });
+
+  test("candidate validation with the same connected session preserves in-flight work", async () => {
+    const pending = deferred();
+    const connectionManager = createConnectionManager();
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => pending.promise,
+    });
+    const search = provider.search("workspace-a", "slow");
+
+    connectionManager.update({ sessionConnected: true, status: "validating" });
+    connectionManager.update({ sessionConnected: true, status: "connected" });
+    pending.resolve(page([pkg("preserved")]));
+    await search;
+
+    assert.strictEqual(provider.state.committed.descriptor.query, "slow");
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["preserved"]);
+  });
+
+  test("an activation change with the same epoch invalidates a pending page", async () => {
+    const secondPage = deferred();
+    const connectionManager = createConnectionManager();
+    const { provider } = createProvider({
+      connectionManager,
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => (
+        requestedPage === 1
+          ? page([pkg("one"), pkg("two")], { pageTotal: 2, count: 3, pageSize: 2 })
+          : secondPage.promise
+      ),
+    });
+    await provider.search("workspace-a", "artifact");
+    const loading = provider.loadNextPage();
+
+    connectionManager.update({ activationId: "activation-b" });
+    secondPage.resolve(page([pkg("stale")], {
+      requestedPage: 2,
+      pageTotal: 2,
+      count: 3,
+      pageSize: 2,
+    }));
+    await loading;
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.deepStrictEqual(provider.searchResults, []);
+  });
+
+  test("does not dispatch a search while disconnected", async () => {
+    let fetches = 0;
+    const connectionManager = createConnectionManager({
+      sessionConnected: false,
+      status: "absent",
+    });
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => {
+        fetches += 1;
+        return page([]);
+      },
+    });
+
+    await provider.search("workspace-a", "artifact");
+
+    assert.strictEqual(fetches, 0);
+    assert.strictEqual(provider.state.pending, null);
+  });
+
+  test("requires an exact namespace and repository response scope", async () => {
+    const { provider, messages } = createProvider({
+      fetchPage: async () => page([pkg("wrong", { repository: "repo-b" })]),
+    });
+
+    await provider.search("workspace-a", "name:wrong", 1, "repo-a");
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+    assert.match(messages.error[0], /outside the requested scope/);
+  });
+
+  test("rejects non-canonical slug_perm records before committing", async () => {
+    const malformed = pkg("artifact");
+    malformed.slug_perm = { value: "artifact-perm" };
+    const { provider } = createProvider({
+      fetchPage: async () => page([malformed]),
+    });
+
+    await provider.search("workspace-a", "name:artifact");
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+  });
+
+  test("invalid repository counts fail currently and perform no fetch", async () => {
+    let fetchCount = 0;
+    const { provider, messages } = createProvider({
+      fetchPage: async () => {
+        fetchCount += 1;
+        return page([]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", [], "name:artifact");
+    await provider.searchRepos(
+      "workspace-a",
+      Array.from({ length: 101 }, (_, index) => `repo-${index}`),
+      "name:artifact"
+    );
+
+    assert.strictEqual(fetchCount, 0);
+    assert.strictEqual(provider.state.failure.kind, "invalid_request");
+    assert.match(messages.error.at(-1), /between 1 and 100/);
+  });
+
+  test("rejects over-limit descriptor and package identity strings", async () => {
+    let fetchCount = 0;
+    const { provider } = createProvider({
+      fetchPage: async () => {
+        fetchCount += 1;
+        return page([]);
+      },
+    });
+
+    await provider.search("w".repeat(201), "artifact");
+    await provider.search("workspace-a", "q".repeat(2049));
+    await provider.search("workspace-a", "artifact", 1, "r".repeat(201));
+
+    assert.strictEqual(fetchCount, 0);
+    assert.strictEqual(provider.state.failure.kind, "invalid_request");
+
+    const oversized = pkg("x".repeat(2049));
+    const { provider: responseProvider } = createProvider({
+      fetchPage: async () => page([oversized]),
+    });
+    await responseProvider.search("workspace-a", "artifact");
+
+    assert.strictEqual(responseProvider.state.committed, null);
+    assert.strictEqual(responseProvider.state.failure.kind, "invalid_response");
+  });
+
+  test("multi-repository work uses four workers and reserves the 5000-item budget", async () => {
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      pageSize: 100,
+      fetchPage: async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await nextTurn();
+        active -= 1;
+        return page([], { pageSize: 100 });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(calls, 50);
+    assert.strictEqual(maxActive, 4);
+    assert.strictEqual(provider.state.committed.descriptor.repositories.length, 100);
+    assert(Object.isFrozen(provider.state.committed.descriptor.repositories));
+    assert.strictEqual(provider.state.committed.diagnostics.unsearchedRepositoryCount, 50);
+    assert.strictEqual(provider.state.committed.pageable, false);
+  });
+
+  test("reports first-page multi-repository truncation without offering paging", async () => {
+    const firstPage = Array.from({ length: 20 }, (_, index) => pkg(`artifact-${index}`));
+    const { provider } = createProvider({
+      pageSize: 20,
+      fetchPage: async () => page(firstPage, {
+        pageSize: 20,
+        pageTotal: 50,
+        count: 1000,
+      }),
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    const committed = provider.state.committed;
+    assert.strictEqual(committed.results.length, 20);
+    assert.strictEqual(committed.totalCount, 1000);
+    assert.strictEqual(committed.pageable, false);
+    assert.strictEqual(committed.diagnostics.truncatedRepositoryCount, 1);
+    assert.strictEqual(committed.diagnostics.truncatedResultCount, 980);
+    assert.strictEqual(committed.diagnostics.partial, true);
+    assert.strictEqual(committed.diagnostics.capReached, true);
+    assert.strictEqual(committed.diagnostics.truncationDetails.length, 1);
+    assert(Object.isFrozen(committed.diagnostics.truncationDetails));
+    assert(Object.isFrozen(committed.diagnostics.truncationDetails[0]));
+
+    const items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.match(items[0].description, /20 of 1,000 matching packages loaded \(partial\)/);
+    assert(items.some(item => /additional matching pages/.test(item.label)));
+    assert.strictEqual(items.some(item => item.contextValue === "loadMore"), false);
+  });
+
+  test("multi-repository cancellation stops scheduling and preserves prior state", async () => {
+    const token = { isCancellationRequested: false };
+    let calls = 0;
+    const { provider, messages } = createProvider({
+      cancellationToken: token,
+      fetchPage: async () => {
+        calls += 1;
+        token.isCancellationRequested = true;
+        return failedPage("cancelled");
+      },
+    });
+
+    await provider.searchRepos(
+      "workspace-a",
+      Array.from({ length: 20 }, (_, index) => `repo-${index}`),
+      "name:artifact"
+    );
+
+    assert(calls <= 4);
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure, null);
+    assert.deepStrictEqual(messages.error, []);
+  });
+
+  test("partial repository success commits exact scope with only 20 failure details", async () => {
+    const repositories = Array.from({ length: 26 }, (_, index) => `repo-${index}`);
+    const { provider, messages } = createProvider({
+      fetchPage: async endpoint => {
+        const repository = repositoryFromEndpoint(endpoint);
+        if (repository !== "repo-25") {
+          return failedPage("forbidden");
+        }
+        return page([pkg("success", { repository })]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(provider.state.committed.descriptor.kind, "repositories");
+    assert.deepStrictEqual(provider.state.committed.descriptor.repositories, repositories);
+    assert.strictEqual(provider.searchResults.length, 1);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 25);
+    assert.strictEqual(provider.state.committed.diagnostics.failureDetails.length, 20);
+    assert.strictEqual(messages.warning.length, 1);
+    assert.match(messages.warning[0], /and 5 more/);
+  });
+
+  test("all repository failures preserve the prior committed session", async () => {
+    let fail = false;
+    const { provider } = createProvider({
+      fetchPage: async () => fail ? failedPage("forbidden") : page([pkg("prior")]),
+    });
+    await provider.search("workspace-a", "prior");
+    const prior = provider.state.committed;
+    fail = true;
+
+    await provider.searchRepos("workspace-a", ["repo-a", "repo-b"], "replacement");
+
+    assert.strictEqual(provider.state.committed, prior);
+    assert.strictEqual(provider.state.failure.descriptor.kind, "repositories");
+  });
+
+  test("deduplicates by namespace, repository, and canonical slug_perm", async () => {
+    const duplicate = pkg("artifact");
+    const { provider } = createProvider({
+      fetchPage: async () => page([duplicate, { ...duplicate }]),
+    });
+
+    await provider.search("workspace-a", "name:artifact");
+
+    assert.strictEqual(provider.searchResults.length, 1);
+  });
+
+  test("duplicate next-page commands return the same promise and fetch once", async () => {
+    const secondPage = deferred();
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls += 1;
+        if (requestedPage === 1) {
+          return page([pkg("one"), pkg("two")], { pageTotal: 2, count: 3, pageSize: 2 });
+        }
+        return secondPage.promise;
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    const first = provider.loadNextPage();
+    const duplicate = provider.loadNextPage();
+    assert.strictEqual(first, duplicate);
+    secondPage.resolve(page([pkg("three")], { requestedPage: 2, pageTotal: 2, count: 3, pageSize: 2 }));
+    await first;
+
+    assert.strictEqual(calls, 2);
+    assert.strictEqual(provider.currentPage, 2);
+    assert.strictEqual(provider.searchResults.length, 3);
+  });
+
+  test("page failure keeps the retry target available", async () => {
+    let pageTwoCalls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        if (requestedPage === 1) {
+          return page([pkg("one"), pkg("two")], { pageTotal: 2, count: 3, pageSize: 2 });
+        }
+        pageTwoCalls += 1;
+        if (pageTwoCalls === 1) {
+          return failedPage("rate_limited", 2, 2);
+        }
+        return page([pkg("three")], { requestedPage: 2, pageTotal: 2, count: 3, pageSize: 2 });
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    await provider.loadNextPage();
+    assert.strictEqual(provider.currentPage, 1);
+    assert.strictEqual(provider.state.committed.pageable, true);
+    await provider.loadNextPage();
+
+    assert.strictEqual(pageTwoCalls, 2);
+    assert.strictEqual(provider.currentPage, 2);
+    assert.strictEqual(provider.searchResults.length, 3);
+  });
+
+  test("a new root search prevents an older page from appending", async () => {
+    const oldPage = deferred();
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage, _size, query) => {
+        if (query === "old" && requestedPage === 1) {
+          return page([pkg("old-one"), pkg("old-two")], { pageTotal: 2, count: 3, pageSize: 2 });
+        }
+        if (query === "old") {
+          return oldPage.promise;
+        }
+        return page([pkg("new")], { pageSize: 2 });
+      },
+    });
+    await provider.search("workspace-a", "old");
+    const loadingPage = provider.loadNextPage();
+
+    await provider.search("workspace-a", "new");
+    oldPage.resolve(page([pkg("stale")], { requestedPage: 2, pageTotal: 2, count: 3, pageSize: 2 }));
+    await loadingPage;
+
+    assert.strictEqual(provider.currentQuery, "new");
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["new"]);
+  });
+
+  test("stops page accumulation at 5000 and replaces Load More with truthful guidance", async function () {
+    this.timeout(5000);
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 100,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls += 1;
+        const data = Array.from({ length: 100 }, (_, index) => (
+          pkg(`artifact-${requestedPage}-${index}`)
+        ));
+        return page(data, {
+          requestedPage,
+          pageTotal: 51,
+          count: 5100,
+          pageSize: 100,
+        });
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    for (let pageNumber = 2; pageNumber <= 50; pageNumber += 1) {
+      await provider.loadNextPage();
+    }
+
+    assert.strictEqual(calls, 50);
+    assert.strictEqual(provider.searchResults.length, 5000);
+    assert.strictEqual(provider.currentPage, 50);
+    assert.strictEqual(provider.state.committed.pageable, false);
+    assert.strictEqual(provider.state.committed.diagnostics.capReached, true);
+    const labels = (await provider.getChildren()).map(node => node.getTreeItem().label);
+    assert(labels.includes("Showing the first 5,000 results"));
+    assert(!labels.some(label => label.startsWith("Load more results")));
+  });
+
+  test("clear invalidates a pending root and publishes no later result", async () => {
+    const pending = deferred();
+    const { provider } = createProvider({ fetchPage: async () => pending.promise });
+    const search = provider.search("workspace-a", "slow");
+
+    provider.clear();
+    pending.resolve(page([pkg("stale")]));
+    await search;
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure, null);
+  });
+
+  test("idle tree derives connection state from the shared manager", async () => {
+    const connectionManager = createConnectionManager({ accountEpoch: 0, sessionConnected: false });
+    const { provider } = createProvider({ connectionManager });
+
+    let nodes = await provider.getChildren();
+    assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
+
+    connectionManager.update({ accountEpoch: 0, sessionConnected: true });
+    nodes = await provider.getChildren();
+    assert.strictEqual(nodes[0].getTreeItem().label, "Search packages across a Cloudsmith workspace");
+  });
+
+  function createProvider(options = {}) {
+    const messages = { error: [], information: [], warning: [] };
+    const connectionManager = options.connectionManager || createConnectionManager();
+    const fetchPage = options.fetchPage || (async () => page([]));
+    const provider = new SearchProvider(
+      {},
+      {
+        connectionManager,
+        createCloudsmithAPI: () => ({}),
+        createPaginatedFetch: () => ({ fetchPage }),
+        withProgress: (_progressOptions, task) => task(
+          { report() {} },
+          options.cancellationToken || {
+            isCancellationRequested: false,
+            onCancellationRequested() { return { dispose() {} }; },
+          }
+        ),
+        notifications: {
+          error(message) { messages.error.push(message); },
+          information(message) { messages.information.push(message); },
+          warning(message) { messages.warning.push(message); },
+        },
+        getPageSize: () => options.pageSize || 50,
+      }
+    );
+    providers.push(provider);
+    return { provider, messages, connectionManager };
+  }
 });
+
+function createConnectionManager(initial = {}) {
+  let state = Object.freeze({
+    activationId: "activation-a",
+    accountEpoch: 0,
+    sessionConnected: true,
+    status: "connected",
+    ...initial,
+  });
+  const listeners = new Set();
+  return {
+    getState() {
+      return state;
+    },
+    onDidChange(listener) {
+      listeners.add(listener);
+      return { dispose() { listeners.delete(listener); } };
+    },
+    update(next) {
+      state = Object.freeze({ ...state, ...next });
+      for (const listener of listeners) {
+        listener(state);
+      }
+    },
+  };
+}
+
+function pkg(name, overrides = {}) {
+  return {
+    name,
+    format: "raw",
+    repository: "repo-a",
+    namespace: "workspace-a",
+    status_str: "Completed",
+    slug: `${name}-slug`,
+    slug_perm: `${name}-perm`,
+    downloads: 0,
+    version: "1.0.0",
+    uploaded_at: "2026-03-25T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function page(data, options = {}) {
+  const requestedPage = options.requestedPage || 1;
+  const pageTotal = options.pageTotal || requestedPage;
+  return {
+    data,
+    pagination: {
+      page: requestedPage,
+      pageTotal,
+      count: options.count ?? data.length,
+      pageSize: options.pageSize || 50,
+    },
+    error: null,
+  };
+}
+
+function failedPage(kind, requestedPage = 1, pageSize = 50) {
+  return {
+    data: [],
+    pagination: { page: requestedPage, pageTotal: requestedPage, count: 0, pageSize },
+    error: {
+      kind,
+      status: kind === "rate_limited" ? 429 : null,
+      retryable: kind === "rate_limited",
+      message: `Failure: ${kind}`,
+      requestId: null,
+      retryAfterMs: null,
+      outcomeUnknown: false,
+      diagnostic: {},
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function repositoryFromEndpoint(endpoint) {
+  return endpoint.split("/").filter(Boolean).at(-1);
+}
+
+function nextTurn() {
+  return new Promise(resolve => setImmediate(resolve));
+}

--- a/test/ssoAuthManager.test.js
+++ b/test/ssoAuthManager.test.js
@@ -1,0 +1,288 @@
+const assert = require("assert");
+const { EventEmitter } = require("events");
+const vscode = require("vscode");
+const { SSOAuthManager } = require("../util/ssoAuthManager");
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+function createConnectionHarness() {
+  const calls = [];
+  let current = null;
+  let nextId = 0;
+  const manager = {
+    beginCredentialOperation() {
+      const controller = new AbortController();
+      current = Object.freeze({ id: ++nextId, controller, signal: controller.signal });
+      calls.push(["begin", current.id]);
+      return current;
+    },
+    isOperationCurrent(token) {
+      return token === current && !token.signal.aborted;
+    },
+    cancelCredentialOperation(token) {
+      calls.push(["cancel", token.id]);
+      if (current === token) token.controller.abort();
+      return Object.freeze({ ok: false, status: "cancelled" });
+    },
+    async replaceCredential(candidate, token) {
+      calls.push(["replace", candidate, token.id]);
+      return Object.freeze({ ok: true, status: "connected", committed: true });
+    },
+  };
+  return { calls, manager };
+}
+
+suite("SSOAuthManager Test Suite", () => {
+  let originalShowErrorMessage;
+  let originalShowInformationMessage;
+  let originalShowWarningMessage;
+  let originalCreateTerminal;
+  let originalOnDidCloseTerminal;
+
+  setup(() => {
+    originalShowErrorMessage = vscode.window.showErrorMessage;
+    originalShowInformationMessage = vscode.window.showInformationMessage;
+    originalShowWarningMessage = vscode.window.showWarningMessage;
+    originalCreateTerminal = vscode.window.createTerminal;
+    originalOnDidCloseTerminal = vscode.window.onDidCloseTerminal;
+    vscode.window.showErrorMessage = async () => undefined;
+    vscode.window.showInformationMessage = async () => undefined;
+    vscode.window.showWarningMessage = async () => undefined;
+  });
+
+  teardown(() => {
+    vscode.window.showErrorMessage = originalShowErrorMessage;
+    vscode.window.showInformationMessage = originalShowInformationMessage;
+    vscode.window.showWarningMessage = originalShowWarningMessage;
+    vscode.window.createTerminal = originalCreateTerminal;
+    vscode.window.onDidCloseTerminal = originalOnDidCloseTerminal;
+  });
+
+  test("CLI import owns an operation before reading and validates before commit", async () => {
+    const read = deferred();
+    const { calls, manager: connectionManager } = createConnectionHarness();
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      findCLIConfigPath: () => "/tmp/cloudsmith-config.ini",
+      readFile: () => {
+        calls.push(["read"]);
+        return read.promise;
+      },
+    });
+
+    const pending = sso.importFromCLI();
+    assert.deepStrictEqual(calls.slice(0, 2), [["begin", 1], ["read"]]);
+    assert.strictEqual(calls.some(call => call[0] === "replace"), false);
+    read.resolve("[default]\napi_key = imported-key\n");
+    const result = await pending;
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(calls.at(-1), ["replace", "imported-key", 1]);
+  });
+
+  test("CLI import rejects oversized config before parsing or replacing credentials", async () => {
+    const { calls, manager: connectionManager } = createConnectionHarness();
+    const messages = [];
+    vscode.window.showErrorMessage = async message => { messages.push(message); };
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      findCLIConfigPath: () => "/tmp/cloudsmith-config.ini",
+      readFile: async () => `api_key=${"x".repeat(70 * 1024)}`,
+    });
+
+    const result = await sso.importFromCLI();
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.error.kind, "config_too_large");
+    assert.strictEqual(calls.some(call => call[0] === "replace"), false);
+    assert.deepStrictEqual(messages, ["Cloudsmith CLI config is too large to import."]);
+  });
+
+  test("CLI read failures never expose infrastructure messages containing credentials", async () => {
+    const leaked = "candidate-secret-in-filesystem-error";
+    const { manager: connectionManager } = createConnectionHarness();
+    const messages = [];
+    vscode.window.showErrorMessage = async message => { messages.push(message); };
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      findCLIConfigPath: () => "/tmp/cloudsmith-config.ini",
+      readFile: async () => { throw new Error(`failed while reading ${leaked}`); },
+    });
+
+    const result = await sso.importFromCLI();
+    const publicSurface = JSON.stringify({ result, messages });
+
+    assert.strictEqual(result.error.kind, "config_read_failed");
+    assert.strictEqual(publicSurface.includes(leaked), false);
+  });
+
+  test("a supplied CLI operation is reused", async () => {
+    const { calls, manager: connectionManager } = createConnectionHarness();
+    const operation = connectionManager.beginCredentialOperation();
+    calls.length = 0;
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      findCLIConfigPath: () => "/tmp/cloudsmith-config.ini",
+      readFile: async () => "api_key=imported-key",
+    });
+
+    await sso.importFromCLI(operation);
+
+    assert.strictEqual(calls.some(call => call[0] === "begin"), false);
+    assert.deepStrictEqual(calls[0], ["replace", "imported-key", operation.id]);
+  });
+
+  test("terminal timeout and close listener are cleaned before cancellation returns", async () => {
+    const { manager: connectionManager } = createConnectionHarness();
+    const cleared = [];
+    let disposed = 0;
+    const terminal = { show() {}, sendText() {} };
+    vscode.window.createTerminal = () => terminal;
+    vscode.window.onDidCloseTerminal = () => ({ dispose: () => { disposed += 1; } });
+    vscode.window.showInformationMessage = async () => "Not now";
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      setTimeout: (callback) => {
+        queueMicrotask(callback);
+        return 41;
+      },
+      clearTimeout: id => cleared.push(id),
+    });
+
+    const result = await sso.loginViaTerminal("workspace-a");
+
+    assert.strictEqual(result.status, "cancelled");
+    assert.deepStrictEqual(cleared, [41]);
+    assert.strictEqual(disposed, 1);
+  });
+
+  test("workspace slugs at the maximum length are accepted", () => {
+    const { manager: connectionManager } = createConnectionHarness();
+    const sso = new SSOAuthManager({}, { connectionManager });
+
+    assert.strictEqual(sso._isValidWorkspaceSlug("w".repeat(128)), true);
+  });
+
+  test("over-limit workspace slugs are rejected before terminal or browser resources start", async () => {
+    const { calls, manager: connectionManager } = createConnectionHarness();
+    let terminalsCreated = 0;
+    let serversCreated = 0;
+    let browserOpens = 0;
+    vscode.window.createTerminal = () => {
+      terminalsCreated += 1;
+      throw new Error("must not create a terminal");
+    };
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      createServer: () => {
+        serversCreated += 1;
+        throw new Error("must not create a callback server");
+      },
+      openExternal: async () => { browserOpens += 1; },
+    });
+    const overLimitSlug = "w".repeat(129);
+
+    const terminalResult = await sso.loginViaTerminal(overLimitSlug);
+    const browserResult = await sso.loginViaBrowser(overLimitSlug);
+
+    assert.strictEqual(terminalResult.error.kind, "invalid_workspace");
+    assert.strictEqual(browserResult.error.kind, "invalid_workspace");
+    assert.strictEqual(terminalsCreated, 0);
+    assert.strictEqual(serversCreated, 0);
+    assert.strictEqual(browserOpens, 0);
+    assert.strictEqual(calls.filter(call => call[0] === "cancel").length, 2);
+  });
+
+  test("browser success routes the callback candidate through the shared manager and closes the server", async () => {
+    const { calls, manager: connectionManager } = createConnectionHarness();
+    let requestHandler = null;
+    let server = null;
+    const cleared = [];
+    const createServer = handler => {
+      requestHandler = handler;
+      server = Object.assign(new EventEmitter(), {
+        closed: false,
+        listen(_port, _host, callback) { callback(); },
+        close() { this.closed = true; },
+      });
+      return server;
+    };
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      createServer,
+      randomBytes: () => Buffer.from("00112233445566778899aabbccddeeff", "hex"),
+      setTimeout: () => 73,
+      clearTimeout: id => cleared.push(id),
+      openExternal: async () => {
+        const response = { writeHead() {}, end() {} };
+        requestHandler({ method: "GET", url: `${server._expectedPath}?token=browser-key` }, response);
+      },
+    });
+
+    const result = await sso.loginViaBrowser("workspace-a");
+
+    assert.strictEqual(result.ok, true);
+    assert.ok(calls.some(call => call[0] === "replace" && call[1] === "browser-key"));
+    assert.strictEqual(server.closed, true);
+    assert.deepStrictEqual(cleared, [73]);
+  });
+
+  test("browser-open failure still closes the callback server", async () => {
+    const { manager: connectionManager } = createConnectionHarness();
+    let server = null;
+    const createServer = () => {
+      server = Object.assign(new EventEmitter(), {
+        closed: false,
+        listen(_port, _host, callback) { callback(); },
+        close() { this.closed = true; },
+      });
+      return server;
+    };
+    const sso = new SSOAuthManager({}, {
+      connectionManager,
+      createServer,
+      openExternal: async () => { throw new Error("browser unavailable"); },
+      setTimeout: () => 19,
+      clearTimeout: () => {},
+    });
+
+    const result = await sso.loginViaBrowser("workspace-a");
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(server.closed, true);
+  });
+
+  test("duplicate callback parameters are rejected as ambiguous", () => {
+    const { manager: connectionManager } = createConnectionHarness();
+    const sso = new SSOAuthManager({}, { connectionManager });
+    let resolved = "not-called";
+    const server = {
+      _expectedPath: "/callback/id",
+      _resolveToken(value) { resolved = value; },
+    };
+    const response = { writeHead() {}, end() {} };
+
+    sso._handleCallbackRequest(
+      { method: "GET", url: "/callback/id?token=first&token=second" },
+      response,
+      server
+    );
+
+    assert.strictEqual(resolved, null);
+  });
+
+  test("callback HTML reports receipt without claiming authentication succeeded", () => {
+    const { manager: connectionManager } = createConnectionHarness();
+    const sso = new SSOAuthManager({}, { connectionManager });
+
+    const html = sso._buildCallbackHtml(true, "/authenticated");
+
+    assert.ok(html.includes("Credentials received"));
+    assert.ok(html.includes("validated and saved"));
+    assert.strictEqual(html.includes("Authentication complete"), false);
+  });
+});

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -2,9 +2,14 @@ const assert = require("assert");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { CredentialManager } = require("../util/credentialManager");
 const {
+  cacheErrorMessage,
+  getActiveUpstreamCacheOperationCount,
+  getUpstreamCacheKey,
   isBenignUpstreamFormatError,
+  MAX_RUNTIME_UPSTREAMS_PER_FORMAT,
   SUPPORTED_UPSTREAM_FORMATS,
   UpstreamChecker,
+  UPSTREAM_CACHE_SCHEMA_VERSION,
 } = require("../util/upstreamChecker");
 const {
   SUPPORTED_UPSTREAM_FORMATS: SHARED_SUPPORTED_UPSTREAM_FORMATS,
@@ -21,6 +26,30 @@ function toApiResult(response) {
   return apiSuccess(response === undefined ? [] : response);
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise(resolvePromise => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+let accountState;
+const connectionManager = {
+  getState() { return { ...accountState }; },
+  setState(next) { accountState = { ...accountState, ...next }; },
+};
+
+function resetAccount() {
+  accountState = {
+    activationId: "activation-a",
+    accountEpoch: 1,
+    sessionConnected: true,
+  };
+}
+
+function createChecker(context, options = {}) {
+  return new UpstreamChecker(context, { connectionManager, ...options });
+}
+
 suite("UpstreamChecker repository upstream cache", () => {
   let originalGet;
   let originalGetApiKey;
@@ -30,6 +59,7 @@ suite("UpstreamChecker repository upstream cache", () => {
   let context;
 
   setup(() => {
+    resetAccount();
     originalGet = CloudsmithAPI.prototype.get;
     originalGetApiKey = CredentialManager.prototype.getApiKey;
     formatResponses = {};
@@ -85,11 +115,14 @@ suite("UpstreamChecker repository upstream cache", () => {
 
   function createCachedEntry(overrides = {}) {
     return {
+      version: UPSTREAM_CACHE_SCHEMA_VERSION,
+      activationId: "activation-a",
+      accountEpoch: 1,
       timestamp: Date.now(),
       successfulFormats: 1,
       groupedUpstreams: {
         python: [
-          { name: "PyPI", upstream_url: "https://pypi.org/simple/" },
+          { name: "PyPI" },
         ],
       },
       ...overrides,
@@ -97,7 +130,7 @@ suite("UpstreamChecker repository upstream cache", () => {
   }
 
   async function assertInvalidCachedEntry(entry) {
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const cacheKey = checker._getRepositoryUpstreamCacheKey("workspace-a", "repo-a");
     store.set(cacheKey, entry);
 
@@ -112,7 +145,12 @@ suite("UpstreamChecker repository upstream cache", () => {
   test("aggregates repository upstreams across formats and reuses the shared cache", async () => {
     formatResponses = {
       python: [
-        { name: "PyPI", upstream_url: "https://pypi.org/simple/" },
+        {
+          name: "PyPI",
+          upstream_url: "https://user:path-secret@example.com/path-secret?token=query-secret",
+          api_key: "never-persist",
+          mode: { nested_secret: "nested-secret" },
+        },
         { name: "Internal mirror", upstream_url: "https://mirror.example/python" },
         { name: "Legacy", upstream_url: "https://legacy.example/python" },
       ],
@@ -126,7 +164,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       conda: apiFailure("not_found", { status: 404 }),
     };
 
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const firstState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.strictEqual(requestCount, SUPPORTED_UPSTREAM_FORMATS.length);
@@ -138,6 +176,14 @@ suite("UpstreamChecker repository upstream cache", () => {
     assert.strictEqual(firstState.groupedUpstreams.get("docker").length, 1);
     assert.strictEqual(firstState.groupedUpstreams.get("docker")[0].format, "docker");
     assert.strictEqual(store.size, 1);
+    const persisted = [...store.values()][0];
+    assert.strictEqual(persisted.version, UPSTREAM_CACHE_SCHEMA_VERSION);
+    assert.strictEqual(persisted.activationId, "activation-a");
+    assert.strictEqual(persisted.accountEpoch, 1);
+    assert.strictEqual(JSON.stringify(persisted).includes("never-persist"), false);
+    assert.strictEqual(JSON.stringify(persisted).includes("path-secret"), false);
+    assert.strictEqual(JSON.stringify(persisted).includes("query-secret"), false);
+    assert.strictEqual(JSON.stringify(persisted).includes("nested-secret"), false);
 
     const secondState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
@@ -157,7 +203,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       },
     };
 
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const firstState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.ok(firstState.failedFormats.includes("npm"));
@@ -174,7 +220,7 @@ suite("UpstreamChecker repository upstream cache", () => {
   test("rejects blank upstream records instead of reporting false active reachability", async () => {
     formatResponses = { python: [{}] };
 
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const state = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.strictEqual(state.active, 0);
@@ -211,8 +257,16 @@ suite("UpstreamChecker repository upstream cache", () => {
     await assertInvalidCachedEntry(createCachedEntry({ groupedUpstreams: { python: [{}] } }));
   });
 
+  test("rejects poisoned nested values in a persisted repository envelope", async () => {
+    await assertInvalidCachedEntry(createCachedEntry({
+      groupedUpstreams: {
+        python: [{ name: "PyPI", mode: { token: "nested-secret" } }],
+      },
+    }));
+  });
+
   test("treats expired cached repository upstream state as invalid", () => {
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const cacheKey = checker._getRepositoryUpstreamCacheKey("workspace-a", "repo-a");
     store.set(cacheKey, createCachedEntry({ timestamp: Date.now() - (11 * 60 * 1000) }));
 
@@ -222,7 +276,7 @@ suite("UpstreamChecker repository upstream cache", () => {
   });
 
   test("accepts a valid cached repository upstream state", () => {
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
     const cacheKey = checker._getRepositoryUpstreamCacheKey("workspace-a", "repo-a");
     store.set(cacheKey, createCachedEntry({ successfulFormats: 7 }));
 
@@ -253,7 +307,7 @@ suite("UpstreamChecker repository upstream cache", () => {
     };
 
     try {
-      const checker = new UpstreamChecker(context);
+      const checker = createChecker(context);
       checker._logRepositoryUpstreamCacheError = (...args) => logCalls.push(args);
       const state = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
@@ -275,6 +329,9 @@ suite("UpstreamChecker repository upstream cache", () => {
 });
 
 suite("UpstreamChecker shared helper and format handling", () => {
+  setup(() => {
+    resetAccount();
+  });
   function createContext() {
     const store = new Map();
     const updates = [];
@@ -303,13 +360,15 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
   function createCachedEntry(overrides = {}) {
     return {
+      version: UPSTREAM_CACHE_SCHEMA_VERSION,
+      activationId: "activation-a",
+      accountEpoch: 1,
       timestamp: Date.now(),
       upstreams: [
         {
           name: "PyPI",
           _format: "python",
           format: "python",
-          upstream_url: "https://pypi.org/simple/",
           is_active: true,
         },
       ],
@@ -323,7 +382,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
   function createResponseAwareChecker(context, formatResponses) {
     let requestCount = 0;
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
 
     checker.api.get = async (endpoint) => {
       requestCount += 1;
@@ -407,7 +466,11 @@ suite("UpstreamChecker shared helper and format handling", () => {
     const { context, updates } = createContext();
     const { checker, getRequestCount } = createResponseAwareChecker(context, {
       python: [
-        { name: "PyPI", upstream_url: "https://pypi.org/simple/" },
+        {
+          name: "PyPI",
+          upstream_url: "https://user:url-secret@example.com/url-secret?token=url-secret",
+          mode: { token: "nested-secret" },
+        },
         { name: "Internal mirror", upstream_url: "https://mirror.example/python" },
         { name: "Legacy", upstream_url: "https://legacy.example/python" },
       ],
@@ -436,7 +499,15 @@ suite("UpstreamChecker shared helper and format handling", () => {
       "docker"
     );
     assert.strictEqual(updates.length, 1);
-    assert.strictEqual(updates[0].key, "cloudsmith-upstreams:all:workspace-a:repo-a");
+    assert.strictEqual(
+      updates[0].key,
+      getUpstreamCacheKey("workspace-a", "repo-a")
+    );
+    assert.strictEqual(updates[0].value.version, UPSTREAM_CACHE_SCHEMA_VERSION);
+    assert.strictEqual(updates[0].value.activationId, "activation-a");
+    assert.strictEqual(updates[0].value.accountEpoch, 1);
+    assert.strictEqual(JSON.stringify(updates[0].value).includes("url-secret"), false);
+    assert.strictEqual(JSON.stringify(updates[0].value).includes("nested-secret"), false);
 
     const secondState = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
@@ -473,10 +544,89 @@ suite("UpstreamChecker shared helper and format handling", () => {
     assert.strictEqual(updates.length, 0);
   });
 
+  test("uses collision-free encoded cache tuple keys", () => {
+    assert.notStrictEqual(
+      getUpstreamCacheKey("workspace:a", "repo"),
+      getUpstreamCacheKey("workspace", "a:repo")
+    );
+    assert.notStrictEqual(
+      getUpstreamCacheKey("workspace", "repo", ["python", "npm"]),
+      getUpstreamCacheKey("workspace", "repo", ["python"])
+    );
+  });
+
+  test("retires per-key operation authority after terminal settlement", async () => {
+    const { context } = createContext();
+    const response = deferred();
+    const checker = createChecker(context, {
+      cloudsmithAPI: { async get() { return response.promise; } },
+    });
+
+    const pending = checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python"]
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(getActiveUpstreamCacheOperationCount(context.globalState), 1);
+    response.resolve(apiSuccess([]));
+    await pending;
+
+    assert.strictEqual(getActiveUpstreamCacheOperationCount(context.globalState), 0);
+  });
+
+  test("rejects over-count and over-limit runtime upstream responses before use", async () => {
+    const { context, updates } = createContext();
+    const checker = createChecker(context, {
+      cloudsmithAPI: {
+        async get(_endpoint, options) {
+          const payload = Array.from(
+            { length: MAX_RUNTIME_UPSTREAMS_PER_FORMAT + 1 },
+            (_, index) => ({ name: `upstream-${index}` })
+          );
+          assert.strictEqual(options.validate(payload), false);
+          return apiSuccess(payload);
+        },
+      },
+    });
+
+    const countResult = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python"]
+    );
+    assert.deepStrictEqual(countResult.failedFormats, ["python"]);
+    assert.strictEqual(countResult.total, 0);
+    assert.strictEqual(updates.length, 0);
+
+    checker.api.get = async (_endpoint, options) => {
+      const payload = [{ name: "x".repeat(501) }];
+      assert.strictEqual(options.validate(payload), false);
+      return apiSuccess(payload);
+    };
+    const fieldResult = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-b",
+      ["python"]
+    );
+    assert.deepStrictEqual(fieldResult.failedFormats, ["python"]);
+    assert.strictEqual(fieldResult.total, 0);
+    assert.strictEqual(updates.length, 0);
+  });
+
+  test("cache failure logs never include exception text or account identifiers", async () => {
+    const secret = "secret-from-quota-exception";
+    const warning = cacheErrorMessage("persist");
+    assert.strictEqual(warning, "[UpstreamChecker] Failed to persist upstream cache.");
+    assert.strictEqual(warning.includes(secret), false);
+    assert.strictEqual(warning.includes("workspace-sensitive"), false);
+    assert(warning.length < 100);
+  });
+
   test("evicts cached upstream data with an invalid timestamp before refetching", async () => {
     const { context, store, updates } = createContext();
     const { checker, getRequestCount } = createResponseAwareChecker(context, {});
-    const cacheKey = "cloudsmith-upstreams:all:workspace-a:repo-a";
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a");
 
     store.set(cacheKey, createCachedEntry({ timestamp: "123" }));
 
@@ -491,7 +641,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
   test("evicts cached upstream data with an invalid upstream list before refetching", async () => {
     const { context, store, updates } = createContext();
     const { checker, getRequestCount } = createResponseAwareChecker(context, {});
-    const cacheKey = "cloudsmith-upstreams:all:workspace-a:repo-a";
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a");
 
     store.set(cacheKey, createCachedEntry({ upstreams: {} }));
 
@@ -499,6 +649,40 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     assert.strictEqual(getRequestCount(), SUPPORTED_UPSTREAM_FORMATS.length);
     assert.strictEqual(state.total, 0);
+    assert.strictEqual(updates[0].key, cacheKey);
+    assert.strictEqual(updates[0].value, undefined);
+  });
+
+  test("evicts a flat cache envelope containing nested secret-bearing fields", async () => {
+    const { context, store, updates } = createContext();
+    const { checker } = createResponseAwareChecker(context, {});
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a");
+    store.set(cacheKey, createCachedEntry({
+      upstreams: [{
+        name: "PyPI",
+        _format: "python",
+        format: "python",
+        mode: { token: "nested-secret" },
+        is_active: true,
+      }],
+    }));
+
+    await checker.getAllUpstreamData("workspace-a", "repo-a");
+
+    assert.strictEqual(updates[0].key, cacheKey);
+    assert.strictEqual(updates[0].value, undefined);
+  });
+
+  test("evicts persisted strings beyond the strict field bound", async () => {
+    const { context, store, updates } = createContext();
+    const { checker } = createResponseAwareChecker(context, {});
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a");
+    store.set(cacheKey, createCachedEntry({
+      upstreams: [{ name: "x".repeat(501), _format: "python", format: "python" }],
+    }));
+
+    await checker.getAllUpstreamData("workspace-a", "repo-a");
+
     assert.strictEqual(updates[0].key, cacheKey);
     assert.strictEqual(updates[0].value, undefined);
   });
@@ -539,7 +723,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
   });
 
   test("returns upstream data without an error when partial failures still yield upstreams", async () => {
-    const checker = new UpstreamChecker({});
+    const checker = createChecker({});
     checker.getAllUpstreamData = async () => ({
       upstreams: [{ name: "PyPI", _format: "python", upstream_url: "https://pypi.org/" }],
       active: 1,
@@ -556,7 +740,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
   });
 
   test("returns an error when formats fail and no upstream data is available", async () => {
-    const checker = new UpstreamChecker({});
+    const checker = createChecker({});
     checker.getAllUpstreamData = async () => ({
       upstreams: [],
       active: 0,
@@ -573,7 +757,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
   test("does not cache non-benign empty upstream results", async () => {
     const { context, updates } = createContext();
-    const checker = new UpstreamChecker(context);
+    const checker = createChecker(context);
 
     checker.api.get = async () => apiFailure("unauthorized", { status: 401 });
 
@@ -583,11 +767,27 @@ suite("UpstreamChecker shared helper and format handling", () => {
     assert.strictEqual(result.upstreams.length, 0);
     assert.strictEqual(updates.length, 0);
   });
+
+  test("does not publish or persist an upstream response after account supersession", async () => {
+    const { context, updates } = createContext();
+    let release;
+    const response = new Promise(resolve => { release = resolve; });
+    const checker = createChecker(context, {
+      cloudsmithAPI: { async get() { return response; } },
+    });
+    const pending = checker.getUpstreamDataForFormats("acme", "repo", ["python"]);
+    await new Promise(resolve => setImmediate(resolve));
+    connectionManager.setState({ accountEpoch: 2 });
+    release(apiSuccess([{ name: "Old PyPI", upstream_url: "https://old.example" }]));
+
+    assert.strictEqual(await pending, null);
+    assert.strictEqual(updates.length, 0);
+  });
 });
 
 suite("UpstreamChecker preview resolution", () => {
   test("previewResolution does not trigger policy fetches and still returns upstream data", async () => {
-    const checker = new UpstreamChecker({});
+    const checker = createChecker({});
     let policyFetchCount = 0;
 
     checker.existsLocally = async () => ({

--- a/test/vulnerabilitySummaryNode.test.js
+++ b/test/vulnerabilitySummaryNode.test.js
@@ -6,9 +6,19 @@ const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 suite("VulnerabilitySummaryNode Test Suite", () => {
   const context = {};
   let originalApiGet;
+  let accountState;
+  const connectionManager = {
+    getState() { return { ...accountState }; },
+    setState(next) { accountState = { ...accountState, ...next }; },
+  };
 
   setup(() => {
     originalApiGet = CloudsmithAPI.prototype.get;
+    accountState = {
+      activationId: "activation-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
   });
 
   teardown(() => {
@@ -22,7 +32,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
       slug_perm_raw: "pkg-slug",
       num_vulnerabilities: 3,
       max_severity: "Critical",
-    }, context);
+    }, context, { connectionManager });
 
     node._fetchVulnerabilities = async () => ([
       {
@@ -143,7 +153,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
       slug_perm: "immutable-package-id",
       num_vulnerabilities: 2,
       max_severity: "High",
-    }, context);
+    }, context, { connectionManager });
 
     const children = await node.getChildren();
 
@@ -182,7 +192,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
       slug_perm: "immutable-package-id",
       num_vulnerabilities: 1,
       max_severity: "Critical",
-    }, context);
+    }, context, { connectionManager });
 
     const children = await node.getChildren();
 
@@ -216,13 +226,13 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
       repository: "repo-a",
       slug_perm: "vulnerable-package",
       num_vulnerabilities: 1,
-    }, context);
+    }, context, { connectionManager });
     const failedNode = new VulnerabilitySummaryNode({
       namespace: "workspace-a",
       repository: "repo-a",
       slug_perm: "failed-package",
       num_vulnerabilities: 1,
-    }, context);
+    }, context, { connectionManager });
 
     const loadedChildren = await vulnerableNode.getChildren();
     const failedChildren = await failedNode.getChildren();
@@ -230,5 +240,29 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
     assert.deepStrictEqual(loadedChildren.map(child => child.cveId), ["CVE-2026-2001"]);
     assert.strictEqual(failedChildren.length, 1);
     assert.strictEqual(failedChildren[0]._label, "Could not load vulnerabilities");
+  });
+
+  test("suppresses and does not cache an old-account expansion completion", async () => {
+    let release;
+    const response = new Promise(resolve => { release = resolve; });
+    const node = new VulnerabilitySummaryNode({
+      namespace: "workspace-a",
+      repository: "repo-a",
+      slug_perm: "old-package",
+      num_vulnerabilities: 1,
+      max_severity: "High",
+    }, context, { connectionManager });
+    node._fetchVulnerabilities = async () => response;
+    const pending = node.getChildren();
+    connectionManager.setState({ accountEpoch: 2 });
+    release({
+      results: [{ vulnerability_id: "CVE-OLD", severity: "Critical" }],
+      numVulns: 1,
+      maxSeverity: "Critical",
+    });
+
+    assert.deepStrictEqual(await pending, []);
+    assert.strictEqual(node._cachedChildren, null);
+    assert.strictEqual(node.maxSeverity, "High");
   });
 });

--- a/test/workspaceCache.test.js
+++ b/test/workspaceCache.test.js
@@ -1,0 +1,53 @@
+const assert = require("assert");
+const { WorkspaceCache } = require("../util/workspaceCache");
+
+suite("WorkspaceCache", () => {
+  let state;
+  let now;
+  let cache;
+
+  setup(() => {
+    state = { activationId: "activation-a", accountEpoch: 1, sessionConnected: true };
+    now = 1_000;
+    cache = new WorkspaceCache({ getState: () => ({ ...state }) }, {
+      now: () => now,
+      ttlMs: 100,
+    });
+  });
+
+  test("stores only immutable workspace summaries and returns clones", () => {
+    const source = [{ slug: "workspace-a", name: "Workspace A", secret: "omit" }];
+    assert.strictEqual(cache.set(source, state), true);
+    source[0].name = "mutated";
+    const first = cache.get();
+    assert.deepStrictEqual(first, [{ slug: "workspace-a", name: "Workspace A" }]);
+    first[0].name = "also-mutated";
+    assert.strictEqual(cache.get()[0].name, "Workspace A");
+  });
+
+  test("invalidates on account epoch, activation, disconnect, and expiry", () => {
+    cache.set([{ slug: "workspace-a", name: "Workspace A" }], state);
+    state.accountEpoch = 2;
+    assert.strictEqual(cache.get(), null);
+
+    state.accountEpoch = 1;
+    cache.set([{ slug: "workspace-a", name: "Workspace A" }], state);
+    state.activationId = "activation-b";
+    assert.strictEqual(cache.get(), null);
+
+    cache.set([{ slug: "workspace-a", name: "Workspace A" }], state);
+    state.sessionConnected = false;
+    assert.strictEqual(cache.get(), null);
+
+    state.sessionConnected = true;
+    cache.set([{ slug: "workspace-a", name: "Workspace A" }], state);
+    now += 100;
+    assert.strictEqual(cache.get(), null);
+  });
+
+  test("rejects malformed or stale writes", () => {
+    assert.strictEqual(cache.set([{ slug: "workspace-a" }], state), false);
+    assert.strictEqual(cache.set([], { ...state, accountEpoch: 2 }), false);
+    assert.strictEqual(cache.get(), null);
+  });
+});

--- a/test/workspaceNode.test.js
+++ b/test/workspaceNode.test.js
@@ -1,59 +1,58 @@
 const assert = require("assert");
-const { CloudsmithAPI } = require("../util/cloudsmithAPI");
-const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
 const WorkspaceNode = require("../models/workspaceNode");
-const { apiFailure } = require("./apiResultHelpers");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
-suite("WorkspaceNode Test Suite", () => {
-  let originalGet;
-  let originalFetchWorkspaceRepositories;
-  let cacheUpdates;
+function createManager() {
+  let state = { activationId: "activation-a", accountEpoch: 1, sessionConnected: true };
+  return {
+    getState() { return { ...state }; },
+    setState(next) { state = { ...state, ...next }; },
+  };
+}
+
+suite("WorkspaceNode", () => {
+  let manager;
+  let updates;
   let context;
 
   setup(() => {
-    originalGet = CloudsmithAPI.prototype.get;
-    originalFetchWorkspaceRepositories =
-      workspaceRepositoryFetcher.fetchWorkspaceRepositories;
-    cacheUpdates = [];
+    manager = createManager();
+    updates = [];
     context = {
       globalState: {
-        update(key, value) {
-          cacheUpdates.push({ key, value });
-        },
+        async update(key, value) { updates.push({ key, value }); },
       },
     };
-
-    CloudsmithAPI.prototype.get = async () => apiFailure("forbidden", { status: 403 });
   });
 
-  teardown(() => {
-    CloudsmithAPI.prototype.get = originalGet;
-    workspaceRepositoryFetcher.fetchWorkspaceRepositories =
-      originalFetchWorkspaceRepositories;
-  });
+  function createNode(fetchWorkspaceRepositories, apiGet = async () => (
+    apiFailure("forbidden", { status: 403 })
+  )) {
+    return new WorkspaceNode({ name: "Workspace A", slug: "workspace-a" }, context, {
+      connectionManager: manager,
+      createCloudsmithAPI: () => ({ get: apiGet }),
+      fetchWorkspaceRepositories,
+    });
+  }
 
   test("shows an error child when the first repository page fails", async () => {
-    workspaceRepositoryFetcher.fetchWorkspaceRepositories = async () => ({
+    const node = createNode(async () => ({
       repositories: [],
       error: apiFailure("server_error", { status: 500 }).error,
       warning: null,
       partial: false,
-    });
-
-    const node = new WorkspaceNode(
-      { name: "Workspace A", slug: "workspace-a" },
-      context
-    );
+      stale: false,
+    }));
 
     const children = await node.getChildren();
 
     assert.strictEqual(children.length, 2);
     assert.strictEqual(children[1]._label, "Failed to load repositories");
-    assert.strictEqual(cacheUpdates.length, 0);
+    assert.strictEqual(updates.length, 0);
   });
 
-  test("updates the repository cache with fetched repositories", async () => {
-    workspaceRepositoryFetcher.fetchWorkspaceRepositories = async () => ({
+  test("keeps fetched repositories in memory and never writes CloudsmithCache", async () => {
+    const node = createNode(async () => ({
       repositories: [
         { name: "repo-a", slug: "repo-a" },
         { name: "repo-b", slug: "repo-b" },
@@ -61,22 +60,42 @@ suite("WorkspaceNode Test Suite", () => {
       error: null,
       warning: null,
       partial: false,
-    });
-
-    const node = new WorkspaceNode(
-      { name: "Workspace A", slug: "workspace-a" },
-      context
-    );
+      stale: false,
+    }));
 
     const repos = await node.getRepositories();
 
-    assert.strictEqual(repos.length, 2);
-    assert.strictEqual(repos[0].name, "repo-a");
-    assert.strictEqual(cacheUpdates.length, 1);
-    assert.strictEqual(cacheUpdates[0].key, "CloudsmithCache");
-    assert.deepStrictEqual(
-      cacheUpdates[0].value.workspaces.map(repo => repo.slug),
-      ["repo-a", "repo-b"]
-    );
+    assert.deepStrictEqual(repos.map(repo => repo.name), ["repo-a", "repo-b"]);
+    assert.strictEqual(updates.length, 0);
+  });
+
+  test("does not publish repositories completed after an account change", async () => {
+    let release;
+    const pendingFetch = new Promise(resolve => { release = resolve; });
+    const node = createNode(async () => pendingFetch);
+    const resultPromise = node.getRepositories();
+    manager.setState({ accountEpoch: 2 });
+    release({
+      repositories: [{ name: "old", slug: "old" }],
+      error: null,
+      stale: false,
+    });
+    assert.deepStrictEqual(await resultPromise, []);
+  });
+
+  test("does not publish quota or repository children after an account change", async () => {
+    let releaseQuota;
+    const pendingQuota = new Promise(resolve => { releaseQuota = resolve; });
+    let repositoryFetches = 0;
+    const node = createNode(async () => {
+      repositoryFetches += 1;
+      return { repositories: [], error: null, stale: false };
+    }, async () => pendingQuota);
+    const resultPromise = node.getChildren();
+    manager.setState({ accountEpoch: 2 });
+    releaseQuota(apiSuccess({ usage: { storage: 1 } }));
+
+    assert.deepStrictEqual(await resultPromise, []);
+    assert.strictEqual(repositoryFetches, 0);
   });
 });

--- a/test/workspaceRepositoryFetcher.test.js
+++ b/test/workspaceRepositoryFetcher.test.js
@@ -11,6 +11,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
   let progressOptions;
   let progressReports;
   let warnCalls;
+  let manager;
 
   setup(() => {
     originalConsole = global.console;
@@ -19,6 +20,15 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
     progressOptions = null;
     progressReports = [];
     warnCalls = [];
+    let state = {
+      activationId: "activation-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    manager = {
+      getState() { return { ...state }; },
+      setState(next) { state = { ...state, ...next }; },
+    };
 
     global.console = new Proxy(originalConsole, {
       get(target, property) {
@@ -64,6 +74,13 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
     return repositories;
   }
 
+  function fetchRepositories(options = {}) {
+    return workspaceRepositoryFetcher.fetchWorkspaceRepositories({}, "workspace-a", {
+      connectionManager: manager,
+      ...options,
+    });
+  }
+
   test("stubs console.warn during test setup", () => {
     console.warn("warning-path");
 
@@ -90,10 +107,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       };
     };
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.strictEqual(progressOptions.title, "Loading repositories for workspace-a...");
     assert.deepStrictEqual(
@@ -136,10 +150,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       };
     };
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.deepStrictEqual(
       calls,
@@ -180,10 +191,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       };
     };
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.deepStrictEqual(calls, [1, 2]);
     assert.strictEqual(result.error, null);
@@ -205,10 +213,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       error: failure,
     });
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.strictEqual(result.error, failure);
     assert.strictEqual(result.partial, false);
@@ -236,10 +241,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       };
     };
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.strictEqual(result.error, null);
     assert.strictEqual(result.partial, true);
@@ -260,10 +262,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       pagination: { page: 1, pageTotal: 1, count: 0, pageSize: 500 },
     });
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.strictEqual(
       result.error,
@@ -293,10 +292,7 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
       };
     };
 
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      {},
-      "workspace-a"
-    );
+    const result = await fetchRepositories();
 
     assert.strictEqual(result.error, null);
     assert.strictEqual(
@@ -313,5 +309,31 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
         "[WorkspaceRepositories] Failed to load additional repositories for workspace-a on page 2: Unexpected repository response format",
       ],
     ]);
+  });
+
+  test("discards all partial repositories when the account changes between pages", async () => {
+    let releaseSecondPage;
+    const secondPage = new Promise(resolve => { releaseSecondPage = resolve; });
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
+      if (page === 1) {
+        return {
+          data: [{ name: "old-repo", slug: "old-repo" }],
+          pagination: { page: 1, pageTotal: 2, count: 2, pageSize: 1 },
+        };
+      }
+      return secondPage;
+    };
+    const pending = fetchRepositories();
+    await new Promise(resolve => setImmediate(resolve));
+    manager.setState({ accountEpoch: 2 });
+    releaseSecondPage({
+      data: [{ name: "also-old", slug: "also-old" }],
+      pagination: { page: 2, pageTotal: 2, count: 2, pageSize: 1 },
+    });
+
+    const result = await pending;
+    assert.strictEqual(result.stale, true);
+    assert.deepStrictEqual(result.repositories, []);
+    assert.strictEqual(result.error.kind, "stale_account");
   });
 });

--- a/util/accountOperation.js
+++ b/util/accountOperation.js
@@ -1,0 +1,64 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+function resolveConnectionManager(context, connectionManager = null) {
+  if (connectionManager && typeof connectionManager.getState === "function") {
+    return connectionManager;
+  }
+
+  if (!context) {
+    return null;
+  }
+
+  // Load lazily so this helper does not participate in the authentication
+  // module's construction graph.
+  const { getConnectionManager } = require("./connectionManager");
+  return typeof getConnectionManager === "function"
+    ? getConnectionManager(context)
+    : null;
+}
+
+function captureAccount(connectionManager) {
+  if (!connectionManager || typeof connectionManager.getState !== "function") {
+    return null;
+  }
+  const state = connectionManager.getState();
+  if (
+    !state
+    || !state.sessionConnected
+    || !Number.isInteger(state.accountEpoch)
+    || typeof state.activationId !== "string"
+    || state.activationId.length === 0
+  ) {
+    return null;
+  }
+  return Object.freeze({
+    accountEpoch: state.accountEpoch,
+    activationId: state.activationId,
+  });
+}
+
+function isAccountCurrent(connectionManager, account) {
+  if (!account || !connectionManager || typeof connectionManager.getState !== "function") {
+    return false;
+  }
+  const state = connectionManager.getState();
+  return Boolean(
+    state
+    && state.sessionConnected
+    && state.accountEpoch === account.accountEpoch
+    && state.activationId === account.activationId
+  );
+}
+
+function captureAccountForContext(context, connectionManager = null) {
+  const manager = resolveConnectionManager(context, connectionManager);
+  const account = captureAccount(manager);
+  return account ? Object.freeze({ manager, account }) : null;
+}
+
+module.exports = {
+  captureAccount,
+  captureAccountForContext,
+  isAccountCurrent,
+  resolveConnectionManager,
+};

--- a/util/cloudsmithAPI.js
+++ b/util/cloudsmithAPI.js
@@ -549,25 +549,6 @@ class CloudsmithAPI {
         return cancelledFailure();
       }
 
-      const credentialResult = await this._awaitAbortable(
-        Promise.resolve().then(() => this._credentialManager.getApiKey()),
-        controller.signal
-      );
-      if (credentialResult.aborted) {
-        return cancelledFailure();
-      }
-      if (!credentialResult.ok) {
-        return failure({ kind: "invalid_request" });
-      }
-      storedKey = credentialResult.value;
-      if (typeof storedKey === "string" && storedKey) {
-        keys.add(storedKey);
-      }
-      if (abortKind !== null || this._now() >= deadline) {
-        if (abortKind === null) abort("timeout");
-        return cancelledFailure();
-      }
-
       const hasCandidateKey = Object.prototype.hasOwnProperty.call(options, "apiKey");
       if (hasCandidateKey) {
         if (typeof options.apiKey === "string" && options.apiKey) {
@@ -575,6 +556,24 @@ class CloudsmithAPI {
           keys.add(selectedKey);
         }
       } else {
+        const credentialResult = await this._awaitAbortable(
+          Promise.resolve().then(() => this._credentialManager.getApiKey()),
+          controller.signal
+        );
+        if (credentialResult.aborted) {
+          return cancelledFailure();
+        }
+        if (!credentialResult.ok) {
+          return failure({ kind: "invalid_request" });
+        }
+        storedKey = credentialResult.value;
+        if (typeof storedKey === "string" && storedKey) {
+          keys.add(storedKey);
+        }
+        if (abortKind !== null || this._now() >= deadline) {
+          if (abortKind === null) abort("timeout");
+          return cancelledFailure();
+        }
         selectedKey = storedKey;
       }
       if (

--- a/util/connectionManager.js
+++ b/util/connectionManager.js
@@ -1,111 +1,1240 @@
-// This class handles the connection to Cloudsmith.
-// A connection session is not actually running since we are just making API calls adhoc when needed. 
-// This mostly just handles verification and if connection can be made. 
-
+const crypto = require("crypto");
 const vscode = require("vscode");
-const { CredentialManager } = require("./credentialManager");
-const { formatApiError } = require("./errorFormatter");
+
+const AUTH_TOKEN_KEY = "cloudsmith-vsc.authToken";
+const LEGACY_CONNECTION_KEY = "cloudsmith-vsc.isConnected";
+const CONNECTION_CONTEXT_KEY = "cloudsmith.connected";
+const MAX_CREDENTIAL_LENGTH = 4096;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const SAFE_PUBLIC_ERROR = Symbol("safe-public-error");
+
+const CONNECTION_STATUSES = Object.freeze({
+  ABSENT: "absent",
+  VALIDATING: "validating",
+  CONNECTED: "connected",
+  FAILED: "failed",
+  INDETERMINATE: "indeterminate",
+  DISPOSED: "disposed",
+});
+
+const managerRegistry = new WeakMap();
+
+function publicError(error, fallbackMessage) {
+  if (!error) return null;
+  if (error[SAFE_PUBLIC_ERROR]) return error;
+  return createPublicError("unexpected", fallbackMessage);
+}
+
+function fixedPublicError(kind, message) {
+  return createPublicError(kind, message);
+}
+
+function createPublicError(kind, message) {
+  const error = { kind, message };
+  Object.defineProperty(error, SAFE_PUBLIC_ERROR, { value: true });
+  return Object.freeze(error);
+}
+
+function validationAPIError(error) {
+  const messages = {
+    unauthorized: "Authentication failed. Check the API key.",
+    forbidden: "The API key does not have permission to access Cloudsmith.",
+    rate_limited: "Cloudsmith rate limited the authentication check. Try again shortly.",
+    server_error: "Cloudsmith could not complete the authentication check. Try again later.",
+    network_error: "Could not reach Cloudsmith. Check the network connection.",
+    timeout: "The Cloudsmith authentication check timed out.",
+    cancelled: "Authentication was cancelled.",
+    invalid_response: "Cloudsmith returned an unexpected authentication response.",
+    redirect_rejected: "Cloudsmith returned an unsafe redirect, so authentication was stopped.",
+    invalid_request: "The authentication request could not be constructed safely.",
+  };
+  const kind = error && Object.prototype.hasOwnProperty.call(messages, error.kind)
+    ? error.kind
+    : "api_error";
+  return fixedPublicError(kind, messages[kind] || "Could not validate the API key.");
+}
+
+function normalizeCandidate(candidate) {
+  if (typeof candidate !== "string") {
+    return Object.freeze({ ok: false, reason: "API key must be text." });
+  }
+  const value = candidate.trim();
+  if (!value) {
+    return Object.freeze({ ok: false, reason: "API key cannot be empty." });
+  }
+  if (value.length > MAX_CREDENTIAL_LENGTH) {
+    return Object.freeze({ ok: false, reason: "API key is too long." });
+  }
+  if (CONTROL_CHARACTER_PATTERN.test(value)) {
+    return Object.freeze({ ok: false, reason: "API key contains invalid characters." });
+  }
+  return Object.freeze({ ok: true, value });
+}
+
+function fingerprint(value) {
+  if (typeof value !== "string" || !value) return null;
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function freezeState(state) {
+  return Object.freeze({
+    activationId: state.activationId,
+    status: state.status,
+    operationId: state.operationId,
+    accountEpoch: state.accountEpoch,
+    credentialPresent: state.credentialPresent,
+    sessionConnected: Boolean(state.sessionConnected),
+    error: state.error || null,
+  });
+}
+
+function bindConnectionManager(context, manager, activationId = manager && manager.activationId) {
+  if (!context || !manager || activationId !== manager.activationId) {
+    throw new TypeError("A matching activation-owned ConnectionManager is required.");
+  }
+  const existing = managerRegistry.get(context);
+  if (existing && existing.manager !== manager) {
+    existing.manager.dispose();
+  }
+  const entry = Object.freeze({ manager, activationId });
+  managerRegistry.set(context, entry);
+  return Object.freeze({
+    dispose() {
+      const current = managerRegistry.get(context);
+      if (current === entry) managerRegistry.delete(context);
+    },
+  });
+}
+
+function unbindConnectionManager(context, manager) {
+  const entry = managerRegistry.get(context);
+  if (entry && (!manager || entry.manager === manager)) {
+    managerRegistry.delete(context);
+    return true;
+  }
+  return false;
+}
+
+function getConnectionManager(context, activationId) {
+  const entry = context && managerRegistry.get(context);
+  if (!entry || (activationId && entry.activationId !== activationId)) return null;
+  if (entry.manager.getState().status === CONNECTION_STATUSES.DISPOSED) return null;
+  return entry.manager;
+}
+
+function getConnectionState(context, activationId) {
+  const manager = getConnectionManager(context, activationId);
+  return manager ? manager.getState() : null;
+}
+
+function getAccountEpoch(context, activationId) {
+  const state = getConnectionState(context, activationId);
+  return state && state.status !== CONNECTION_STATUSES.INDETERMINATE
+    ? state.accountEpoch
+    : null;
+}
 
 class ConnectionManager {
-  constructor(context) {
+  constructor(context, options = {}) {
+    if (!context || !context.secrets) {
+      throw new TypeError("Extension context with SecretStorage is required.");
+    }
     this.context = context;
+    this.activationId = options.activationId || crypto.randomUUID();
+    this._createCloudsmithAPI = options.createCloudsmithAPI || ((apiContext) => {
+      const { CloudsmithAPI } = require("./cloudsmithAPI");
+      return new CloudsmithAPI(apiContext);
+    });
+    this._executeCommand = options.executeCommand || vscode.commands.executeCommand;
+    this._stateEmitter = new vscode.EventEmitter();
+    this.onDidChange = this._stateEmitter.event;
+    this._state = freezeState({
+      activationId: this.activationId,
+      status: CONNECTION_STATUSES.INDETERMINATE,
+      operationId: 0,
+      accountEpoch: 0,
+      credentialPresent: null,
+      sessionConnected: false,
+      error: null,
+    });
+    this._stableState = this._state;
+    this._knownFingerprint = undefined;
+    this._operationCounter = 0;
+    this._currentOperation = null;
+    this._operationPublicationSequence = new WeakMap();
+    this._mutationQueue = Promise.resolve();
+    this._projectionQueue = Promise.resolve();
+    this._secretEventSequence = 0;
+    this._secretEventChain = Promise.resolve();
+    this._expectedSecretIntent = null;
+    this._disposed = false;
+
+    const onDidChange = context.secrets.onDidChange;
+    this._secretListener = typeof onDidChange === "function"
+      ? onDidChange.call(context.secrets, event => this._onSecretChange(event))
+      : null;
   }
 
-  // Check response to API for authentication - basic workflow for now
-  async checkConnectivity(apiKey) {
-    const { CloudsmithAPI } = require("./cloudsmithAPI");
-    let checkPassed = "false";
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
-    const result = await cloudsmithAPI.get("user/self", {
-      apiKey,
-      responseType: "object",
-      validate: value => typeof value.authenticated === "boolean",
-      retry: "never",
-    });
+  getState() {
+    return this._state;
+  }
 
-    if (!result.ok || !result.data.authenticated) {
-      this._lastError = result.ok ? null : result.error;
-      if (!result.ok) {
-        checkPassed = "error";
-      } else {
-        checkPassed = "false";
-      }
-      await this.context.secrets.store("cloudsmith-vsc.isConnected", checkPassed);
-      await vscode.commands.executeCommand("setContext", "cloudsmith.connected", false);
-    } else {
-      checkPassed = "true";
-      await this.context.secrets.store("cloudsmith-vsc.isConnected", checkPassed);
-      await vscode.commands.executeCommand("setContext", "cloudsmith.connected", true);
+  isOperationCurrent(token) {
+    return !this._disposed && token === this._currentOperation && !token.signal.aborted;
+  }
+
+  _canPublishOperation(token) {
+    return this.isOperationCurrent(token)
+      && this._operationPublicationSequence.get(token) === this._secretEventSequence;
+  }
+
+  beginCredentialOperation() {
+    return this._beginOperation(true);
+  }
+
+  async cancelCredentialOperation(token) {
+    if (!this.isOperationCurrent(token)) {
+      return Object.freeze({ ok: false, status: "stale", state: this._state });
+    }
+    token.controller.abort();
+    this._currentOperation = null;
+    this._setState({
+      ...this._stableState,
+      operationId: token.id,
+      accountEpoch: this._state.accountEpoch,
+    });
+    const projectionError = await this._projectConnection(this._state.sessionConnected);
+    return Object.freeze({
+      ok: false,
+      status: "cancelled",
+      partial: Boolean(projectionError),
+      projectionError,
+      state: this._state,
+    });
+  }
+
+  async initialize() {
+    const token = this._beginOperation(true);
+    await this._deleteLegacyStatus();
+    let stored;
+    let readError = null;
+    try {
+      stored = await this.context.secrets.get(AUTH_TOKEN_KEY);
+    } catch (error) {
+      readError = error;
+    }
+    await this._awaitSecretEventBarrier();
+    if (!this._canPublishOperation(token)) return this._staleResult();
+    if (readError) {
+      return this._finishIndeterminate(token, readError, "Could not read stored credentials.");
+    }
+    return this._acceptStoredSnapshot(stored, token, { source: "startup" });
+  }
+
+  async replaceCredential(candidate, token = null) {
+    const operation = token || this._beginOperation(true);
+    if (!this.isOperationCurrent(operation)) return this._staleResult();
+
+    const normalized = normalizeCandidate(candidate);
+    if (!normalized.ok) {
+      return this._finishReplacementFailure(
+        operation,
+        fixedPublicError("invalid_candidate", normalized.reason)
+      );
     }
 
-    return checkPassed;
+    const validation = await this._validateCandidate(normalized.value, operation.signal);
+    await this._awaitSecretEventBarrier();
+    if (!this._canPublishOperation(operation)) return this._staleResult();
+    if (!validation.ok) {
+      return this._finishReplacementFailure(operation, validation.error);
+    }
+
+    return this._enqueueMutation(() => this._commitCandidate(normalized.value, operation));
   }
 
-  // Check if currently connected 
+  async disconnect(token = null) {
+    const operation = token || this._beginOperation(true);
+    if (!this.isOperationCurrent(operation)) return this._staleResult();
+    return this._enqueueMutation(() => this._commitDelete(operation));
+  }
+
+  async checkConnectivity(apiKey) {
+    const normalized = normalizeCandidate(apiKey);
+    if (!normalized.ok) {
+      return "false";
+    }
+    const validation = await this._validateCandidate(normalized.value);
+    if (validation.ok) return "true";
+    return validation.error && validation.error.kind === "unauthorized" ? "false" : "error";
+  }
+
   async isConnected() {
-    const isConnected = await this.context.secrets.get("cloudsmith-vsc.isConnected");
-    return isConnected
-
+    return this._state.sessionConnected ? "true" : "false";
   }
 
-  // Connect to Cloudsmith
   async connect(options = {}) {
-    const context = this.context;
     const { promptOnMissingCredentials = true } = options;
-    let showConnectMsg = true; // controls whether to show connected notification. Used for refresh.
-    let currentConnectionStatus = await this.isConnected();
-    let connectionStatus = "";
-
-    const credentialManager = new CredentialManager(context);
-    const apiKey = await credentialManager.getApiKey();
-
-    checkCreds: if (!apiKey) {
-      await vscode.commands.executeCommand("setContext", "cloudsmith.connected", false);
+    const result = await this.initialize();
+    if (result.ok) {
+      if (result.status === CONNECTION_STATUSES.CONNECTED) {
+        vscode.window.showInformationMessage("Connected to Cloudsmith.");
+        return "true";
+      }
       if (promptOnMissingCredentials) {
-        vscode.window
-          .showWarningMessage("No credentials configured!", "Configure", "Cancel")
-          .then((selection) => {
-            select: if (selection === "Configure") {
-              vscode.commands.executeCommand("cloudsmith-vsc.configureCredentials");
-              break select;
-            }
-          });
+        const selection = await vscode.window.showWarningMessage(
+          "No credentials configured!",
+          "Configure",
+          "Cancel"
+        );
+        if (selection === "Configure") {
+          await vscode.commands.executeCommand("cloudsmith-vsc.configureCredentials");
+        }
       }
       return "false";
-    } else {
-      connectionStatus = await this.checkConnectivity(apiKey);
+    }
+    if (result.status === "stale") return this._state.sessionConnected ? "true" : "false";
+    const errorMessage = result.error
+      ? result.error.message
+      : "Could not connect to Cloudsmith. Check the credentials and try again.";
+    const selection = await vscode.window.showErrorMessage(errorMessage, "Configure", "Cancel");
+    if (selection === "Configure") {
+      await vscode.commands.executeCommand("cloudsmith-vsc.configureCredentials");
+    }
+    return result.status === CONNECTION_STATUSES.FAILED ? "false" : "error";
+  }
 
-      if (currentConnectionStatus === connectionStatus) { //if current = new status, no need to show notification
-        showConnectMsg = false;
-      }
+  dispose() {
+    if (this._disposed) return;
+    this._disposed = true;
+    if (this._currentOperation) this._currentOperation.controller.abort();
+    this._currentOperation = null;
+    if (this._secretListener && typeof this._secretListener.dispose === "function") {
+      this._secretListener.dispose();
+    }
+    unbindConnectionManager(this.context, this);
+    this._setState({
+      ...this._state,
+      status: CONNECTION_STATUSES.DISPOSED,
+      sessionConnected: false,
+      error: null,
+    });
+    this._stateEmitter.dispose();
+  }
 
-      if (connectionStatus === "false" || connectionStatus === "error") {
-        const errorMsg = this._lastError
-          ? formatApiError(this._lastError)
-          : "Could not connect to Cloudsmith. Check the credentials and try again.";
-        vscode.window
-          .showErrorMessage(
-            errorMsg,
-            "Configure",
-            "Cancel"
-          )
-          .then((selection) => {
-            select: if (selection === "Configure") {
-              vscode.commands.executeCommand("cloudsmith-vsc.configureCredentials");
-              break select;
-            }
-          });
-        return connectionStatus;
-      } else { // connection status = true
-        if (showConnectMsg) {
-          vscode.window.showInformationMessage("Connected to Cloudsmith.");
-        }
-        // checkConnectivity() already stored "cloudsmith-vsc.isConnected"
+  _beginOperation(publish) {
+    if (this._disposed) {
+      const controller = new AbortController();
+      controller.abort();
+      return Object.freeze({ id: ++this._operationCounter, controller, signal: controller.signal });
+    }
+    if (this._currentOperation) this._currentOperation.controller.abort();
+    const controller = new AbortController();
+    const token = Object.freeze({
+      id: ++this._operationCounter,
+      controller,
+      signal: controller.signal,
+    });
+    this._currentOperation = token;
+    this._operationPublicationSequence.set(token, this._secretEventSequence);
+    if (publish) {
+      this._setState({
+        status: CONNECTION_STATUSES.VALIDATING,
+        operationId: token.id,
+        accountEpoch: this._state.accountEpoch,
+        credentialPresent: this._stableState.credentialPresent,
+        sessionConnected: this._stableState.sessionConnected,
+        error: null,
+      });
+    }
+    return token;
+  }
+
+  async _validateCandidate(apiKey, signal) {
+    if (signal && signal.aborted) {
+      return Object.freeze({ ok: false, error: fixedPublicError("cancelled", "Authentication was cancelled.") });
+    }
+    try {
+      const api = this._createCloudsmithAPI(this.context);
+      const result = await api.get("user/self", {
+        apiKey,
+        signal,
+        responseType: "object",
+        validate: value => Boolean(value) && typeof value.authenticated === "boolean",
+        retry: "never",
+      });
+      if (signal && signal.aborted) {
+        return Object.freeze({ ok: false, error: fixedPublicError("cancelled", "Authentication was cancelled.") });
       }
-      return connectionStatus;
+      if (result && result.ok && result.data.authenticated) {
+        return Object.freeze({ ok: true });
+      }
+      const error = result && !result.ok
+        ? validationAPIError(result.error)
+        : fixedPublicError("unauthorized", "The API key was not accepted by Cloudsmith.");
+      return Object.freeze({ ok: false, error });
+    } catch (error) {
+      return Object.freeze({
+        ok: false,
+        error: publicError(error, "Could not validate the API key."),
+      });
+    }
+  }
+
+  async _commitCandidate(candidate, operation) {
+    await this._awaitSecretEventBarrier();
+    if (!this._canPublishOperation(operation)) return this._staleResult();
+    const candidateFingerprint = fingerprint(candidate);
+    const intent = this._createSecretIntent("store", candidateFingerprint, operation);
+    this._expectedSecretIntent = intent;
+    const expectedSelfEvent = this._expectSelfEvent(intent, candidateFingerprint);
+
+    let writeError = null;
+    try {
+      await this.context.secrets.store(AUTH_TOKEN_KEY, candidate);
+    } catch (error) {
+      writeError = error;
+    }
+    await this._awaitSecretEventBarrier();
+    this._closeSelfEventExpectation(intent, expectedSelfEvent);
+    if (intent.highestExternal) {
+      return this._restoreCapturedExternal(intent, writeError);
     }
 
+    let finalRead;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      finalRead = await this._readFinalAuthoritativeSnapshot(intent, operation);
+      if (!finalRead.ok || finalRead.sequence === this._secretEventSequence) break;
+    }
+    if (finalRead.external) {
+      return this._restoreCapturedExternal(intent, writeError);
+    }
+    if (!finalRead.ok) {
+      const readError = finalRead.error;
+      if (!this.isOperationCurrent(operation)) {
+        this._recordIndeterminateBaseline(operation, writeError || readError);
+        return this._staleResult();
+      }
+      return this._finishIndeterminate(
+        operation,
+        writeError || readError,
+        "Credential storage outcome could not be determined.",
+        true
+      );
+    }
+    if (finalRead.sequence !== this._secretEventSequence) {
+      return this._finishIndeterminate(
+        operation,
+        { kind: "unstable_secret_state", message: "Credentials changed during final verification." },
+        "Credentials changed during final verification.",
+        true
+      );
+    }
+    const stored = finalRead.value;
+    const operationOwned = finalRead.operationOwned && this._canPublishOperation(operation);
+    const storedFingerprint = fingerprint(stored);
+    if (storedFingerprint === candidateFingerprint) {
+      intent.active = false;
+      if (!operationOwned && !this._currentOperation) {
+        await this._reconcileAfterLostOwnership(stored);
+        return this._staleResult();
+      }
+      this._adoptFingerprint(storedFingerprint);
+      const state = this._makeStableState(CONNECTION_STATUSES.CONNECTED, operation.id, true, true, null);
+      this._stableState = state;
+      if (!operationOwned) return this._staleResult();
+      this._setState(state);
+      this._currentOperation = null;
+      const projectionError = await this._projectConnection(true);
+      return Object.freeze({
+        ok: true,
+        status: CONNECTION_STATUSES.CONNECTED,
+        committed: true,
+        partial: Boolean(projectionError),
+        error: projectionError,
+        state: this._state,
+      });
+    }
+
+    if (!operationOwned) return this._staleResult();
+
+    if (writeError && storedFingerprint === this._knownFingerprint) {
+      return this._finishReplacementFailure(operation, publicError(writeError, "Could not save credentials."));
+    }
+
+    this._expectedSecretIntent = null;
+    return this._supersedeWithSnapshot(stored, operation, writeError);
+  }
+
+  async _commitDelete(operation) {
+    await this._awaitSecretEventBarrier();
+    if (!this._canPublishOperation(operation)) return this._staleResult();
+    const intent = this._createSecretIntent("delete", null, operation);
+    this._expectedSecretIntent = intent;
+    const expectedSelfEvent = this._expectSelfEvent(intent, null);
+
+    let writeError = null;
+    try {
+      await this.context.secrets.delete(AUTH_TOKEN_KEY);
+    } catch (error) {
+      writeError = error;
+    }
+    await this._awaitSecretEventBarrier();
+    this._closeSelfEventExpectation(intent, expectedSelfEvent);
+    if (intent.highestExternal) {
+      await this._deleteLegacyStatus();
+      return this._restoreCapturedExternal(intent, writeError);
+    }
+    await this._deleteLegacyStatus();
+
+    let finalRead;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      finalRead = await this._readFinalAuthoritativeSnapshot(intent, operation);
+      if (!finalRead.ok || finalRead.sequence === this._secretEventSequence) break;
+    }
+    if (finalRead.external) {
+      return this._restoreCapturedExternal(intent, writeError);
+    }
+    if (!finalRead.ok) {
+      const readError = finalRead.error;
+      if (!this.isOperationCurrent(operation)) {
+        this._recordIndeterminateBaseline(operation, writeError || readError);
+        return this._staleResult();
+      }
+      return this._finishIndeterminate(
+        operation,
+        writeError || readError,
+        "Credential deletion outcome could not be determined.",
+        true
+      );
+    }
+    if (finalRead.sequence !== this._secretEventSequence) {
+      return this._finishIndeterminate(
+        operation,
+        { kind: "unstable_secret_state", message: "Credentials changed during final verification." },
+        "Credentials changed during final verification.",
+        true
+      );
+    }
+    const stored = finalRead.value;
+    const operationOwned = finalRead.operationOwned && this._canPublishOperation(operation);
+    if (typeof stored !== "string" || !stored) {
+      intent.active = false;
+      if (!operationOwned && !this._currentOperation) {
+        await this._reconcileAfterLostOwnership(stored);
+        return this._staleResult();
+      }
+      this._adoptFingerprint(null);
+      const state = this._makeStableState(CONNECTION_STATUSES.ABSENT, operation.id, false, false, null);
+      this._stableState = state;
+      if (!operationOwned) return this._staleResult();
+      this._setState(state);
+      this._currentOperation = null;
+      const projectionError = await this._projectConnection(false);
+      return Object.freeze({
+        ok: true,
+        status: CONNECTION_STATUSES.ABSENT,
+        committed: true,
+        partial: Boolean(projectionError),
+        error: projectionError,
+        state: this._state,
+      });
+    }
+
+    if (!operationOwned) return this._staleResult();
+
+    if (writeError && fingerprint(stored) === this._knownFingerprint) {
+      return this._finishReplacementFailure(operation, publicError(writeError, "Could not delete credentials."));
+    }
+    this._expectedSecretIntent = null;
+    return this._supersedeWithSnapshot(stored, operation, writeError);
+  }
+
+  async _acceptStoredSnapshot(stored, operation, options = {}) {
+    if (!this.isOperationCurrent(operation)) return this._staleResult();
+    if (typeof stored !== "string" || !stored) {
+      this._adoptFingerprint(null);
+      const state = this._makeStableState(CONNECTION_STATUSES.ABSENT, operation.id, false, false, null);
+      this._stableState = state;
+      this._setState(state);
+      this._currentOperation = null;
+      const projectionError = await this._projectConnection(false);
+      return Object.freeze({
+        ok: true,
+        status: CONNECTION_STATUSES.ABSENT,
+        committed: false,
+        partial: Boolean(projectionError),
+        error: projectionError,
+        state: this._state,
+      });
+    }
+
+    const normalized = normalizeCandidate(stored);
+    if (!normalized.ok || normalized.value !== stored) {
+      this._adoptFingerprint(fingerprint(stored));
+      const error = fixedPublicError(
+        "invalid_candidate",
+        normalized.ok ? "Stored credentials are not normalized." : normalized.reason
+      );
+      const state = this._makeStableState(CONNECTION_STATUSES.FAILED, operation.id, true, false, error);
+      this._stableState = state;
+      this._setState(state);
+      this._currentOperation = null;
+      const projectionError = await this._projectConnection(false);
+      return Object.freeze({
+        ok: false,
+        status: CONNECTION_STATUSES.FAILED,
+        committed: false,
+        partial: Boolean(projectionError),
+        error,
+        projectionError,
+        state: this._state,
+        source: options.source || "external",
+      });
+    }
+
+    const snapshotFingerprint = fingerprint(normalized.value);
+    const identityChanged = this._knownFingerprint !== snapshotFingerprint;
+    this._adoptFingerprint(snapshotFingerprint);
+    if (identityChanged) {
+      this._stableState = this._makeStableState(
+        CONNECTION_STATUSES.FAILED,
+        operation.id,
+        true,
+        false,
+        null
+      );
+      this._setState({ ...this._state, sessionConnected: false, credentialPresent: true });
+    }
+
+    const validation = await this._validateCandidate(normalized.value, operation.signal);
+    if (!this._canPublishOperation(operation)) return this._staleResult();
+    if (!validation.ok) {
+      const error = validation.error;
+      const state = this._makeStableState(CONNECTION_STATUSES.FAILED, operation.id, true, false, error);
+      this._stableState = state;
+      this._setState(state);
+      this._currentOperation = null;
+      const projectionError = await this._projectConnection(false);
+      return Object.freeze({
+        ok: false,
+        status: CONNECTION_STATUSES.FAILED,
+        committed: false,
+        partial: Boolean(projectionError),
+        error,
+        projectionError,
+        state: this._state,
+        source: options.source || "external",
+      });
+    }
+
+    const state = this._makeStableState(CONNECTION_STATUSES.CONNECTED, operation.id, true, true, null);
+    this._stableState = state;
+    this._setState(state);
+    this._currentOperation = null;
+    const projectionError = await this._projectConnection(true);
+    return Object.freeze({
+      ok: true,
+      status: CONNECTION_STATUSES.CONNECTED,
+      committed: false,
+      partial: Boolean(projectionError),
+      error: projectionError,
+      state: this._state,
+      source: options.source || "external",
+    });
+  }
+
+  async _supersedeWithSnapshot(stored, operation, writeError) {
+    if (this.isOperationCurrent(operation)) operation.controller.abort();
+    const token = this._beginOperation(true);
+    const result = await this._acceptStoredSnapshot(stored, token, { source: "external" });
+    return Object.freeze({
+      ok: false,
+      status: "superseded",
+      committed: false,
+      error: writeError
+        ? publicError(writeError, "Credential persistence did not complete as requested.")
+        : fixedPublicError(
+          "persistence_mismatch",
+          "Credential persistence did not complete as requested. The current credentials were reloaded."
+        ),
+      state: result.state || this._state,
+    });
+  }
+
+  async _finishReplacementFailure(operation, error) {
+    if (!this.isOperationCurrent(operation)) return this._staleResult();
+    this._expectedSecretIntent = null;
+    const safeError = publicError(error, "Could not validate credentials.");
+    const restored = freezeState({
+      ...this._stableState,
+      operationId: operation.id,
+      accountEpoch: this._state.accountEpoch,
+      error: safeError,
+    });
+    this._stableState = restored;
+    this._setState(restored);
+    this._currentOperation = null;
+    const projectionError = await this._projectConnection(restored.sessionConnected);
+    return Object.freeze({
+      ok: false,
+      status: CONNECTION_STATUSES.FAILED,
+      committed: false,
+      preserved: restored.sessionConnected,
+      partial: Boolean(projectionError),
+      error: safeError,
+      projectionError,
+      state: this._state,
+    });
+  }
+
+  async _finishIndeterminate(operation, error, fallbackMessage, advanceEpoch = false) {
+    if (!this.isOperationCurrent(operation)) return this._staleResult();
+    const intent = this._expectedSecretIntent;
+    const observedAuthoritative = Boolean(
+      intent
+      && intent.observed
+      && intent.observedFingerprint === this._knownFingerprint
+    );
+    if (advanceEpoch && !observedAuthoritative) {
+      this._advanceIndeterminateEpoch();
+    }
+    const safeError = publicError(error, fallbackMessage);
+    const state = freezeState({
+      status: CONNECTION_STATUSES.INDETERMINATE,
+      operationId: operation.id,
+      accountEpoch: this._state.accountEpoch,
+      credentialPresent: null,
+      sessionConnected: false,
+      error: safeError,
+    });
+    this._stableState = state;
+    this._setState(state);
+    this._currentOperation = null;
+    const projectionError = await this._projectConnection(false);
+    return Object.freeze({
+      ok: false,
+      status: CONNECTION_STATUSES.INDETERMINATE,
+      committed: false,
+      error: safeError,
+      projectionError,
+      state: this._state,
+    });
+  }
+
+  _advanceIndeterminateEpoch() {
+    this._knownFingerprint = undefined;
+    this._setState({ ...this._state, accountEpoch: this._state.accountEpoch + 1 });
+  }
+
+  _recordIndeterminateBaseline(operation, error) {
+    if (!(this._expectedSecretIntent && this._expectedSecretIntent.observed)) {
+      this._advanceIndeterminateEpoch();
+    }
+    const safeError = publicError(error, "Credential storage outcome could not be determined.");
+    this._stableState = freezeState({
+      status: CONNECTION_STATUSES.INDETERMINATE,
+      operationId: operation.id,
+      accountEpoch: this._state.accountEpoch,
+      credentialPresent: null,
+      sessionConnected: false,
+      error: safeError,
+    });
+    this._setState({
+      ...this._state,
+      accountEpoch: this._stableState.accountEpoch,
+      credentialPresent: null,
+      sessionConnected: false,
+    });
+    this._projectConnection(false);
+  }
+
+  _adoptFingerprint(nextFingerprint) {
+    if (this._knownFingerprint !== nextFingerprint) {
+      this._knownFingerprint = nextFingerprint;
+      this._setState({ ...this._state, accountEpoch: this._state.accountEpoch + 1 });
+      return true;
+    }
+    return false;
+  }
+
+  _makeStableState(status, operationId, credentialPresent, sessionConnected, error) {
+    return freezeState({
+      status,
+      operationId,
+      accountEpoch: this._state.accountEpoch,
+      credentialPresent,
+      sessionConnected,
+      error: publicError(error, "Authentication failed."),
+    });
+  }
+
+  _setState(next) {
+    this._state = freezeState({ ...next, activationId: this.activationId });
+    if (!this._disposed || this._state.status === CONNECTION_STATUSES.DISPOSED) {
+      this._stateEmitter.fire(this._state);
+    }
+  }
+
+  _enqueueMutation(task) {
+    const run = this._mutationQueue.then(task, task);
+    this._mutationQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  async _awaitSecretEventBarrier() {
+    while (true) {
+      const chain = this._secretEventChain;
+      await chain;
+      if (chain === this._secretEventChain) return this._secretEventSequence;
+    }
+  }
+
+  async _readFinalAuthoritativeSnapshot(intent, operation) {
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const sequenceBeforeRead = this._secretEventSequence;
+      let value;
+      let error = null;
+      try {
+        value = await this.context.secrets.get(AUTH_TOKEN_KEY);
+      } catch (readError) {
+        error = readError;
+      }
+
+      const sequenceAfterBarrier = await this._awaitSecretEventBarrier();
+      if (intent.highestExternal) {
+        return Object.freeze({ ok: false, external: true });
+      }
+      if (sequenceAfterBarrier !== sequenceBeforeRead) continue;
+
+      const operationOwned = this._canPublishOperation(operation)
+        && this._operationCounter === operation.id;
+      if (error) {
+        return Object.freeze({ ok: false, external: false, error, operationOwned });
+      }
+      return Object.freeze({
+        ok: true,
+        external: false,
+        value,
+        operationOwned,
+        sequence: sequenceAfterBarrier,
+      });
+    }
+
+    return Object.freeze({
+      ok: false,
+      external: false,
+      operationOwned: false,
+      error: Object.freeze({
+        kind: "unstable_secret_state",
+        message: "Credentials kept changing while their final state was being verified.",
+      }),
+    });
+  }
+
+  async _reconcileAfterLostOwnership(stored) {
+    if (this._currentOperation || this._disposed) return;
+    const operation = this._beginOperation(true);
+    await this._acceptStoredSnapshot(stored, operation, { source: "reconcile" });
+  }
+
+  _onSecretChange(event) {
+    if (this._disposed || !event || event.key !== AUTH_TOKEN_KEY) return;
+    const sequence = ++this._secretEventSequence;
+    let snapshotPromise;
+    try {
+      // Invoke get() at notification time. Serializing the invocation itself would
+      // allow a later write to erase the value associated with this event.
+      snapshotPromise = Promise.resolve(this.context.secrets.get(AUTH_TOKEN_KEY));
+    } catch (error) {
+      snapshotPromise = Promise.reject(error);
+    }
+    const record = Object.freeze({ sequence, snapshotPromise });
+    const handle = () => this._classifySecretEvent(record);
+    this._secretEventChain = this._secretEventChain.then(handle, handle);
+  }
+
+  async _classifySecretEvent(record) {
+    let stored;
+    try {
+      stored = await record.snapshotPromise;
+    } catch (error) {
+      if (this._disposed) return;
+      const intent = this._expectedSecretIntent;
+      if (intent && intent.active && record.sequence > intent.afterSequence) {
+        this._captureExternalSnapshot(intent, {
+          sequence: record.sequence,
+          readable: false,
+          error,
+          value: null,
+          fingerprint: undefined,
+        });
+        return;
+      }
+      const token = this._beginOperation(true);
+      await this._finishIndeterminate(token, error, "Could not read changed credentials.", true);
+      return;
+    }
+    if (this._disposed) return;
+
+    const observedFingerprint = fingerprint(stored);
+    const intent = this._expectedSecretIntent;
+    const expectedSelfEvent = intent && intent.expectedSelfEvents.find(expected => (
+      expected.active
+      && !expected.consumed
+      && expected.fingerprint === observedFingerprint
+      && record.sequence > expected.afterSequence
+      && record.sequence <= expected.throughSequence
+    ));
+    if (expectedSelfEvent) {
+      expectedSelfEvent.active = false;
+      expectedSelfEvent.consumed = true;
+      intent.expectedSelfEvents = intent.expectedSelfEvents.filter(expected => expected.active);
+      intent.observed = true;
+      intent.observedFingerprint = observedFingerprint;
+      if (this._currentOperation) {
+        this._operationPublicationSequence.set(this._currentOperation, record.sequence);
+      }
+      this._adoptFingerprint(observedFingerprint);
+      if (!intent.active && this._state.status === CONNECTION_STATUSES.INDETERMINATE) {
+        this._expectedSecretIntent = null;
+        const token = this._beginOperation(true);
+        await this._acceptStoredSnapshot(stored, token, { source: "external" });
+      }
+      return;
+    }
+
+    if (intent && intent.active && record.sequence > intent.afterSequence) {
+      this._captureExternalSnapshot(intent, {
+        sequence: record.sequence,
+        readable: true,
+        error: null,
+        value: stored,
+        fingerprint: observedFingerprint,
+      });
+      return;
+    }
+
+    if (observedFingerprint === this._knownFingerprint) {
+      if (this._currentOperation) {
+        this._operationPublicationSequence.set(this._currentOperation, record.sequence);
+      }
+      return;
+    }
+
+    this._expectedSecretIntent = null;
+    const token = this._beginOperation(true);
+    await this._acceptStoredSnapshot(stored, token, { source: "external" });
+  }
+
+  _createSecretIntent(kind, expectedFingerprint, operation) {
+    return {
+      kind,
+      fingerprint: expectedFingerprint,
+      operation,
+      afterSequence: this._secretEventSequence,
+      observed: false,
+      observedFingerprint: undefined,
+      active: true,
+      expectedSelfEvents: [],
+      highestExternal: null,
+      externalOperation: null,
+    };
+  }
+
+  _expectSelfEvent(intent, expectedFingerprint) {
+    const expected = {
+      fingerprint: expectedFingerprint,
+      afterSequence: this._secretEventSequence,
+      throughSequence: Number.POSITIVE_INFINITY,
+      active: true,
+      consumed: false,
+    };
+    intent.expectedSelfEvents.push(expected);
+    return expected;
+  }
+
+  _closeSelfEventExpectation(intent, expected) {
+    if (!expected || expected.consumed) return;
+    expected.throughSequence = this._secretEventSequence;
+    expected.active = false;
+    intent.expectedSelfEvents = intent.expectedSelfEvents.filter(item => item.active);
+  }
+
+  _captureExternalSnapshot(intent, snapshot) {
+    if (intent.highestExternal && intent.highestExternal.sequence >= snapshot.sequence) return;
+    intent.highestExternal = snapshot;
+    const externalOperation = this._beginOperation(true);
+    intent.externalOperation = externalOperation;
+
+    if (!snapshot.readable) {
+      this._advanceIndeterminateEpoch();
+      const state = freezeState({
+        status: CONNECTION_STATUSES.INDETERMINATE,
+        operationId: externalOperation.id,
+        accountEpoch: this._state.accountEpoch,
+        credentialPresent: null,
+        sessionConnected: false,
+        error: publicError(snapshot.error, "Could not read changed credentials."),
+      });
+      this._stableState = state;
+      this._setState(state);
+      return;
+    }
+
+    this._adoptFingerprint(snapshot.fingerprint);
+    const credentialPresent = typeof snapshot.value === "string" && snapshot.value.length > 0;
+    this._stableState = this._makeStableState(
+      credentialPresent ? CONNECTION_STATUSES.FAILED : CONNECTION_STATUSES.ABSENT,
+      externalOperation.id,
+      credentialPresent,
+      false,
+      null
+    );
+    this._setState({
+      status: CONNECTION_STATUSES.VALIDATING,
+      operationId: externalOperation.id,
+      accountEpoch: this._state.accountEpoch,
+      credentialPresent,
+      sessionConnected: false,
+      error: null,
+    });
+    this._projectConnection(false);
+  }
+
+  async _restoreCapturedExternal(intent, writeError) {
+    restoreLoop:
+    while (intent.highestExternal) {
+      await this._awaitSecretEventBarrier();
+      const target = intent.highestExternal;
+      if (!target.readable) {
+        const operation = intent.externalOperation;
+        if (operation && this.isOperationCurrent(operation)) {
+          await this._finishIndeterminate(
+            operation,
+            target.error || writeError,
+            "Credential storage outcome could not be determined."
+          );
+        }
+        const result = Object.freeze({
+          ok: false,
+          status: CONNECTION_STATUSES.INDETERMINATE,
+          committed: false,
+          error: publicError(target.error || writeError, "Credential storage outcome could not be determined."),
+          state: this._state,
+        });
+        this._retireSecretIntent(intent);
+        return result;
+      }
+
+      const expectedSelfEvent = this._expectSelfEvent(intent, target.fingerprint);
+      let restoreError = null;
+      try {
+        if (target.fingerprint === null) {
+          await this.context.secrets.delete(AUTH_TOKEN_KEY);
+        } else {
+          await this.context.secrets.store(AUTH_TOKEN_KEY, target.value);
+        }
+      } catch (error) {
+        restoreError = error;
+      }
+      await this._awaitSecretEventBarrier();
+      this._closeSelfEventExpectation(intent, expectedSelfEvent);
+      if (intent.highestExternal.sequence > target.sequence) continue;
+
+      let authoritative;
+      let authoritativeSequence = null;
+      let authoritativeStable = false;
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const sequenceBeforeRead = this._secretEventSequence;
+        try {
+          authoritative = await this.context.secrets.get(AUTH_TOKEN_KEY);
+        } catch (error) {
+          const operation = intent.externalOperation;
+          if (operation && this.isOperationCurrent(operation)) {
+            await this._finishIndeterminate(
+              operation,
+              restoreError || error,
+              "Credential restoration outcome could not be determined.",
+              true
+            );
+          }
+          const result = Object.freeze({
+            ok: false,
+            status: CONNECTION_STATUSES.INDETERMINATE,
+            committed: false,
+            error: publicError(restoreError || error, "Credential restoration outcome could not be determined."),
+            state: this._state,
+          });
+          this._retireSecretIntent(intent);
+          return result;
+        }
+        authoritativeSequence = await this._awaitSecretEventBarrier();
+        if (intent.highestExternal.sequence > target.sequence) continue restoreLoop;
+        if (
+          sequenceBeforeRead === authoritativeSequence
+          && authoritativeSequence === this._secretEventSequence
+        ) {
+          authoritativeStable = true;
+          break;
+        }
+      }
+      if (!authoritativeStable || authoritativeSequence !== this._secretEventSequence) continue;
+
+      const authoritativeFingerprint = fingerprint(authoritative);
+      if (authoritativeFingerprint !== target.fingerprint) {
+        const sequence = ++this._secretEventSequence;
+        this._captureExternalSnapshot(intent, {
+          sequence,
+          readable: true,
+          error: null,
+          value: authoritative,
+          fingerprint: authoritativeFingerprint,
+        });
+        continue;
+      }
+
+      const externalOperation = intent.externalOperation;
+      if (authoritativeSequence !== this._secretEventSequence) continue;
+      if (externalOperation && this.isOperationCurrent(externalOperation)) {
+        const accepted = await this._acceptStoredSnapshot(authoritative, externalOperation, { source: "external" });
+        if (
+          accepted.status === "stale"
+          && intent.highestExternal.sequence === target.sequence
+          && authoritativeSequence === this._secretEventSequence
+        ) {
+          await this._updateStableExternalBaseline(authoritative, target);
+          if (!this._currentOperation && this._knownFingerprint === target.fingerprint) {
+            await this._reconcileAfterLostOwnership(authoritative);
+          }
+        }
+      } else if (!this._currentOperation) {
+        await this._reconcileAfterLostOwnership(authoritative);
+      } else {
+        await this._updateStableExternalBaseline(authoritative, target);
+        if (!this._currentOperation && this._knownFingerprint === target.fingerprint) {
+          await this._reconcileAfterLostOwnership(authoritative);
+        }
+      }
+      if (
+        intent.highestExternal.sequence > target.sequence
+        || authoritativeSequence !== this._secretEventSequence
+      ) {
+        continue;
+      }
+      const result = Object.freeze({
+        ok: false,
+        status: "superseded",
+        committed: false,
+        error: writeError
+          ? publicError(writeError, "Credentials changed outside this operation.")
+          : fixedPublicError(
+            "credential_changed",
+            "Credentials changed outside this operation. The latest value was restored."
+          ),
+        state: this._state,
+      });
+      this._retireSecretIntent(intent);
+      return result;
+    }
+    this._retireSecretIntent(intent);
+    return this._staleResult();
+  }
+
+  _retireSecretIntent(intent) {
+    if (!intent) return;
+    intent.active = false;
+    intent.operation = null;
+    intent.externalOperation = null;
+    intent.highestExternal = null;
+    intent.expectedSelfEvents = [];
+    intent.observedFingerprint = undefined;
+    if (this._expectedSecretIntent === intent) {
+      this._expectedSecretIntent = null;
+    }
+  }
+
+  async _updateStableExternalBaseline(stored, snapshot) {
+    if (snapshot.fingerprint === null) {
+      this._stableState = this._makeStableState(
+        CONNECTION_STATUSES.ABSENT,
+        this._state.operationId,
+        false,
+        false,
+        null
+      );
+      return;
+    }
+    const normalized = normalizeCandidate(stored);
+    if (!normalized.ok || normalized.value !== stored) {
+      this._stableState = this._makeStableState(
+        CONNECTION_STATUSES.FAILED,
+        this._state.operationId,
+        true,
+        false,
+        fixedPublicError(
+          "invalid_candidate",
+          normalized.ok ? "Stored credentials are not normalized." : normalized.reason
+        )
+      );
+      return;
+    }
+    const validation = await this._validateCandidate(normalized.value);
+    if (this._knownFingerprint !== snapshot.fingerprint) return;
+    this._stableState = this._makeStableState(
+      validation.ok ? CONNECTION_STATUSES.CONNECTED : CONNECTION_STATUSES.FAILED,
+      this._state.operationId,
+      true,
+      validation.ok,
+      validation.error
+    );
+  }
+
+  _projectConnection(connected) {
+    const project = async () => {
+      let lastError = null;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          await this._executeCommand("setContext", CONNECTION_CONTEXT_KEY, connected);
+          return null;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      return publicError(lastError, "Could not update the Cloudsmith connection indicator.");
+    };
+    const run = this._projectionQueue.then(project, project);
+    this._projectionQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  async _deleteLegacyStatus() {
+    if (!this.context.secrets || typeof this.context.secrets.delete !== "function") return;
+    try {
+      await this.context.secrets.delete(LEGACY_CONNECTION_KEY);
+    } catch {
+      // The compatibility key is never authoritative; retry on the next initialization.
+    }
+  }
+
+  _staleResult() {
+    return Object.freeze({
+      ok: false,
+      status: "stale",
+      committed: false,
+      state: this._state,
+    });
   }
 }
 
-module.exports = { ConnectionManager };
+module.exports = {
+  AUTH_TOKEN_KEY,
+  CONNECTION_STATUSES,
+  ConnectionManager,
+  bindConnectionManager,
+  getAccountEpoch,
+  getConnectionManager,
+  getConnectionState,
+  normalizeCandidate,
+  unbindConnectionManager,
+};

--- a/util/credentialManager.js
+++ b/util/credentialManager.js
@@ -1,63 +1,178 @@
-// This class handles credential storage and retrieval. 
-
 const vscode = require("vscode");
 
-class CredentialManager {
-  constructor(context) {
-    this.context = context;
+const AUTH_TOKEN_KEY = "cloudsmith-vsc.authToken";
+
+function unavailableResult() {
+  return Object.freeze({
+    ok: false,
+    status: "unavailable",
+    committed: false,
+    error: Object.freeze({
+      kind: "unavailable",
+      message: "Authentication is not ready. Reload the extension and try again.",
+    }),
+  });
+}
+
+async function runCLIAutoDetect(options) {
+  const {
+    connectionManager,
+    secrets,
+    ssoManager,
+    showInformationMessage,
+    handleAuthenticationResult,
+  } = options;
+  const stableState = connectionManager.getState();
+  if (
+    stableState.status !== "absent"
+    || stableState.credentialPresent !== false
+    || stableState.sessionConnected
+  ) {
+    return Object.freeze({ ok: false, status: "not_applicable" });
   }
 
-  // Show input box to enter credential key and store as a secret
-  async storeApiKey() {
-    const context = this.context;
-    const apiKey = await vscode.window.showInputBox({
-      prompt: "Enter a Cloudsmith API key",
-      password: true,
-      ignoreFocusOut: true,
+  const operation = connectionManager.beginCredentialOperation();
+  let currentKey;
+  try {
+    currentKey = await secrets.get(AUTH_TOKEN_KEY);
+  } catch {
+    if (connectionManager.isOperationCurrent(operation)) {
+      await connectionManager.cancelCredentialOperation(operation);
+    }
+    return Object.freeze({
+      ok: false,
+      status: "failed",
+      committed: false,
+      error: Object.freeze({
+        kind: "credential_read_failed",
+        message: "Could not check stored Cloudsmith credentials. Try again.",
+      }),
     });
-
-    if (apiKey) {
-      await context.secrets.store("cloudsmith-vsc.authToken", apiKey);
-      vscode.window.showInformationMessage("Credentials saved.");
-      return true;
+  }
+  if (!connectionManager.isOperationCurrent(operation)) {
+    return Object.freeze({ ok: false, status: "stale" });
+  }
+  if (currentKey) {
+    return connectionManager.initialize();
+  }
+  if (ssoManager.hasCLICredentials()) {
+    const choice = await showInformationMessage(
+      "Cloudsmith CLI credentials detected. Import them?",
+      "Import",
+      "Dismiss"
+    );
+    if (!connectionManager.isOperationCurrent(operation)) {
+      return Object.freeze({ ok: false, status: "stale" });
     }
-    return false;
+    if (choice === "Import") {
+      const result = await ssoManager.importFromCLI(operation);
+      await handleAuthenticationResult(result);
+      return result;
+    }
+  }
+  return connectionManager.cancelCredentialOperation(operation);
+}
+
+class CredentialManager {
+  constructor(context, options = {}) {
+    this.context = context;
+    this._connectionManager = options.connectionManager || null;
+    this._showInputBox = options.showInputBox || vscode.window.showInputBox;
+    this._showWarningMessage = options.showWarningMessage || vscode.window.showWarningMessage;
   }
 
-  // Fetch credential from secret store
   async getApiKey() {
-    const context = this.context;
-    const apiKey = await context.secrets.get("cloudsmith-vsc.authToken");
-
-    if (!apiKey) {
-      return null;
-    }
-
-    return apiKey;
+    const apiKey = await this.context.secrets.get(AUTH_TOKEN_KEY);
+    return typeof apiKey === "string" && apiKey ? apiKey : null;
   }
 
-  // Clear secret
-  async clearCredentials() {
-    const context = this.context;
-    const apiKey = await context.secrets.get("cloudsmith-vsc.authToken");
+  async storeApiKey(operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
 
-    if (apiKey) {
-      vscode.window
-        .showWarningMessage(
-          "Delete the stored API key?",
-          { modal: true },
-          "Delete"
-        )
-        .then(async (selection) => {
-          if (selection === "Delete") {
-            await context.secrets.delete("cloudsmith-vsc.authToken");
-            vscode.window.showInformationMessage("Credentials cleared.");
-          }
-        });
-    } else {
-      vscode.window.showWarningMessage("No credentials found.");
+    const token = operation || manager.beginCredentialOperation();
+    if (!manager.isOperationCurrent(token)) {
+      return Object.freeze({ ok: false, status: "stale", committed: false, state: manager.getState() });
     }
+    let apiKey;
+    try {
+      apiKey = await this._showInputBox({
+        prompt: "Enter a Cloudsmith API key",
+        password: true,
+        ignoreFocusOut: true,
+      });
+    } catch {
+      await manager.cancelCredentialOperation(token);
+      return Object.freeze({
+        ok: false,
+        status: "failed",
+        committed: false,
+        error: Object.freeze({
+          kind: "input_failed",
+          message: "Could not read the API key. Try again.",
+        }),
+      });
+    }
+
+    if (typeof apiKey !== "string") {
+      return manager.cancelCredentialOperation(token);
+    }
+    return manager.replaceCredential(apiKey, token);
+  }
+
+  async saveApiKey(apiKey, operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
+    return manager.replaceCredential(apiKey, operation || manager.beginCredentialOperation());
+  }
+
+  async clearCredentials(operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
+
+    const token = operation || manager.beginCredentialOperation();
+    if (!manager.isOperationCurrent(token)) {
+      return Object.freeze({ ok: false, status: "stale", committed: false, state: manager.getState() });
+    }
+    const state = manager.getState();
+    if (state.credentialPresent === false) {
+      await manager.cancelCredentialOperation(token);
+      await this._showWarningMessage("No credentials found.");
+      return Object.freeze({ ok: false, status: "absent", committed: false, state: manager.getState() });
+    }
+
+    let selection;
+    try {
+      selection = await this._showWarningMessage(
+        "Delete the stored API key?",
+        { modal: true },
+        "Delete"
+      );
+    } catch {
+      await manager.cancelCredentialOperation(token);
+      return Object.freeze({
+        ok: false,
+        status: "failed",
+        committed: false,
+        error: Object.freeze({
+          kind: "confirmation_failed",
+          message: "Could not confirm credential deletion. Try again.",
+        }),
+      });
+    }
+
+    if (selection !== "Delete") {
+      return manager.cancelCredentialOperation(token);
+    }
+    return manager.disconnect(token);
+  }
+
+  _getConnectionManager() {
+    if (this._connectionManager) return this._connectionManager;
+    // Lazy loading avoids a circular dependency while preserving fail-closed lookup.
+    const { getConnectionManager } = require("./connectionManager");
+    return getConnectionManager(this.context);
   }
 }
 
-module.exports = { CredentialManager };
+module.exports = { AUTH_TOKEN_KEY, CredentialManager, runCLIAutoDetect };

--- a/util/dependencyVulnEnricher.js
+++ b/util/dependencyVulnEnricher.js
@@ -2,6 +2,11 @@
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { getFoundDependencyKey } = require("./foundDependencyKey");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("./accountOperation");
 
 const VULNERABILITY_CACHE_TTL_MS = 10 * 60 * 1000;
 const VULNERABILITY_CACHE_MAX_SIZE = 5000;
@@ -297,13 +302,20 @@ function pruneExpiredVulnerabilityCache(now = Date.now()) {
   }
 }
 
-function getCachedVulnerabilitySummary(packageKey) {
+function getCachedVulnerabilitySummary(packageKey, account, now) {
   const cached = vulnerabilityCache.get(packageKey);
   if (!cached) {
     return null;
   }
 
-  if (cached.expiresAt > Date.now()) {
+  if (
+    cached.expiresAt > now
+    && cached.activationId === account.activationId
+    && cached.accountEpoch === account.accountEpoch
+  ) {
+    // Reinsert cache hits so the hard-cap eviction policy is deterministic LRU.
+    vulnerabilityCache.delete(packageKey);
+    vulnerabilityCache.set(packageKey, cached);
     return cached.value;
   }
 
@@ -311,24 +323,41 @@ function getCachedVulnerabilitySummary(packageKey) {
   return null;
 }
 
-function setCachedVulnerabilitySummary(packageKey, value) {
+function setCachedVulnerabilitySummary(packageKey, value, account, now) {
+  vulnerabilityCache.delete(packageKey);
   if (vulnerabilityCache.size >= VULNERABILITY_CACHE_MAX_SIZE) {
-    pruneExpiredVulnerabilityCache();
+    pruneExpiredVulnerabilityCache(now);
+  }
+  while (vulnerabilityCache.size >= VULNERABILITY_CACHE_MAX_SIZE) {
+    const oldestKey = vulnerabilityCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    vulnerabilityCache.delete(oldestKey);
   }
 
   vulnerabilityCache.set(packageKey, {
-    expiresAt: Date.now() + VULNERABILITY_CACHE_TTL_MS,
+    activationId: account.activationId,
+    accountEpoch: account.accountEpoch,
+    expiresAt: now + VULNERABILITY_CACHE_TTL_MS,
     value,
   });
 }
 
-async function fetchVulnerabilitySummary(api, packageModel, fallbackSummary, cancellationToken) {
+async function fetchVulnerabilitySummary(
+  api,
+  packageModel,
+  fallbackSummary,
+  cancellationToken,
+  connectionManager,
+  account,
+  now
+) {
   const packageKey = getFoundDependencyKey({ cloudsmithPackage: packageModel });
   if (!packageKey) {
     return fallbackSummary;
   }
 
-  const cachedValue = getCachedVulnerabilitySummary(packageKey);
+  if (!isAccountCurrent(connectionManager, account)) return null;
+  const cachedValue = getCachedVulnerabilitySummary(packageKey, account, now());
   if (cachedValue) {
     return cachedValue;
   }
@@ -363,12 +392,17 @@ async function fetchVulnerabilitySummary(api, packageModel, fallbackSummary, can
     retry: "never",
     cancellationToken,
   });
-  if (!response.ok || isCancellationRequested(cancellationToken)) {
+  if (
+    !response.ok
+    || isCancellationRequested(cancellationToken)
+    || !isAccountCurrent(connectionManager, account)
+  ) {
     return null;
   }
 
   const summary = summarizeEntries(extractVulnerabilityEntries(response.data), fallbackSummary);
-  setCachedVulnerabilitySummary(packageKey, summary);
+  if (!isAccountCurrent(connectionManager, account)) return null;
+  setCachedVulnerabilitySummary(packageKey, summary, account, now());
   return summary;
 }
 
@@ -389,7 +423,13 @@ function applyVulnerabilityPatch(dependencies, patchMap) {
 async function enrichVulnerabilities(dependencies, workspace, options = {}) {
   const onProgress = typeof options.onProgress === "function" ? options.onProgress : null;
   const cancellationToken = options.cancellationToken || null;
+  const connectionManager = resolveConnectionManager(options.context, options.connectionManager);
+  const account = options.account || captureAccount(connectionManager);
+  if (!account || !isAccountCurrent(connectionManager, account)) {
+    return Array.isArray(dependencies) ? dependencies : [];
+  }
   const api = options.cloudsmithAPI || new CloudsmithAPI(options.context);
+  const now = options.now || Date.now;
   const groups = collectPackageGroups(dependencies);
   const patchMap = new Map();
   const detailTargets = [];
@@ -405,7 +445,7 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
     }
   }
 
-  if (onProgress && patchMap.size > 0) {
+  if (onProgress && patchMap.size > 0 && isAccountCurrent(connectionManager, account)) {
     onProgress(new Map(patchMap), {
       completed: 0,
       total: detailTargets.length,
@@ -415,8 +455,10 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
   }
 
   let completed = 0;
+  let stale = false;
   await runPool(detailTargets, VULNERABILITY_CONCURRENCY, async (target) => {
-    if (isCancellationRequested(cancellationToken)) {
+    if (isCancellationRequested(cancellationToken) || !isAccountCurrent(connectionManager, account)) {
+      stale = stale || !isAccountCurrent(connectionManager, account);
       return;
     }
 
@@ -424,15 +466,22 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
       api,
       target.packageModel,
       target.fallbackSummary,
-      cancellationToken
+      cancellationToken,
+      connectionManager,
+      account,
+      now
     );
 
+    if (!isAccountCurrent(connectionManager, account)) {
+      stale = true;
+      return;
+    }
     if (summary) {
       patchMap.set(target.key, summary);
     }
     completed += 1;
 
-    if (onProgress) {
+    if (onProgress && isAccountCurrent(connectionManager, account)) {
       onProgress(summary ? new Map([[target.key, summary]]) : new Map(), {
         completed,
         total: detailTargets.length,
@@ -442,6 +491,9 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
     }
   });
 
+  if (stale || !isAccountCurrent(connectionManager, account)) {
+    return Array.isArray(dependencies) ? dependencies : [];
+  }
   return applyVulnerabilityPatch(dependencies, patchMap);
 }
 
@@ -489,4 +541,5 @@ module.exports = {
   getVulnerabilityCacheSize() {
     return vulnerabilityCache.size;
   },
+  VULNERABILITY_CACHE_MAX_SIZE,
 };

--- a/util/filterState.js
+++ b/util/filterState.js
@@ -4,4 +4,8 @@
 
 const activeFilters = new Map();
 
-module.exports = { activeFilters };
+function clear() {
+  activeFilters.clear();
+}
+
+module.exports = { activeFilters, clear };

--- a/util/paginatedFetch.js
+++ b/util/paginatedFetch.js
@@ -153,6 +153,7 @@ function parsePagination(headers, requestedPage, requestedPageSize, itemCount) {
     if (
         !Number.isInteger(effectivePage)
         || effectivePage < 1
+        || effectivePage !== requestedPage
         || !Number.isInteger(effectivePageSize)
         || effectivePageSize < 1
         || itemCount > effectivePageSize

--- a/util/recentPackages.js
+++ b/util/recentPackages.js
@@ -107,4 +107,8 @@ function getAll() {
   return _recent.slice();
 }
 
-module.exports = { add, getAll };
+function clear() {
+  _recent.length = 0;
+}
+
+module.exports = { add, clear, getAll };

--- a/util/recentSearches.js
+++ b/util/recentSearches.js
@@ -1,66 +1,292 @@
-// Stores and retrieves recent searches from context.globalState.
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+// Versioned, bounded recent-search persistence.
+// Searches are non-secret, but only the fields required to replay them are stored.
 
-const STORAGE_KEY_PREFIX = 'cloudsmith-recentSearches';
+const STORAGE_KEY_PREFIX = "cloudsmith-recentSearches:v2";
+const STORAGE_VERSION = 2;
+const DEFAULT_MAX = 10;
+const HARD_MAX = 50;
+const MAX_WORKSPACE_LENGTH = 200;
+const MAX_QUERY_LENGTH = 2048;
+const MAX_REPOSITORIES = 100;
 
-class RecentSearches {
-    constructor(context, workspaceSlug) {
-        this.context = context;
-        this.workspaceSlug = workspaceSlug || '';
-        this.storageKey = this.workspaceSlug
-            ? `${STORAGE_KEY_PREFIX}:${this.workspaceSlug}`
-            : STORAGE_KEY_PREFIX;
+// Multiple command handlers can construct RecentSearches for the same workspace.
+// Serialize by the actual Memento object and storage key so those instances cannot
+// read/modify/write over one another.
+const writeQueues = new WeakMap();
+
+function queueFor(globalState, storageKey, operation) {
+  let queues = writeQueues.get(globalState);
+  if (!queues) {
+    queues = new Map();
+    writeQueues.set(globalState, queues);
+  }
+
+  const previous = queues.get(storageKey) || Promise.resolve();
+  const current = previous.catch(() => undefined).then(operation);
+  queues.set(storageKey, current);
+
+  return current.finally(() => {
+    if (queues.get(storageKey) === current) {
+      queues.delete(storageKey);
     }
-
-    /**
-     * Add a search entry. Deduplicates by workspace+query.
-     * @param {object} entry - { workspace, query, scope, timestamp }
-     */
-    add(entry) {
-        const searches = this.getAll();
-        const dedupKey = `${entry.workspace}:${entry.query}`;
-
-        // Remove existing entry with same workspace+query
-        const filtered = searches.filter(s => `${s.workspace}:${s.query}` !== dedupKey);
-
-        // Prepend new entry
-        filtered.unshift({
-            workspace: entry.workspace,
-            query: entry.query,
-            scope: entry.scope || 'workspace',
-            timestamp: entry.timestamp || Date.now(),
-        });
-
-        // Cap at max
-        const max = this._getMax();
-        const capped = filtered.slice(0, max);
-
-        this.context.globalState.update(this.storageKey, capped);
-    }
-
-    /**
-     * Get all recent searches, sorted by most recent first.
-     * @returns {Array} Array of search entries.
-     */
-    getAll() {
-        const max = this._getMax();
-        if (max === 0) {
-            return [];
-        }
-        const searches = this.context.globalState.get(this.storageKey) || [];
-        return searches.slice(0, max);
-    }
-
-    /** Clear all recent searches. */
-    clear() {
-        this.context.globalState.update(this.storageKey, []);
-    }
-
-    /** Get the configured max from settings. */
-    _getMax() {
-        const vscode = require('vscode');
-        const config = vscode.workspace.getConfiguration('cloudsmith-vsc');
-        return config.get('recentSearches') ?? 10;
-    }
+  });
 }
 
-module.exports = { RecentSearches };
+function isBoundedString(value, maxLength) {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength;
+}
+
+function normalizeRepositories(value) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_REPOSITORIES) {
+    return null;
+  }
+
+  const repositories = [];
+  for (const repository of value) {
+    if (
+      !isBoundedString(repository, MAX_WORKSPACE_LENGTH)
+      || repository !== repository.trim()
+    ) {
+      return null;
+    }
+    repositories.push(repository);
+  }
+
+  return [...new Set(repositories)].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeScope(scope) {
+  if (scope && typeof scope === "object" && !Array.isArray(scope)) {
+    const keys = Object.keys(scope).sort().join(",");
+    if (scope.kind === "workspace" && keys === "kind") {
+      return Object.freeze({ kind: "workspace" });
+    }
+    if (
+      scope.kind === "repository"
+      && keys === "kind,repository"
+      && isBoundedString(scope.repository, MAX_WORKSPACE_LENGTH)
+      && scope.repository === scope.repository.trim()
+    ) {
+      return Object.freeze({ kind: "repository", repository: scope.repository });
+    }
+    if (scope.kind === "repositories" && keys === "kind,repositories") {
+      const repositories = normalizeRepositories(scope.repositories);
+      return repositories
+        ? Object.freeze({ kind: "repositories", repositories: Object.freeze(repositories) })
+        : null;
+    }
+  }
+  return null;
+}
+
+function normalizeEntry(entry, expectedWorkspace, now) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+
+  const workspace = entry.workspace;
+  const query = entry.query;
+  const scope = normalizeScope(entry.scope);
+  if (
+    !isBoundedString(workspace, MAX_WORKSPACE_LENGTH)
+    || workspace !== workspace.trim()
+    || !isBoundedString(query, MAX_QUERY_LENGTH)
+    || !scope
+    || (expectedWorkspace && workspace !== expectedWorkspace)
+  ) {
+    return null;
+  }
+
+  const suppliedTimestamp = entry.timestamp;
+  const timestamp = Number.isFinite(suppliedTimestamp) && suppliedTimestamp > 0
+    ? suppliedTimestamp
+    : now();
+
+  return Object.freeze({ workspace, query, scope, timestamp });
+}
+
+function isStoredEntry(value, expectedWorkspace) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.join(",") !== "query,scope,timestamp,workspace") {
+    return false;
+  }
+  if (
+    !isBoundedString(value.workspace, MAX_WORKSPACE_LENGTH)
+    || value.workspace !== value.workspace.trim()
+    || !isBoundedString(value.query, MAX_QUERY_LENGTH)
+    || (expectedWorkspace && value.workspace !== expectedWorkspace)
+    || !Number.isFinite(value.timestamp)
+    || value.timestamp <= 0
+  ) {
+    return false;
+  }
+
+  const scope = value.scope;
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) {
+    return false;
+  }
+  if (scope.kind === "workspace") {
+    return Object.keys(scope).length === 1;
+  }
+  if (scope.kind === "repository") {
+    return Object.keys(scope).sort().join(",") === "kind,repository"
+      && isBoundedString(scope.repository, MAX_WORKSPACE_LENGTH)
+      && scope.repository === scope.repository.trim();
+  }
+  if (scope.kind !== "repositories" || Object.keys(scope).sort().join(",") !== "kind,repositories") {
+    return false;
+  }
+  const normalized = normalizeRepositories(scope.repositories);
+  return Boolean(
+    normalized
+    && normalized.length === scope.repositories.length
+    && normalized.every((repository, index) => repository === scope.repositories[index])
+  );
+}
+
+function cloneEntry(entry) {
+  let scope;
+  if (entry.scope.kind === "repositories") {
+    scope = Object.freeze({
+      kind: "repositories",
+      repositories: Object.freeze([...entry.scope.repositories]),
+    });
+  } else if (entry.scope.kind === "repository") {
+    scope = Object.freeze({ kind: "repository", repository: entry.scope.repository });
+  } else {
+    scope = Object.freeze({ kind: "workspace" });
+  }
+  return Object.freeze({
+    workspace: entry.workspace,
+    query: entry.query,
+    scope,
+    timestamp: entry.timestamp,
+  });
+}
+
+function parseEnvelope(value, expectedWorkspace, max) {
+  if (
+    !value
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || Object.keys(value).sort().join(",") !== "items,version"
+    || value.version !== STORAGE_VERSION
+    || !Array.isArray(value.items)
+    || value.items.length > HARD_MAX
+    || !value.items.every(item => isStoredEntry(item, expectedWorkspace))
+  ) {
+    return null;
+  }
+
+  return value.items.slice(0, max).map(cloneEntry);
+}
+
+function entryKey(entry) {
+  const scopeIdentity = entry.scope.kind === "repositories"
+    ? entry.scope.repositories
+    : (entry.scope.kind === "repository" ? entry.scope.repository : null);
+  return JSON.stringify([
+    entry.workspace,
+    entry.query,
+    entry.scope.kind,
+    scopeIdentity,
+  ]);
+}
+
+class RecentSearches {
+  constructor(context, workspaceSlug, options = {}) {
+    this.context = context;
+    this.workspaceSlug = workspaceSlug || "";
+    this._now = options.now || Date.now;
+    this.storageKey = this.workspaceSlug
+      ? `${STORAGE_KEY_PREFIX}:${encodeURIComponent(this.workspaceSlug)}`
+      : STORAGE_KEY_PREFIX;
+  }
+
+  async add(entry) {
+    const normalized = normalizeEntry(entry, this.workspaceSlug, this._now);
+    if (!normalized) {
+      throw new TypeError("Recent search descriptor is invalid.");
+    }
+
+    return queueFor(this.context.globalState, this.storageKey, async () => {
+      const max = this._getMax();
+      if (max === 0) {
+        await this.context.globalState.update(this.storageKey, {
+          version: STORAGE_VERSION,
+          items: [],
+        });
+        return;
+      }
+
+      const stored = this.context.globalState.get(this.storageKey);
+      const searches = parseEnvelope(stored, this.workspaceSlug, max) || [];
+      const key = entryKey(normalized);
+      const items = [normalized, ...searches.filter(search => entryKey(search) !== key)]
+        .sort((left, right) => right.timestamp - left.timestamp)
+        .slice(0, max)
+        .map(cloneEntry);
+
+      await this.context.globalState.update(this.storageKey, {
+        version: STORAGE_VERSION,
+        items,
+      });
+    });
+  }
+
+  async getAll() {
+    return queueFor(this.context.globalState, this.storageKey, async () => {
+      const max = this._getMax();
+      if (max === 0) {
+        return [];
+      }
+
+      const stored = this.context.globalState.get(this.storageKey);
+      if (stored === undefined) {
+        return [];
+      }
+      const parsed = parseEnvelope(stored, this.workspaceSlug, max);
+      if (parsed) {
+        return parsed;
+      }
+
+      // Old and malformed shapes are never replayed with broader authority.
+      try {
+        await this.context.globalState.update(this.storageKey, undefined);
+      } catch {
+        // The invalid value is still ignored even when best-effort eviction fails.
+      }
+      return [];
+    });
+  }
+
+  async clear() {
+    return queueFor(this.context.globalState, this.storageKey, async () => {
+      await this.context.globalState.update(this.storageKey, {
+        version: STORAGE_VERSION,
+        items: [],
+      });
+    });
+  }
+
+  _getMax() {
+    const vscode = require("vscode");
+    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
+    const configured = config.get("recentSearches");
+    if (!Number.isInteger(configured)) {
+      return DEFAULT_MAX;
+    }
+    return Math.max(0, Math.min(HARD_MAX, configured));
+  }
+}
+
+module.exports = {
+  HARD_MAX,
+  RecentSearches,
+  STORAGE_KEY_PREFIX,
+  STORAGE_VERSION,
+};

--- a/util/ssoAuthManager.js
+++ b/util/ssoAuthManager.js
@@ -1,438 +1,416 @@
-// SSO authentication manager — pragmatic credential setup for SSO-enabled
-// Cloudsmith workspaces.
-//
-// Three approaches, in order of reliability:
-//
-// A. CLI config import (importFromCLI) — PRIMARY
-//    Reads an existing API key from the Cloudsmith CLI's config file
-//    (~/.cloudsmith/config.ini). This is the most reliable path for SSO users.
-//
-// B. Terminal-based SSO (loginViaTerminal)
-//    Opens a VS Code integrated terminal and runs `cloudsmith auth -o {workspace}`
-//    so the user can complete the interactive SAML + 2FA flow. After the terminal
-//    closes, offers to import the resulting credentials.
-//
-// C. Browser-based SAML redirect (loginViaBrowser) — EXPERIMENTAL
-//    Starts a local HTTP server on port 12400, opens the SAML endpoint in the
-//    browser, and waits for the redirect. Gated behind the
-//    cloudsmith-vsc.experimentalSSOBrowser setting. Uses a one-time callback path
-//    to reject unrelated localhost traffic and avoids logging callback payloads.
-
 const crypto = require("crypto");
-const vscode = require("vscode");
-const http = require("http");
-const url = require("url");
 const fs = require("fs");
-const path = require("path");
+const http = require("http");
 const os = require("os");
+const path = require("path");
+const url = require("url");
+const vscode = require("vscode");
 
-// The CLI always uses port 12400 for the SAML redirect.
 const SAML_CALLBACK_PORT = 12400;
 const CALLBACK_SUCCESS_PATH = "/authenticated";
-
-// Known query parameter names that might contain the auth token.
 const TOKEN_PARAM_NAMES = ["api_key", "token", "access_token", "key"];
 const WORKSPACE_SLUG_PATTERN = /^[A-Za-z0-9._-]+$/;
+const MAX_WORKSPACE_SLUG_LENGTH = 128;
+const MAX_CLI_CONFIG_BYTES = 64 * 1024;
+
+function configTooLargeError() {
+  const error = new Error("Cloudsmith CLI configuration exceeds the supported size.");
+  error.code = "CONFIG_TOO_LARGE";
+  return error;
+}
+
+async function readBoundedTextFile(filePath) {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(MAX_CLI_CONFIG_BYTES + 1);
+    let total = 0;
+    while (total < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+    }
+    if (total > MAX_CLI_CONFIG_BYTES) throw configTooLargeError();
+    return buffer.subarray(0, total).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function readBoundedTextFileSync(filePath) {
+  const descriptor = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(MAX_CLI_CONFIG_BYTES + 1);
+    let total = 0;
+    while (total < buffer.length) {
+      const bytesRead = fs.readSync(descriptor, buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+    }
+    if (total > MAX_CLI_CONFIG_BYTES) throw configTooLargeError();
+    return buffer.subarray(0, total).toString("utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function failedResult(kind, message) {
+  return Object.freeze({
+    ok: false,
+    status: "failed",
+    committed: false,
+    error: Object.freeze({ kind, message }),
+  });
+}
+
+function unavailableResult() {
+  return failedResult(
+    "unavailable",
+    "Authentication is not ready. Reload the extension and try again."
+  );
+}
 
 class SSOAuthManager {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
+    this._connectionManager = options.connectionManager || null;
+    this._readFile = options.readFile
+      ? async filePath => {
+        const content = await options.readFile(filePath, "utf8");
+        if (Buffer.byteLength(content, "utf8") > MAX_CLI_CONFIG_BYTES) throw configTooLargeError();
+        return content;
+      }
+      : readBoundedTextFile;
+    this._readFileSync = options.readFileSync
+      ? filePath => {
+        const content = options.readFileSync(filePath, "utf8");
+        if (Buffer.byteLength(content, "utf8") > MAX_CLI_CONFIG_BYTES) throw configTooLargeError();
+        return content;
+      }
+      : readBoundedTextFileSync;
+    this._accessSync = options.accessSync || fs.accessSync;
+    this._findConfigPath = options.findCLIConfigPath || null;
+    this._setTimeout = options.setTimeout || setTimeout;
+    this._clearTimeout = options.clearTimeout || clearTimeout;
+    this._createServer = options.createServer || http.createServer;
+    this._randomBytes = options.randomBytes || crypto.randomBytes;
+    this._openExternal = options.openExternal || vscode.env.openExternal;
   }
 
-  // --------------------------------------------------------------------------
-  // Approach A: Import credentials from Cloudsmith CLI config (primary)
-  // --------------------------------------------------------------------------
+  async importFromCLI(operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
+    const token = operation || manager.beginCredentialOperation();
+    if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
 
-  /**
-   * Import an API key from the Cloudsmith CLI's config file.
-   *
-   * The CLI stores credentials in an INI-style config file after
-   * `cloudsmith auth` or `cloudsmith auth -o {workspace}` completes.
-   *
-   * @returns {Promise<boolean>} True if import succeeded, false otherwise.
-   */
-  async importFromCLI() {
     const configPath = this._findCLIConfigPath();
-
     if (!configPath) {
+      await manager.cancelCredentialOperation(token);
       vscode.window.showErrorMessage(
         'Could not find Cloudsmith CLI configuration. Run "cloudsmith auth" in a terminal first.'
       );
-      return false;
+      return failedResult("config_missing", "Cloudsmith CLI configuration was not found.");
     }
 
     let content;
     try {
-      content = await fs.promises.readFile(configPath, "utf8");
-    } catch (e) {
-      console.debug("Could not read Cloudsmith CLI config:", configPath, e);
-      vscode.window.showErrorMessage(
-        "Could not read Cloudsmith CLI config. Check file permissions."
+      content = await this._readFile(configPath);
+    } catch (error) {
+      await manager.cancelCredentialOperation(token);
+      const tooLarge = error && error.code === "CONFIG_TOO_LARGE";
+      const publicMessage = tooLarge
+        ? "Cloudsmith CLI config is too large to import."
+        : "Could not read Cloudsmith CLI config. Check file permissions.";
+      vscode.window.showErrorMessage(publicMessage);
+      return failedResult(
+        tooLarge ? "config_too_large" : "config_read_failed",
+        publicMessage
       );
-      return false;
     }
+    if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
 
     const apiKey = this._parseAPIKeyFromConfig(content);
-
     if (!apiKey) {
+      await manager.cancelCredentialOperation(token);
       vscode.window.showErrorMessage(
-        "No API key found in Cloudsmith CLI config. " +
-        "Run 'cloudsmith auth -o {workspace}' to authenticate first."
+        "No API key found in Cloudsmith CLI config. Run 'cloudsmith auth -o {workspace}' first."
       );
-      return false;
+      return failedResult("credential_missing", "No API key was found in the CLI configuration.");
     }
 
-    await this.context.secrets.store("cloudsmith-vsc.authToken", apiKey);
-    vscode.window.showInformationMessage(
-      "Credentials imported from Cloudsmith CLI config. Connected."
-    );
-    return true;
+    return manager.replaceCredential(apiKey, token);
   }
 
-  /**
-   * Silently check whether CLI credentials exist (for auto-detect on activation).
-   * Returns true if a config file with an API key was found, false otherwise.
-   * Does NOT import or store anything — call importFromCLI() to do that.
-   */
   hasCLICredentials() {
     const configPath = this._findCLIConfigPath();
-    if (!configPath) {
-      return false;
-    }
+    if (!configPath) return false;
     try {
-      const content = fs.readFileSync(configPath, "utf8");
-      return !!this._parseAPIKeyFromConfig(content);
-    } catch (e) { // eslint-disable-line no-unused-vars
+      const content = this._readFileSync(configPath, "utf8");
+      return Boolean(this._parseAPIKeyFromConfig(content));
+    } catch {
       return false;
     }
   }
 
-  /**
-   * Locate the Cloudsmith CLI config file.
-   * Checks platform-specific paths and returns the first one that exists,
-   * or null if none are found.
-   */
   _findCLIConfigPath() {
+    if (this._findConfigPath) return this._findConfigPath();
     const home = os.homedir();
-    const candidates = [];
-
-    // The CLI's primary config location
-    candidates.push(path.join(home, ".cloudsmith", "config.ini"));
-
-    // XDG-style (Linux)
-    const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
-    candidates.push(path.join(xdgConfig, "cloudsmith", "config.ini"));
-
-    // macOS Application Support
+    const candidates = [
+      path.join(home, ".cloudsmith", "config.ini"),
+      path.join(process.env.XDG_CONFIG_HOME || path.join(home, ".config"), "cloudsmith", "config.ini"),
+    ];
     if (process.platform === "darwin") {
-      candidates.push(
-        path.join(home, "Library", "Application Support", "cloudsmith", "config.ini")
-      );
+      candidates.push(path.join(home, "Library", "Application Support", "cloudsmith", "config.ini"));
     }
-
-    // Windows AppData
     if (process.platform === "win32" && process.env.APPDATA) {
-      candidates.push(
-        path.join(process.env.APPDATA, "cloudsmith", "config.ini")
-      );
+      candidates.push(path.join(process.env.APPDATA, "cloudsmith", "config.ini"));
     }
-
     for (const candidate of candidates) {
       try {
-        fs.accessSync(candidate, fs.constants.R_OK);
+        this._accessSync(candidate, fs.constants.R_OK);
         return candidate;
-      } catch (e) { // eslint-disable-line no-unused-vars
-        // File doesn't exist or isn't readable, try next
+      } catch {
+        // Try the next platform-specific location.
       }
     }
     return null;
   }
 
-  /**
-   * Parse the API key from a Cloudsmith CLI INI-style config string.
-   *
-   * Expected format:
-   *   [default]
-   *   api_key = cs_xxxxxxxxxxxxxxxxxxxx
-   *
-   * @param   {string} content  Raw config file content.
-   * @returns {string|null}     The API key, or null if not found.
-   */
   _parseAPIKeyFromConfig(content) {
-    const lines = content.split("\n");
-    for (const line of lines) {
-      const trimmed = line.trim();
-      // Match: api_key = value  or  api_key=value
-      const match = trimmed.match(/^api_key\s*=\s*(.+)$/);
+    if (typeof content !== "string") return null;
+    if (Buffer.byteLength(content, "utf8") > MAX_CLI_CONFIG_BYTES) return null;
+    for (const line of content.split("\n")) {
+      const match = line.trim().match(/^api_key\s*=\s*(.+)$/);
       if (match) {
         const key = match[1].trim();
-        if (key) {
-          return key;
-        }
+        if (key) return key;
       }
     }
     return null;
   }
 
-  // --------------------------------------------------------------------------
-  // Approach B: Terminal-based SSO (opens integrated terminal)
-  // --------------------------------------------------------------------------
-
-  /**
-   * Open a VS Code integrated terminal and run `cloudsmith auth -o {workspace}`
-   * so the user can complete the interactive SAML + 2FA flow. After the terminal
-   * is visible, show an info message offering to import credentials once done.
-   *
-   * @param {string} workspaceSlug  The Cloudsmith workspace/org slug.
-   * @returns {Promise<boolean>} True if credentials were imported after the
-   *          terminal flow, false otherwise.
-   */
-  async loginViaTerminal(workspaceSlug) {
+  async loginViaTerminal(workspaceSlug, operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
+    const token = operation || manager.beginCredentialOperation();
     if (!this._isValidWorkspaceSlug(workspaceSlug)) {
+      await manager.cancelCredentialOperation(token);
       vscode.window.showErrorMessage("Enter a valid Cloudsmith workspace slug.");
-      return false;
+      return failedResult("invalid_workspace", "The Cloudsmith workspace slug is invalid.");
     }
 
-    // Create and show an integrated terminal
     const terminal = vscode.window.createTerminal("Cloudsmith SSO");
-    terminal.show();
-    terminal.sendText(`cloudsmith auth -o ${workspaceSlug}`);
-
-    // Listen for the terminal closing so we can auto-prompt import
-    const closePromise = new Promise((resolve) => {
-      let done = false;
-      const disposable = vscode.window.onDidCloseTerminal((closed) => {
-        if (!done && closed === terminal) {
+    let closeDisposable = null;
+    let timeout = null;
+    let abortListener = null;
+    try {
+      terminal.show();
+      terminal.sendText(`cloudsmith auth -o ${workspaceSlug}`);
+      await new Promise((resolve) => {
+        let done = false;
+        const finish = () => {
+          if (done) return;
           done = true;
-          disposable.dispose();
           resolve();
-        }
+        };
+        closeDisposable = vscode.window.onDidCloseTerminal((closed) => {
+          if (closed === terminal) finish();
+        });
+        timeout = this._setTimeout(finish, 10000);
+        abortListener = finish;
+        token.signal.addEventListener("abort", abortListener, { once: true });
+        if (token.signal.aborted) finish();
       });
 
-      // Also offer import after a delay in case the user doesn't close the terminal
-      setTimeout(() => {
-        if (!done) {
-          done = true;
-          disposable.dispose();
-          resolve();
-        }
-      }, 10000);
-    });
-
-    await closePromise;
-
-    // Offer to import credentials
-    const choice = await vscode.window.showInformationMessage(
-      "Import credentials from the Cloudsmith CLI config?",
-      "Import", "Not now"
-    );
-
-    if (choice === "Import") {
-      return this.importFromCLI();
+      if (!manager.isOperationCurrent(token)) {
+        return failedResult("stale", "Authentication was superseded.");
+      }
+      const choice = await vscode.window.showInformationMessage(
+        "Import credentials from the Cloudsmith CLI config?",
+        "Import",
+        "Not now"
+      );
+      if (!manager.isOperationCurrent(token)) {
+        return failedResult("stale", "Authentication was superseded.");
+      }
+      if (choice === "Import") return this.importFromCLI(token);
+      return manager.cancelCredentialOperation(token);
+    } catch {
+      if (manager.isOperationCurrent(token)) await manager.cancelCredentialOperation(token);
+      return failedResult(
+        "terminal_failed",
+        "Could not start Cloudsmith CLI authentication."
+      );
+    } finally {
+      if (timeout !== null) this._clearTimeout(timeout);
+      if (closeDisposable && typeof closeDisposable.dispose === "function") closeDisposable.dispose();
+      if (abortListener) token.signal.removeEventListener("abort", abortListener);
     }
-    return false;
   }
 
-  // --------------------------------------------------------------------------
-  // Approach C: Experimental browser-based SAML redirect
-  // --------------------------------------------------------------------------
-
-  /**
-   * Attempt SSO login via the SAML endpoint with a localhost:12400 redirect.
-   *
-   * EXPERIMENTAL — gated behind cloudsmith-vsc.experimentalSSOBrowser setting.
-   *
-   * The Cloudsmith CLI uses this exact flow on port 12400. The SAML endpoint
-   * may require prior authentication (JWT), which creates a chicken-and-egg
-   * problem for first-time setup. This flow uses a one-time callback path and
-   * stores the resulting token without logging callback contents.
-   *
-   * @param {string} workspaceSlug  The Cloudsmith workspace/org slug.
-   * @returns {Promise<boolean>} True if login succeeded, false otherwise.
-   */
-  async loginViaBrowser(workspaceSlug) {
+  async loginViaBrowser(workspaceSlug, operation = null) {
+    const manager = this._getConnectionManager();
+    if (!manager) return unavailableResult();
+    const token = operation || manager.beginCredentialOperation();
     if (!this._isValidWorkspaceSlug(workspaceSlug)) {
+      await manager.cancelCredentialOperation(token);
       vscode.window.showErrorMessage("Enter a valid Cloudsmith workspace slug.");
-      return false;
+      return failedResult("invalid_workspace", "The Cloudsmith workspace slug is invalid.");
     }
 
-    const callbackId = crypto.randomBytes(16).toString("hex");
+    const callbackId = this._randomBytes(16).toString("hex");
     const callbackPath = `/callback/${callbackId}`;
-
-    // Start a local HTTP server on the CLI's fixed port (12400)
-    let serverResult;
+    let server = null;
     try {
-      serverResult = await this._startCallbackServer(callbackPath);
-    } catch (err) {
-      vscode.window.showErrorMessage(
-        `Could not start the SSO callback server on port ${SAML_CALLBACK_PORT}. ` +
-        `Free the port and try again. (${err.message})`
-      );
-      return false;
-    }
+      const serverResult = await this._startCallbackServer(callbackPath);
+      server = serverResult.server;
+      if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
 
-    const { server } = serverResult;
-    const redirectUrl = `http://127.0.0.1:${SAML_CALLBACK_PORT}${callbackPath}`;
-    const authUrl =
-      `https://api.cloudsmith.io/orgs/${encodeURIComponent(workspaceSlug)}/saml/` +
-      `?redirect_url=${encodeURIComponent(redirectUrl)}`;
+      const redirectUrl = `http://127.0.0.1:${SAML_CALLBACK_PORT}${callbackPath}`;
+      const authUrl =
+        `https://api.cloudsmith.io/orgs/${encodeURIComponent(workspaceSlug)}/saml/` +
+        `?redirect_url=${encodeURIComponent(redirectUrl)}`;
+      const tokenPromise = this._waitForCallbackToken(server, token.signal);
+      await this._openExternal(vscode.Uri.parse(authUrl));
+      if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
+      vscode.window.showInformationMessage("Browser sign-in started. Waiting for authentication...");
 
-    // Create a promise that resolves when the callback arrives or times out
-    const tokenPromise = new Promise((resolve) => {
-      server._resolveToken = resolve;
+      const candidate = await tokenPromise;
+      if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
+      if (candidate) return manager.replaceCredential(candidate, token);
 
-      const timeout = setTimeout(() => {
-        resolve(null);
-      }, 5 * 60 * 1000);
-
-      server._timeout = timeout;
-    });
-
-    // Open the browser for SSO authentication
-    await vscode.env.openExternal(vscode.Uri.parse(authUrl));
-    vscode.window.showInformationMessage(
-      "Browser sign-in started. Waiting for authentication..."
-    );
-
-    // Wait for the callback
-    const token = await tokenPromise;
-
-    // Clean up
-    this._shutdownServer(server);
-
-    if (!token) {
-      // Offer CLI import as fallback
       const choice = await vscode.window.showWarningMessage(
         "Browser-based SSO did not complete. Select a fallback method.",
-        "Open Terminal", "Import from CLI", "Dismiss"
+        "Open Terminal",
+        "Import from CLI",
+        "Dismiss"
       );
-      if (choice === "Open Terminal") {
-        return this.loginViaTerminal(workspaceSlug);
-      }
-      if (choice === "Import from CLI") {
-        return this.importFromCLI();
-      }
-      return false;
+      if (!manager.isOperationCurrent(token)) return failedResult("stale", "Authentication was superseded.");
+      if (choice === "Open Terminal") return this.loginViaTerminal(workspaceSlug, token);
+      if (choice === "Import from CLI") return this.importFromCLI(token);
+      return manager.cancelCredentialOperation(token);
+    } catch {
+      if (manager.isOperationCurrent(token)) await manager.cancelCredentialOperation(token);
+      const message = "Browser authentication could not start or complete.";
+      vscode.window.showErrorMessage(
+        `Could not complete browser SSO on port ${SAML_CALLBACK_PORT}. ${message}`
+      );
+      return failedResult("browser_failed", message);
+    } finally {
+      if (server) this._shutdownServer(server);
     }
-
-    await this.context.secrets.store("cloudsmith-vsc.authToken", token);
-    vscode.window.showInformationMessage("SSO authentication complete. Credentials saved.");
-    return true;
   }
 
-  /**
-   * Start a local HTTP server on port 12400 (the CLI's fixed port).
-   * Rejects if the port is unavailable.
-   */
+  _waitForCallbackToken(server, signal) {
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (candidate) => {
+        if (settled) return;
+        settled = true;
+        if (server._timeout !== null) this._clearTimeout(server._timeout);
+        server._timeout = null;
+        signal.removeEventListener("abort", onAbort);
+        server._resolveToken = null;
+        resolve(candidate);
+      };
+      const onAbort = () => finish(null);
+      server._resolveToken = finish;
+      server._timeout = this._setTimeout(() => finish(null), 5 * 60 * 1000);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    });
+  }
+
   _startCallbackServer(expectedPath) {
     return new Promise((resolve, reject) => {
-      const server = http.createServer((req, res) => {
-        this._handleCallbackRequest(req, res, server);
-      });
+      const server = this._createServer((req, res) => this._handleCallbackRequest(req, res, server));
       server._expectedPath = expectedPath;
-
+      server._timeout = null;
+      const onError = (error) => {
+        const message = error.code === "EADDRINUSE"
+          ? `Port ${SAML_CALLBACK_PORT} is already in use`
+          : "Failed to start the callback server";
+        reject(new Error(message));
+      };
+      server.once("error", onError);
       server.listen(SAML_CALLBACK_PORT, "127.0.0.1", () => {
+        server.removeListener("error", onError);
+        server.on("error", () => {
+          if (server._resolveToken) server._resolveToken(null);
+          this._shutdownServer(server);
+        });
         resolve({ server, port: SAML_CALLBACK_PORT });
-      });
-
-      server.on("error", (err) => {
-        if (err.code === "EADDRINUSE") {
-          reject(new Error(`Port ${SAML_CALLBACK_PORT} is already in use`));
-        } else {
-          reject(new Error(`Failed to start callback server: ${err.message}`));
-        }
       });
     });
   }
 
-  /**
-   * Handle an incoming HTTP request on the callback server.
-   * Accept only the one-time callback path and avoid logging token-bearing data.
-   */
   _handleCallbackRequest(req, res, server) {
     const parsed = url.parse(req.url, true);
     const params = parsed.query || {};
     const pathName = parsed.pathname || "/";
-
     if (req.method !== "GET") {
       res.writeHead(405, { "Content-Type": "text/plain" });
       res.end("Method Not Allowed");
       return;
     }
-
-    if (pathName === CALLBACK_SUCCESS_PATH) {
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(this._buildCallbackHtml(true));
-      return;
-    }
-
     if (pathName !== server._expectedPath) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
       return;
     }
 
-    // Look for the token in known parameter names
     let token = null;
     for (const name of TOKEN_PARAM_NAMES) {
-      if (params[name]) {
+      if (typeof params[name] === "string" && params[name]) {
         token = params[name];
         break;
       }
     }
-
-    // Resolve the token promise
-    if (server._resolveToken) {
-      server._resolveToken(token);
-      server._resolveToken = null;
-    }
-
+    if (server._resolveToken) server._resolveToken(token);
     if (token) {
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
       res.end(this._buildCallbackHtml(true, CALLBACK_SUCCESS_PATH));
       return;
     }
-
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(this._buildCallbackHtml(false));
   }
 
-  /**
-   * Shut down the callback server and clear the timeout.
-   */
   _shutdownServer(server) {
-    if (server._timeout) {
-      clearTimeout(server._timeout);
+    if (server._timeout !== null) {
+      this._clearTimeout(server._timeout);
       server._timeout = null;
     }
+    server._resolveToken = null;
     try {
       server.close();
-    } catch (e) { // eslint-disable-line no-unused-vars
-      // Server may already be closed
+    } catch {
+      // The server may already be closed.
     }
   }
 
   _isValidWorkspaceSlug(workspaceSlug) {
-    return typeof workspaceSlug === "string" &&
-      workspaceSlug.length > 0 &&
-      WORKSPACE_SLUG_PATTERN.test(workspaceSlug);
+    return typeof workspaceSlug === "string"
+      && workspaceSlug.length > 0
+      && workspaceSlug.length <= MAX_WORKSPACE_SLUG_LENGTH
+      && WORKSPACE_SLUG_PATTERN.test(workspaceSlug);
   }
 
   _buildCallbackHtml(success, replacePath) {
-    const heading = success ? "\u2705 Authentication complete" : "\u274C Authentication incomplete";
+    const heading = success ? "\u2705 Credentials received" : "\u274C Credentials not received";
     const message = success
-      ? "Close this tab and return to VS Code."
-      : "No credentials were found in the redirect. Try the terminal-based SSO flow or import from the CLI.";
-
+      ? "Return to VS Code while the credentials are validated and saved."
+      : "No credentials were found in the redirect. Try the terminal flow or CLI import.";
     const script = replacePath
       ? `<script>if (window.history && window.history.replaceState) { window.history.replaceState(null, "", "${replacePath}"); }</script>`
       : "";
-
     return "<html><body style=\"font-family:sans-serif;text-align:center;padding:40px\">" +
-      `<h2>${heading}</h2>` +
-      `<p>${message}</p>` +
-      script +
-      "</body></html>";
+      `<h2>${heading}</h2><p>${message}</p>${script}</body></html>`;
+  }
+
+  _getConnectionManager() {
+    if (this._connectionManager) return this._connectionManager;
+    const { getConnectionManager } = require("./connectionManager");
+    return getConnectionManager(this.context);
   }
 }
 

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -3,106 +3,320 @@ const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
 const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("./accountOperation");
+const {
   getSupportedUpstreamFormats,
   SUPPORTED_UPSTREAM_FORMATS,
 } = require("./upstreamFormats");
+
+const UPSTREAM_CACHE_SCHEMA_VERSION = 3;
 const UPSTREAM_CACHE_TTL_MS = 10 * 60 * 1000;
 const UPSTREAM_FETCH_BATCH_SIZE = 5;
-const REPOSITORY_UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v2";
+const UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v3";
+const MAX_PERSISTED_UPSTREAMS = 5000;
+const MAX_PERSISTED_UPSTREAMS_PER_FORMAT = 500;
+const MAX_PERSISTED_STRING_LENGTH = 2048;
+const MAX_PERSISTED_NAME_LENGTH = 500;
+const MAX_PERSISTED_DISTRO_VERSIONS = 100;
+const MAX_RUNTIME_UPSTREAMS = 5000;
+const MAX_RUNTIME_UPSTREAMS_PER_FORMAT = 500;
+const MAX_RUNTIME_URL_LENGTH = 8192;
 const BENIGN_UPSTREAM_FORMAT_STATUS_CODES = new Set([400, 404, 405, 422]);
+const PERSISTED_UPSTREAM_KEYS = Object.freeze([
+  "name",
+  "is_active",
+  "_format",
+  "format",
+  "mode",
+  "created_at",
+  "trust_level",
+  "verify_ssl",
+  "index_status",
+  "index_package_count",
+  "priority",
+  "distribution",
+  "distro_versions",
+  "upstream_distribution",
+]);
+const persistedUpstreamKeySet = new Set(PERSISTED_UPSTREAM_KEYS);
+const persistedStringFieldLimits = new Map([
+  ["name", MAX_PERSISTED_NAME_LENGTH],
+  ["_format", MAX_PERSISTED_NAME_LENGTH],
+  ["format", MAX_PERSISTED_NAME_LENGTH],
+  ["mode", MAX_PERSISTED_NAME_LENGTH],
+  ["created_at", MAX_PERSISTED_NAME_LENGTH],
+  ["trust_level", MAX_PERSISTED_NAME_LENGTH],
+  ["index_status", MAX_PERSISTED_NAME_LENGTH],
+  ["distribution", MAX_PERSISTED_STRING_LENGTH],
+  ["upstream_distribution", MAX_PERSISTED_STRING_LENGTH],
+]);
+const cacheOperations = new WeakMap();
+const cacheWriteQueues = new WeakMap();
 
-function isCacheObjectRecord(value) {
+function isObjectRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, expectedKeys) {
+  if (!isObjectRecord(value)) return false;
+  const keys = Object.keys(value).sort();
+  return keys.length === expectedKeys.length
+    && keys.every((key, index) => key === expectedKeys[index]);
 }
 
 function getUpstreamCacheKey(workspace, repo, formats = SUPPORTED_UPSTREAM_FORMATS) {
   const normalizedFormats = getSupportedUpstreamFormats(formats);
-  const isAllFormats =
-    normalizedFormats.length === SUPPORTED_UPSTREAM_FORMATS.length &&
-    normalizedFormats.every((format, index) => format === SUPPORTED_UPSTREAM_FORMATS[index]);
-
-  if (isAllFormats) {
-    return `cloudsmith-upstreams:all:${workspace}:${repo}`;
-  }
-
-  return `cloudsmith-upstreams:formats:${workspace}:${repo}:${normalizedFormats.join(",")}`;
+  const isAllFormats = normalizedFormats.length === SUPPORTED_UPSTREAM_FORMATS.length
+    && normalizedFormats.every((format, index) => format === SUPPORTED_UPSTREAM_FORMATS[index]);
+  const tuple = isAllFormats
+    ? ["all", workspace, repo]
+    : ["formats", workspace, repo, normalizedFormats];
+  return `${UPSTREAM_CACHE_KEY_PREFIX}:${encodeURIComponent(JSON.stringify(tuple))}`;
 }
 
-function logUpstreamCacheError(action, workspace, repo, error) {
-  const message = error && error.message ? error.message : String(error);
-  console.warn(
-    `[UpstreamChecker] Failed to ${action} upstream cache for ${workspace}/${repo}: ${message}`
-  );
+function getCacheMap(registry, globalState) {
+  let cacheMap = registry.get(globalState);
+  if (!cacheMap) {
+    cacheMap = new Map();
+    registry.set(globalState, cacheMap);
+  }
+  return cacheMap;
 }
 
-function evictInvalidUpstreamCacheEntry(globalState, cacheKey, workspace, repo) {
-  if (!globalState || typeof globalState.update !== "function") {
-    return;
-  }
+function beginCacheOperation(globalState, cacheKey) {
+  if (!globalState || !isObjectRecord(globalState)) return null;
+  const operations = getCacheMap(cacheOperations, globalState);
+  const operationToken = Symbol(cacheKey);
+  operations.set(cacheKey, operationToken);
+  return operationToken;
+}
 
-  try {
-    const updateResult = globalState.update(cacheKey, undefined);
-    if (updateResult && typeof updateResult.catch === "function") {
-      updateResult.catch((error) => {
-        logUpstreamCacheError("evict invalid entry from", workspace, repo, error);
-      });
+function isCacheOperationCurrent(globalState, cacheKey, operationToken) {
+  return Boolean(operationToken)
+    && getCacheMap(cacheOperations, globalState).get(cacheKey) === operationToken;
+}
+
+function finishCacheOperation(globalState, cacheKey, operationToken) {
+  if (!globalState || !operationToken) return;
+  const operations = cacheOperations.get(globalState);
+  if (!operations || operations.get(cacheKey) !== operationToken) return;
+  operations.delete(cacheKey);
+  if (operations.size === 0) cacheOperations.delete(globalState);
+}
+
+function getActiveUpstreamCacheOperationCount(globalState) {
+  return cacheOperations.get(globalState)?.size || 0;
+}
+
+function queueCacheWrite(globalState, cacheKey, write) {
+  const queues = getCacheMap(cacheWriteQueues, globalState);
+  const previous = queues.get(cacheKey) || Promise.resolve();
+  const pending = previous.then(write, write);
+  const settled = pending.then(() => undefined, () => undefined);
+  queues.set(cacheKey, settled);
+  settled.finally(() => {
+    if (queues.get(cacheKey) === settled) queues.delete(cacheKey);
+  });
+  return pending;
+}
+
+function cacheErrorMessage(action) {
+  const safeAction = action === "persist" || action === "evict invalid entry from"
+    ? action
+    : "update";
+  return `[UpstreamChecker] Failed to ${safeAction} upstream cache.`;
+}
+
+function logCacheError(action) {
+  console.warn(cacheErrorMessage(action));
+}
+
+function evictCacheEntry(globalState, cacheKey, workspace, repo) {
+  if (!globalState || typeof globalState.update !== "function") return;
+  queueCacheWrite(globalState, cacheKey, async () => {
+    try {
+      await globalState.update(cacheKey, undefined);
+    } catch (error) {
+      logCacheError("evict invalid entry from", workspace, repo, error);
     }
-  } catch (error) {
-    logUpstreamCacheError("evict invalid entry from", workspace, repo, error);
-  }
+  });
 }
 
-function getCachedUpstreamResponse(globalState, cacheKey, workspace, repo) {
-  if (!globalState || typeof globalState.get !== "function") {
-    return null;
-  }
+function boundedString(value, maxLength = MAX_PERSISTED_STRING_LENGTH) {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength
+    ? value
+    : null;
+}
 
+function normalizePersistedField(key, value) {
+  if (persistedStringFieldLimits.has(key)) {
+    return boundedString(value, persistedStringFieldLimits.get(key));
+  }
+  if (["is_active", "verify_ssl"].includes(key)) {
+    return typeof value === "boolean" ? value : null;
+  }
+  if (["index_package_count", "priority"].includes(key)) {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (key === "distro_versions") {
+    if (
+      !Array.isArray(value)
+      || value.length > MAX_PERSISTED_DISTRO_VERSIONS
+      || !value.every(item => boundedString(item, MAX_PERSISTED_NAME_LENGTH))
+    ) return null;
+    return value.slice();
+  }
+  return null;
+}
+
+function serializeUpstream(upstream) {
+  const serialized = {};
+  for (const key of PERSISTED_UPSTREAM_KEYS) {
+    if (upstream[key] === undefined) continue;
+    const normalized = normalizePersistedField(key, upstream[key]);
+    if (normalized !== null) serialized[key] = normalized;
+  }
+  return serialized.name ? serialized : null;
+}
+
+function serializeUpstreamArray(upstreams, max = MAX_PERSISTED_UPSTREAMS) {
+  if (!Array.isArray(upstreams) || upstreams.length > max) return null;
+  const serialized = upstreams.map(serializeUpstream);
+  return serialized.every(Boolean) ? serialized : null;
+}
+
+function canonicalizeRuntimeUpstream(value) {
+  if (!isObjectRecord(value)) return null;
+  const name = boundedString(value.name, MAX_PERSISTED_NAME_LENGTH);
+  if (!name) return null;
+  const canonical = { name };
+  for (const key of PERSISTED_UPSTREAM_KEYS) {
+    if (key === "name" || value[key] === undefined) continue;
+    const normalized = normalizePersistedField(key, value[key]);
+    if (normalized !== null) canonical[key] = normalized;
+  }
+  if (typeof value.upstream_url === "string" && value.upstream_url.length <= MAX_RUNTIME_URL_LENGTH) {
+    canonical.upstream_url = value.upstream_url;
+  }
+  for (const key of [
+    "auth_mode", "auth_username", "extra_header_1", "extra_value_1",
+    "extra_header_2", "extra_value_2",
+  ]) {
+    const normalized = boundedString(value[key], MAX_PERSISTED_STRING_LENGTH);
+    if (normalized !== null) canonical[key] = normalized;
+  }
+  if (
+    typeof value.priority === "string"
+    && boundedString(value.priority, MAX_PERSISTED_NAME_LENGTH)
+  ) {
+    canonical.priority = value.priority;
+  }
+  return canonical;
+}
+
+function isPersistedUpstream(value) {
+  return isUpstreamRecord(value)
+    && Object.keys(value).every(key => persistedUpstreamKeySet.has(key))
+    && Object.entries(value).every(([key, fieldValue]) => {
+      const normalized = normalizePersistedField(key, fieldValue);
+      if (normalized === null) return false;
+      return Array.isArray(normalized)
+        ? JSON.stringify(normalized) === JSON.stringify(fieldValue)
+        : normalized === fieldValue;
+    });
+}
+
+function isAccountEnvelope(value, account, expectedKeys) {
+  return hasExactKeys(value, expectedKeys)
+    && value.version === UPSTREAM_CACHE_SCHEMA_VERSION
+    && value.activationId === account.activationId
+    && value.accountEpoch === account.accountEpoch
+    && Number.isFinite(value.timestamp);
+}
+
+function isFresh(timestamp, now) {
+  return timestamp <= now && now - timestamp < UPSTREAM_CACHE_TTL_MS;
+}
+
+function getCachedFlatResponse(globalState, cacheKey, workspace, repo, account, now) {
+  if (!globalState || typeof globalState.get !== "function") return null;
   const cached = globalState.get(cacheKey);
-  if (cached === undefined) {
-    return null;
-  }
-
-  const isValidCacheEntry = isCacheObjectRecord(cached)
-    && Number.isFinite(cached.timestamp)
+  if (cached === undefined) return null;
+  const valid = isAccountEnvelope(cached, account, [
+    "accountEpoch", "activationId", "active", "failedFormats", "successfulFormats",
+    "timestamp", "total", "upstreams", "version",
+  ])
+    && isFresh(cached.timestamp, now)
     && Array.isArray(cached.upstreams)
-    && cached.upstreams.every(isUpstreamRecord)
-    && Number.isFinite(cached.active)
-    && Number.isFinite(cached.total)
-    && Array.isArray(cached.failedFormats)
-    && cached.failedFormats.length === 0
-    && Number.isFinite(cached.successfulFormats);
-
-  if (!isValidCacheEntry) {
-    evictInvalidUpstreamCacheEntry(globalState, cacheKey, workspace, repo);
+    && cached.upstreams.length <= MAX_PERSISTED_UPSTREAMS
+    && cached.upstreams.every(isPersistedUpstream)
+    && Number.isInteger(cached.active) && cached.active >= 0
+    && Number.isInteger(cached.total) && cached.total === cached.upstreams.length
+    && cached.active <= cached.total
+    && Array.isArray(cached.failedFormats) && cached.failedFormats.length === 0
+    && Number.isInteger(cached.successfulFormats)
+    && cached.successfulFormats >= 0
+    && cached.successfulFormats <= SUPPORTED_UPSTREAM_FORMATS.length;
+  if (!valid) {
+    evictCacheEntry(globalState, cacheKey, workspace, repo);
     return null;
   }
-
-  if ((Date.now() - cached.timestamp) >= UPSTREAM_CACHE_TTL_MS) {
-    return null;
-  }
-
   return {
-    upstreams: cached.upstreams,
+    upstreams: cached.upstreams.map(upstream => ({ ...upstream })),
     active: cached.active,
     total: cached.total,
-    failedFormats: cached.failedFormats,
+    failedFormats: [],
     successfulFormats: cached.successfulFormats,
   };
 }
 
-async function persistUpstreamResponse(globalState, cacheKey, workspace, repo, response) {
-  if (!globalState || typeof globalState.update !== "function") {
-    return;
-  }
-
-  try {
-    await globalState.update(cacheKey, {
-      timestamp: Date.now(),
-      ...response,
-    });
-  } catch (error) {
-    logUpstreamCacheError("persist", workspace, repo, error);
-  }
+async function persistFlatResponse(
+  globalState,
+  cacheKey,
+  workspace,
+  repo,
+  response,
+  account,
+  connectionManager,
+  operationId,
+  now
+) {
+  if (!globalState || typeof globalState.update !== "function") return;
+  const serializedUpstreams = serializeUpstreamArray(response.upstreams);
+  if (
+    !serializedUpstreams
+    || !Number.isSafeInteger(response.active)
+    || response.active < 0
+    || response.active > serializedUpstreams.length
+    || response.total !== serializedUpstreams.length
+    || !Number.isSafeInteger(response.successfulFormats)
+    || response.successfulFormats < 0
+    || response.successfulFormats > SUPPORTED_UPSTREAM_FORMATS.length
+  ) return;
+  await queueCacheWrite(globalState, cacheKey, async () => {
+    if (
+      !isAccountCurrent(connectionManager, account)
+      || !isCacheOperationCurrent(globalState, cacheKey, operationId)
+    ) return;
+    try {
+      await globalState.update(cacheKey, {
+        version: UPSTREAM_CACHE_SCHEMA_VERSION,
+        activationId: account.activationId,
+        accountEpoch: account.accountEpoch,
+        timestamp: now(),
+        upstreams: serializedUpstreams,
+        active: response.active,
+        total: response.total,
+        failedFormats: [],
+        successfulFormats: response.successfulFormats,
+      });
+    } catch (error) {
+      logCacheError("persist", workspace, repo, error);
+    }
+  });
 }
 
 function isBenignUpstreamFormatError(error) {
@@ -117,17 +331,17 @@ function isAbortError(error) {
   return error && (error.name === "AbortError" || error.code === "ABORT_ERR");
 }
 
+function isCancelled(options = {}) {
+  return Boolean(options.signal?.aborted || options.cancellationToken?.isCancellationRequested);
+}
+
 function getActiveUpstreamsFromRepositoryState(state, format) {
-  if (!state || !(state.groupedUpstreams instanceof Map)) {
-    return [];
-  }
-
-  const upstreams = state.groupedUpstreams.get(format);
-  if (!Array.isArray(upstreams)) {
-    return [];
-  }
-
-  return upstreams.filter((upstream) => upstream && upstream.is_active !== false);
+  const upstreams = state && state.groupedUpstreams instanceof Map
+    ? state.groupedUpstreams.get(format)
+    : null;
+  return Array.isArray(upstreams)
+    ? upstreams.filter(upstream => upstream && upstream.is_active !== false)
+    : [];
 }
 
 function sortUpstreams(left, right) {
@@ -136,90 +350,76 @@ function sortUpstreams(left, right) {
   if (leftName !== rightName) {
     return leftName.localeCompare(rightName, undefined, { sensitivity: "base" });
   }
-
-  const leftFormat = typeof left._format === "string"
-    ? left._format
-    : (typeof left.format === "string" ? left.format : "");
-  const rightFormat = typeof right._format === "string"
-    ? right._format
-    : (typeof right.format === "string" ? right.format : "");
-
+  const leftFormat = typeof left._format === "string" ? left._format : (left.format || "");
+  const rightFormat = typeof right._format === "string" ? right._format : (right.format || "");
   return leftFormat.localeCompare(rightFormat, undefined, { sensitivity: "base" });
 }
 
 async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) {
-  const { signal, cancellationToken } = options;
   try {
-    if (signal && signal.aborted) {
-      return { format, status: "aborted", upstreams: [] };
-    }
-
-    const result = await api.get(
-      apiEndpoint(["repos", workspace, repo, "upstream", format]),
-      {
-        responseType: "array",
-        validate: isUpstreamArray,
-        retry: "never",
-        signal,
-        cancellationToken,
-      }
-    );
-
-    if (signal && signal.aborted) {
-      return { format, status: "aborted", upstreams: [] };
-    }
-
+    if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
+    const result = await api.get(apiEndpoint(["repos", workspace, repo, "upstream", format]), {
+      responseType: "array",
+      validate: isUpstreamArray,
+      retry: "never",
+      signal: options.signal,
+      cancellationToken: options.cancellationToken,
+    });
+    if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
     if (!result.ok) {
-      if (result.error.kind === "cancelled") {
-        return { format, status: "aborted", upstreams: [] };
-      }
-      if (isWarningWorthyUpstreamFormatError(result.error)) {
-        return { format, status: "failed", error: result.error, upstreams: [] };
-      }
-
-      return { format, status: "loaded", upstreams: [] };
+      if (result.error.kind === "cancelled") return { format, status: "aborted", upstreams: [] };
+      return isWarningWorthyUpstreamFormatError(result.error)
+        ? { format, status: "failed", error: result.error, upstreams: [] }
+        : { format, status: "loaded", upstreams: [] };
     }
-
+    if (!isUpstreamArray(result.data)) {
+      return {
+        format,
+        status: "failed",
+        error: invalidUpstreamResponseError(),
+        upstreams: [],
+      };
+    }
     return {
       format,
       status: "loaded",
-      upstreams: result.data.map((upstream) => ({
-        ...upstream,
+      upstreams: result.data.map(upstream => ({
+        ...canonicalizeRuntimeUpstream(upstream),
         _format: format,
         format,
       })),
     };
   } catch (error) {
-    if (isAbortError(error) || (signal && signal.aborted)) {
-      return { format, status: "aborted", upstreams: [] };
-    }
-
-    return { format, status: "failed", error, upstreams: [] };
+    return isAbortError(error) || isCancelled(options)
+      ? { format, status: "aborted", upstreams: [] }
+      : { format, status: "failed", error, upstreams: [] };
   }
 }
 
 class UpstreamChecker {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
-    this.api = new CloudsmithAPI(context);
+    this.connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this.api = options.cloudsmithAPI || new CloudsmithAPI(context);
+    this.now = options.now || Date.now;
   }
 
-  /**
-   * Check if a package exists locally in a repository.
-   *
-   * @param   {string} workspace  Workspace slug.
-   * @param   {string} repo       Repository slug.
-   * @param   {string} name       Package name.
-   * @param   {string} format     Package format (e.g., 'python', 'npm').
-   * @returns {Object|null}       Package object if found, null otherwise.
-   */
-  async existsLocally(workspace, repo, name, format) {
-    const qb = new SearchQueryBuilder();
+  _captureAccount(options = {}) {
+    const account = options.account || captureAccount(this.connectionManager);
+    return isAccountCurrent(this.connectionManager, account) ? account : null;
+  }
+
+  _emptyRepositoryState() {
+    return this._buildRepositoryUpstreamState(new Map(), [], 0);
+  }
+
+  async existsLocally(workspace, repo, name, format, options = {}) {
+    const account = this._captureAccount(options);
+    if (!account) return { data: null, error: null, stale: true };
     let endpoint;
     try {
-      endpoint = apiEndpoint(["packages", workspace, repo], {
-        query: { query: qb.name(name).format(format).build(), page_size: 1 },
-      });
+      const query = new SearchQueryBuilder().name(name).format(format).build();
+      endpoint = apiEndpoint(["packages", workspace, repo], { query: { query, page_size: 1 } });
     } catch (error) {
       return { data: null, error };
     }
@@ -228,24 +428,16 @@ class UpstreamChecker {
       validate: isPackageArray,
       retry: "safe-read",
     });
-    if (!result.ok) {
-      return { data: null, error: result.error };
+    if (!isAccountCurrent(this.connectionManager, account)) {
+      return { data: null, error: null, stale: true };
     }
-    if (result.data.length === 0) {
-      return { data: null, error: null };
-    }
-    return { data: result.data[0], error: null };
+    if (!result.ok) return { data: null, error: result.error };
+    return { data: result.data[0] || null, error: null };
   }
 
-  /**
-   * Get active upstream configurations for a specific format in a repository.
-   *
-   * @param   {string} workspace  Workspace slug.
-   * @param   {string} repo       Repository slug.
-   * @param   {string} format     Package format slug.
-   * @returns {Array}             Array of upstream config objects.
-   */
-  async getUpstreamsForFormat(workspace, repo, format) {
+  async getUpstreamsForFormat(workspace, repo, format, options = {}) {
+    const account = this._captureAccount(options);
+    if (!account) return { data: [], error: null, stale: true };
     let endpoint;
     try {
       endpoint = apiEndpoint(["repos", workspace, repo, "upstream", format]);
@@ -257,173 +449,130 @@ class UpstreamChecker {
       validate: isUpstreamArray,
       retry: "safe-read",
     });
+    if (!isAccountCurrent(this.connectionManager, account)) {
+      return { data: [], error: null, stale: true };
+    }
     if (!result.ok) {
       return isBenignUpstreamFormatError(result.error)
         ? { data: [], error: null }
         : { data: [], error: result.error };
     }
-    return { data: result.data, error: null };
+    if (!isUpstreamArray(result.data)) {
+      return { data: [], error: invalidUpstreamResponseError() };
+    }
+    return { data: result.data.map(canonicalizeRuntimeUpstream), error: null };
   }
 
   async getUpstreamDataForFormats(workspace, repo, formats, options = {}) {
-    const { signal, cancellationToken } = options;
+    const account = this._captureAccount(options);
+    if (!account || isCancelled(options)) return null;
     const requestedFormats = getSupportedUpstreamFormats(formats);
-
-    if (signal && signal.aborted) {
-      return null;
-    }
-
     if (requestedFormats.length === 0) {
-      return {
-        upstreams: [],
-        active: 0,
-        total: 0,
-        failedFormats: [],
-        successfulFormats: 0,
-      };
+      return { upstreams: [], active: 0, total: 0, failedFormats: [], successfulFormats: 0 };
     }
-
     const cacheKey = getUpstreamCacheKey(workspace, repo, requestedFormats);
-    const globalState = this.context && this.context.globalState
-      ? this.context.globalState
-      : null;
-    const cached = getCachedUpstreamResponse(globalState, cacheKey, workspace, repo);
-
-    if (cached) {
-      return cached;
-    }
-
-    if (signal && signal.aborted) {
-      return null;
-    }
-
-    const upstreams = [];
-    const failedFormats = [];
-    let successfulFormats = 0;
-
-    for (let index = 0; index < requestedFormats.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
-      if (signal && signal.aborted) {
-        return null;
-      }
-
-      const batch = requestedFormats.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
-      const batchResults = await Promise.all(
-        batch.map((format) => fetchFormatUpstreams(this.api, workspace, repo, format, {
-          signal,
-          cancellationToken,
-        }))
+    const globalState = this.context && this.context.globalState;
+    const operationToken = globalState ? beginCacheOperation(globalState, cacheKey) : null;
+    try {
+      const cached = getCachedFlatResponse(
+        globalState,
+        cacheKey,
+        workspace,
+        repo,
+        account,
+        this.now()
       );
+      if (cached && isAccountCurrent(this.connectionManager, account)) return cached;
 
-      if (signal && signal.aborted) {
-        return null;
+      const upstreams = [];
+      const failedFormats = [];
+      let successfulFormats = 0;
+      for (let index = 0; index < requestedFormats.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
+        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) return null;
+        const batch = requestedFormats.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
+        const results = await Promise.all(batch.map(format => (
+          fetchFormatUpstreams(this.api, workspace, repo, format, options)
+        )));
+        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) return null;
+        for (const result of results) {
+          if (result.status === "aborted") return null;
+          if (result.status === "failed") failedFormats.push(result.format);
+          if (result.status === "loaded") {
+            if (upstreams.length + result.upstreams.length > MAX_RUNTIME_UPSTREAMS) {
+              failedFormats.push(result.format);
+              continue;
+            }
+            successfulFormats += 1;
+            upstreams.push(...result.upstreams);
+          }
+        }
       }
-
-      for (const result of batchResults) {
-        if (result.status === "aborted") {
-          return null;
-        }
-
-        if (result.status === "failed") {
-          failedFormats.push(result.format);
-          continue;
-        }
-
-        if (result.status !== "loaded") {
-          continue;
-        }
-
-        successfulFormats += 1;
-        upstreams.push(...result.upstreams);
+      upstreams.sort(sortUpstreams);
+      const response = {
+        upstreams,
+        active: upstreams.filter(upstream => upstream.is_active !== false).length,
+        total: upstreams.length,
+        failedFormats,
+        successfulFormats,
+      };
+      if (!isAccountCurrent(this.connectionManager, account)) return null;
+      if (!isCancelled(options) && failedFormats.length === 0 && globalState) {
+        await persistFlatResponse(
+          globalState,
+          cacheKey,
+          workspace,
+          repo,
+          response,
+          account,
+          this.connectionManager,
+          operationToken,
+          this.now
+        );
       }
+      return isAccountCurrent(this.connectionManager, account) ? response : null;
+    } finally {
+      finishCacheOperation(globalState, cacheKey, operationToken);
     }
-
-    upstreams.sort(sortUpstreams);
-    const active = upstreams.filter((upstream) => upstream.is_active !== false).length;
-    const response = {
-      upstreams,
-      active,
-      total: upstreams.length,
-      failedFormats,
-      successfulFormats,
-    };
-
-    if (
-      !signal?.aborted &&
-      failedFormats.length === 0 &&
-      globalState
-    ) {
-      await persistUpstreamResponse(globalState, cacheKey, workspace, repo, response);
-    }
-
-    return response;
   }
 
-  async getAllUpstreamData(workspace, repo, options = {}) {
+  getAllUpstreamData(workspace, repo, options = {}) {
     return this.getUpstreamDataForFormats(workspace, repo, SUPPORTED_UPSTREAM_FORMATS, options);
   }
 
   async getAllUpstreams(workspace, repo, options = {}) {
     const result = await this.getAllUpstreamData(workspace, repo, options);
-    if (result === null) {
-      return { data: [], error: null, aborted: true };
-    }
-
+    if (result === null) return { data: [], error: null, aborted: true };
     if (result.failedFormats.length > 0 && result.upstreams.length === 0) {
-      return {
-        data: result.upstreams,
-        error: `Could not load upstream data for: ${result.failedFormats.join(", ")}`,
-      };
+      return { data: [], error: `Could not load upstream data for: ${result.failedFormats.join(", ")}` };
     }
-
     return { data: result.upstreams, error: null };
   }
 
-  /**
-   * Load all upstream configurations for a repository across every supported format.
-   * Results are cached in globalState for 10 minutes when the fetch completes without failures.
-   *
-   * @param   {string} workspace Workspace slug.
-   * @param   {string} repo      Repository slug.
-   * @param   {Object} options   Optional request settings.
-   * @returns {Object}           Aggregated upstream state.
-   */
   async getRepositoryUpstreamState(workspace, repo, options = {}) {
-    const cachedState = this._getCachedRepositoryUpstreamState(workspace, repo);
-    if (cachedState) {
-      return cachedState;
+    const account = this._captureAccount(options);
+    if (!account || isCancelled(options)) return this._emptyRepositoryState();
+    const globalState = this.context && this.context.globalState;
+    const cacheKey = this._getRepositoryUpstreamCacheKey(workspace, repo);
+    const operationToken = globalState ? beginCacheOperation(globalState, cacheKey) : null;
+    try {
+      const cached = this._getCachedRepositoryUpstreamState(workspace, repo, account);
+      if (cached && isAccountCurrent(this.connectionManager, account)) return cached;
+      const fetched = await this._fetchRepositoryUpstreamState(workspace, repo, {
+        ...options,
+        account,
+      });
+      if (!isAccountCurrent(this.connectionManager, account)) return this._emptyRepositoryState();
+      if (!isCancelled(options) && fetched.failedFormats.length === 0) {
+        await this._cacheRepositoryUpstreamState(workspace, repo, fetched, account, operationToken);
+      }
+      return isAccountCurrent(this.connectionManager, account) ? fetched : this._emptyRepositoryState();
+    } finally {
+      finishCacheOperation(globalState, cacheKey, operationToken);
     }
-
-    const signal = options && options.signal ? options.signal : null;
-    const cancellationToken = options && options.cancellationToken
-      ? options.cancellationToken
-      : null;
-    const fetchState = await this._fetchRepositoryUpstreamState(workspace, repo, {
-      signal,
-      cancellationToken,
-    });
-
-    if (
-      !signal?.aborted
-      && !cancellationToken?.isCancellationRequested
-      && fetchState.failedFormats.length === 0
-    ) {
-      await this._cacheRepositoryUpstreamState(workspace, repo, fetchState);
-    }
-
-    return fetchState;
   }
 
-  /**
-   * Load the flattened upstream list for a repository across every supported format.
-   *
-   * @param   {string} workspace Workspace slug.
-   * @param   {string} repo      Repository slug.
-   * @param   {Object} options   Optional request settings.
-   * @returns {Array}            Flattened upstream list.
-   */
   async getRepositoryUpstreams(workspace, repo, options = {}) {
-    const state = await this.getRepositoryUpstreamState(workspace, repo, options);
-    return state.upstreams;
+    return (await this.getRepositoryUpstreamState(workspace, repo, options)).upstreams;
   }
 
   async getActiveRepositoryUpstreamsForFormat(workspace, repo, format, options = {}) {
@@ -431,25 +580,17 @@ class UpstreamChecker {
     return getActiveUpstreamsFromRepositoryState(state, format);
   }
 
-  /**
-   * Orchestrate a full upstream resolution preview.
-   * Checks local existence and upstream configs for a package preview.
-   *
-   * @param   {string} workspace  Workspace slug.
-   * @param   {string} repo       Repository slug.
-   * @param   {string} name       Package name.
-   * @param   {string} format     Package format.
-   * @returns {Object}            Combined result with local and upstream info.
-   */
-  async previewResolution(workspace, repo, name, format) {
+  async previewResolution(workspace, repo, name, format, options = {}) {
+    const account = this._captureAccount(options);
+    if (!account) return null;
+    const sharedOptions = { ...options, account };
     const [localPkg, upstreams] = await Promise.all([
-      this.existsLocally(workspace, repo, name, format),
-      this.getUpstreamsForFormat(workspace, repo, format),
+      this.existsLocally(workspace, repo, name, format, sharedOptions),
+      this.getUpstreamsForFormat(workspace, repo, format, sharedOptions),
     ]);
-
-    const upstreamList = Array.isArray(upstreams.data) ? upstreams.data : [];
-    const activeUpstreams = upstreamList.filter((upstream) => upstream.is_active !== false);
-
+    if (!isAccountCurrent(this.connectionManager, account)) return null;
+    const configs = Array.isArray(upstreams.data) ? upstreams.data : [];
+    const active = configs.filter(upstream => upstream.is_active !== false);
     return {
       name,
       format,
@@ -457,240 +598,154 @@ class UpstreamChecker {
       repo,
       local: localPkg,
       upstreams: {
-        data: {
-          total: upstreamList.length,
-          active: activeUpstreams.length,
-          configs: upstreamList,
-        },
+        data: { total: configs.length, active: active.length, configs },
         error: upstreams.error,
       },
-      canResolveViaUpstream: activeUpstreams.length > 0,
+      canResolveViaUpstream: active.length > 0,
     };
   }
 
   _getRepositoryUpstreamCacheKey(workspace, repo) {
-    return `${REPOSITORY_UPSTREAM_CACHE_KEY_PREFIX}:${workspace}:${repo}`;
-  }
-
-  _isCacheObjectRecord(value) {
-    return isCacheObjectRecord(value);
+    const tuple = ["repository", workspace, repo];
+    return `${UPSTREAM_CACHE_KEY_PREFIX}:${encodeURIComponent(JSON.stringify(tuple))}`;
   }
 
   _logRepositoryUpstreamCacheError(action, workspace, repo, error) {
-    const message = error && error.message ? error.message : String(error);
-    console.warn(
-      `[UpstreamChecker] Failed to ${action} repository upstream cache for ${workspace}/${repo}: ${message}`
-    );
+    logCacheError(action, workspace, repo, error);
   }
 
   _evictInvalidRepositoryUpstreamCacheEntry(workspace, repo, globalState) {
-    if (!globalState || typeof globalState.update !== "function") {
-      return;
-    }
-
-    try {
-      const updateResult = globalState.update(
-        this._getRepositoryUpstreamCacheKey(workspace, repo),
-        undefined
-      );
-
-      if (updateResult && typeof updateResult.catch === "function") {
-        updateResult.catch((error) => {
-          this._logRepositoryUpstreamCacheError("evict invalid entry from", workspace, repo, error);
-        });
-      }
-    } catch (error) {
-      this._logRepositoryUpstreamCacheError("evict invalid entry from", workspace, repo, error);
-    }
+    evictCacheEntry(globalState, this._getRepositoryUpstreamCacheKey(workspace, repo), workspace, repo);
   }
 
-  _getCachedRepositoryUpstreamState(workspace, repo) {
+  _getCachedRepositoryUpstreamState(workspace, repo, suppliedAccount = null) {
+    const account = suppliedAccount || captureAccount(this.connectionManager);
+    if (!account || !isAccountCurrent(this.connectionManager, account)) return null;
     const globalState = this.context && this.context.globalState;
-    if (!globalState || typeof globalState.get !== "function") {
-      return null;
-    }
-
+    if (!globalState || typeof globalState.get !== "function") return null;
     const cached = globalState.get(this._getRepositoryUpstreamCacheKey(workspace, repo));
-    const isValidCacheEntry = this._isCacheObjectRecord(cached)
-      && Number.isFinite(cached.timestamp)
-      && this._isCacheObjectRecord(cached.groupedUpstreams)
-      && Object.values(cached.groupedUpstreams).every(isUpstreamArray);
-
-    if (!isValidCacheEntry) {
-      if (cached !== undefined) {
-        this._evictInvalidRepositoryUpstreamCacheEntry(workspace, repo, globalState);
-      }
+    if (cached === undefined) return null;
+    const formats = isObjectRecord(cached.groupedUpstreams)
+      ? Object.keys(cached.groupedUpstreams)
+      : [];
+    const valid = isAccountEnvelope(cached, account, [
+      "accountEpoch", "activationId", "groupedUpstreams", "successfulFormats",
+      "timestamp", "version",
+    ])
+      && isFresh(cached.timestamp, this.now())
+      && isObjectRecord(cached.groupedUpstreams)
+      && formats.every(format => SUPPORTED_UPSTREAM_FORMATS.includes(format))
+      && formats.every(format => (
+        Array.isArray(cached.groupedUpstreams[format])
+        && cached.groupedUpstreams[format].length <= MAX_PERSISTED_UPSTREAMS_PER_FORMAT
+        && cached.groupedUpstreams[format].every(isPersistedUpstream)
+      ))
+      && formats.reduce((total, format) => (
+        total + cached.groupedUpstreams[format].length
+      ), 0) <= MAX_PERSISTED_UPSTREAMS
+      && Number.isInteger(cached.successfulFormats)
+      && cached.successfulFormats >= 0
+      && cached.successfulFormats <= SUPPORTED_UPSTREAM_FORMATS.length;
+    if (!valid) {
+      this._evictInvalidRepositoryUpstreamCacheEntry(workspace, repo, globalState);
       return null;
     }
-
-    if ((Date.now() - cached.timestamp) >= UPSTREAM_CACHE_TTL_MS) {
-      return null;
-    }
-
-    const groupedUpstreams = this._deserializeGroupedUpstreams(cached.groupedUpstreams);
-    const successfulFormats = Number.isFinite(cached.successfulFormats)
-      ? cached.successfulFormats
-      : SUPPORTED_UPSTREAM_FORMATS.length;
-
-    return this._buildRepositoryUpstreamState(groupedUpstreams, [], successfulFormats);
+    return this._buildRepositoryUpstreamState(
+      this._deserializeGroupedUpstreams(cached.groupedUpstreams),
+      [],
+      cached.successfulFormats
+    );
   }
 
-  async _cacheRepositoryUpstreamState(workspace, repo, state) {
+  async _cacheRepositoryUpstreamState(workspace, repo, state, account, operationId) {
     const globalState = this.context && this.context.globalState;
-    if (!globalState || typeof globalState.update !== "function") {
-      return;
-    }
-
+    if (!globalState || typeof globalState.update !== "function") return;
+    const cacheKey = this._getRepositoryUpstreamCacheKey(workspace, repo);
     const groupedUpstreams = {};
+    let persistedCount = 0;
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
       const upstreams = state.groupedUpstreams.get(format);
       if (Array.isArray(upstreams) && upstreams.length > 0) {
-        groupedUpstreams[format] = upstreams;
+        const serialized = serializeUpstreamArray(
+          upstreams,
+          MAX_PERSISTED_UPSTREAMS_PER_FORMAT
+        );
+        if (!serialized || persistedCount + serialized.length > MAX_PERSISTED_UPSTREAMS) return;
+        groupedUpstreams[format] = serialized;
+        persistedCount += serialized.length;
       }
     }
-
-    try {
-      await globalState.update(this._getRepositoryUpstreamCacheKey(workspace, repo), {
-        timestamp: Date.now(),
-        successfulFormats: state.successfulFormats,
-        groupedUpstreams,
-      });
-    } catch (error) {
-      this._logRepositoryUpstreamCacheError("persist", workspace, repo, error);
-    }
+    await queueCacheWrite(globalState, cacheKey, async () => {
+      if (
+        !isAccountCurrent(this.connectionManager, account)
+        || !isCacheOperationCurrent(globalState, cacheKey, operationId)
+      ) return;
+      try {
+        await globalState.update(cacheKey, {
+          version: UPSTREAM_CACHE_SCHEMA_VERSION,
+          activationId: account.activationId,
+          accountEpoch: account.accountEpoch,
+          timestamp: this.now(),
+          successfulFormats: state.successfulFormats,
+          groupedUpstreams,
+        });
+      } catch (error) {
+        this._logRepositoryUpstreamCacheError("persist", workspace, repo, error);
+      }
+    });
   }
 
   async _fetchRepositoryUpstreamState(workspace, repo, options = {}) {
-    const { signal, cancellationToken } = options;
-    const groupedUpstreams = new Map();
-    const failedFormats = [];
-    let successfulFormats = 0;
-
-    for (
-      let index = 0;
-      index < SUPPORTED_UPSTREAM_FORMATS.length;
-      index += UPSTREAM_FETCH_BATCH_SIZE
-    ) {
-      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
-        return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
+    const grouped = new Map();
+    const failed = [];
+    let successful = 0;
+    for (let index = 0; index < SUPPORTED_UPSTREAM_FORMATS.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
+      if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
+        return this._emptyRepositoryState();
       }
-
-      const batch = SUPPORTED_UPSTREAM_FORMATS.slice(
-        index,
-        index + UPSTREAM_FETCH_BATCH_SIZE
-      );
-
-      const batchResults = await Promise.all(
-        batch.map((format) =>
-          this._fetchFormatUpstreams(workspace, repo, format, options)
-        )
-      );
-
-      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
-        return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
+      const batch = SUPPORTED_UPSTREAM_FORMATS.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
+      const results = await Promise.all(batch.map(format => (
+        fetchFormatUpstreams(this.api, workspace, repo, format, options)
+      )));
+      if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
+        return this._emptyRepositoryState();
       }
-
-      for (const result of batchResults) {
-        if (result.status === "failed") {
-          failedFormats.push(result.format);
-          continue;
+      for (const result of results) {
+        if (result.status === "failed") failed.push(result.format);
+        if (result.status === "loaded") {
+          const retainedCount = Array.from(grouped.values()).reduce(
+            (total, upstreams) => total + upstreams.length,
+            0
+          );
+          if (retainedCount + result.upstreams.length > MAX_RUNTIME_UPSTREAMS) {
+            failed.push(result.format);
+            continue;
+          }
+          successful += 1;
+          if (result.upstreams.length > 0) grouped.set(result.format, result.upstreams);
         }
-
-        if (result.status !== "loaded") {
-          continue;
-        }
-
-        successfulFormats += 1;
-
-        if (result.upstreams.length === 0) {
-          continue;
-        }
-
-        groupedUpstreams.set(result.format, result.upstreams);
       }
     }
-
-    return this._buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats);
-  }
-
-  async _fetchFormatUpstreams(workspace, repo, format, options = {}) {
-    const { signal, cancellationToken } = options;
-    try {
-      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
-        return { format, status: "aborted", upstreams: [] };
-      }
-
-      const result = await this.api.get(
-        apiEndpoint(["repos", workspace, repo, "upstream", format]),
-        {
-          responseType: "array",
-          validate: isUpstreamArray,
-          retry: "never",
-          signal,
-          cancellationToken,
-        }
-      );
-
-      if (signal?.aborted || cancellationToken?.isCancellationRequested) {
-        return { format, status: "aborted", upstreams: [] };
-      }
-
-      if (!result.ok) {
-        if (result.error.kind === "cancelled") {
-          return { format, status: "aborted", upstreams: [] };
-        }
-        if (this._isWarningWorthyFormatError(result.error)) {
-          return { format, status: "failed", upstreams: [] };
-        }
-        return { format, status: "loaded", upstreams: [] };
-      }
-
-      return {
-        format,
-        status: "loaded",
-        upstreams: result.data.map((upstream) => ({ ...upstream, format })),
-      };
-    } catch (error) {
-      if (this._isAbortError(error) || signal?.aborted) {
-        return { format, status: "aborted", upstreams: [] };
-      }
-
-      return { format, status: "failed", upstreams: [] };
-    }
+    return this._buildRepositoryUpstreamState(grouped, failed, successful);
   }
 
   _buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats) {
     const normalizedGrouped = new Map();
     const upstreams = [];
     let active = 0;
-
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
-      const formatUpstreams = Array.isArray(groupedUpstreams.get(format))
-        ? groupedUpstreams.get(format).slice()
+      const values = Array.isArray(groupedUpstreams.get(format))
+        ? groupedUpstreams.get(format).slice().sort(sortUpstreams)
         : [];
-
-      if (formatUpstreams.length === 0) {
-        continue;
-      }
-
-      formatUpstreams.sort((left, right) => {
-        const leftName = typeof left.name === "string" ? left.name : "";
-        const rightName = typeof right.name === "string" ? right.name : "";
-        return leftName.localeCompare(rightName, undefined, { sensitivity: "base" });
-      });
-
-      const taggedUpstreams = formatUpstreams.map((upstream) => ({
+      if (values.length === 0) continue;
+      const tagged = values.map(upstream => ({
         ...upstream,
-        format: typeof upstream.format === "string" && upstream.format
-          ? upstream.format
-          : format,
+        format: typeof upstream.format === "string" && upstream.format ? upstream.format : format,
       }));
-
-      normalizedGrouped.set(format, taggedUpstreams);
-      upstreams.push(...taggedUpstreams);
-      active += taggedUpstreams.filter((upstream) => upstream.is_active !== false).length;
+      normalizedGrouped.set(format, tagged);
+      upstreams.push(...tagged);
+      active += tagged.filter(upstream => upstream.is_active !== false).length;
     }
-
     return {
       groupedUpstreams: normalizedGrouped,
       failedFormats: Array.isArray(failedFormats) ? failedFormats.slice() : [],
@@ -703,16 +758,11 @@ class UpstreamChecker {
 
   _deserializeGroupedUpstreams(groupedUpstreams) {
     const grouped = new Map();
-    const source = groupedUpstreams && typeof groupedUpstreams === "object"
-      ? groupedUpstreams
-      : {};
-
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
-      if (Array.isArray(source[format])) {
-        grouped.set(format, source[format].slice());
+      if (Array.isArray(groupedUpstreams[format])) {
+        grouped.set(format, groupedUpstreams[format].map(upstream => ({ ...upstream })));
       }
     }
-
     return grouped;
   }
 
@@ -726,50 +776,63 @@ class UpstreamChecker {
 }
 
 function isRecordArray(value) {
-  return Array.isArray(value) && value.every(item => (
-    Boolean(item) && typeof item === "object" && !Array.isArray(item)
-  ));
+  return Array.isArray(value) && value.every(item => isObjectRecord(item));
 }
 
 function isPackageArray(value) {
-  return isRecordArray(value) && value.every(item => (
-    typeof item.name === "string"
-    && item.name.length > 0
-    && typeof item.format === "string"
-    && item.format.length > 0
+  return isRecordArray(value) && value.length <= 100 && value.every(item => (
+    boundedString(item.name, MAX_PERSISTED_STRING_LENGTH)
+    && boundedString(item.format, MAX_PERSISTED_NAME_LENGTH)
   ));
 }
 
 function isUpstreamRecord(value) {
-  return Boolean(value)
-    && typeof value === "object"
-    && !Array.isArray(value)
-    && typeof value.name === "string"
-    && value.name.trim().length > 0
-    && (value.is_active === undefined || typeof value.is_active === "boolean");
+  return canonicalizeRuntimeUpstream(value) !== null;
 }
 
 function isUpstreamArray(value) {
-  return Array.isArray(value) && value.every(isUpstreamRecord);
+  return Array.isArray(value)
+    && value.length <= MAX_RUNTIME_UPSTREAMS_PER_FORMAT
+    && value.every(isUpstreamRecord);
+}
+
+function invalidUpstreamResponseError() {
+  return Object.freeze({
+    kind: "invalid_response",
+    status: null,
+    retryable: false,
+    message: "Cloudsmith returned an invalid upstream response.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
 }
 
 async function getAllUpstreamData(context, workspace, repo, options = {}) {
-  const checker = new UpstreamChecker(context);
+  const checker = new UpstreamChecker(context, options);
   return checker.getAllUpstreamData(workspace, repo, options);
 }
 
 async function getUpstreamDataForFormats(context, workspace, repo, formats, options = {}) {
-  const checker = new UpstreamChecker(context);
+  const checker = new UpstreamChecker(context, options);
   return checker.getUpstreamDataForFormats(workspace, repo, formats, options);
 }
 
 module.exports = {
+  cacheErrorMessage,
   getAllUpstreamData,
   getUpstreamDataForFormats,
   getActiveUpstreamsFromRepositoryState,
+  getActiveUpstreamCacheOperationCount,
   isBenignUpstreamFormatError,
+  getUpstreamCacheKey,
+  MAX_PERSISTED_UPSTREAMS,
+  MAX_RUNTIME_UPSTREAMS_PER_FORMAT,
+  PERSISTED_UPSTREAM_KEYS,
   SUPPORTED_UPSTREAM_FORMATS,
   UpstreamChecker,
+  UPSTREAM_CACHE_SCHEMA_VERSION,
   UPSTREAM_FETCH_BATCH_SIZE,
   UPSTREAM_CACHE_TTL_MS,
 };

--- a/util/workspaceCache.js
+++ b/util/workspaceCache.js
@@ -1,0 +1,77 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+function normalizeWorkspace(workspace) {
+  if (
+    !workspace
+    || typeof workspace !== "object"
+    || Array.isArray(workspace)
+    || typeof workspace.slug !== "string"
+    || workspace.slug.length === 0
+    || typeof workspace.name !== "string"
+    || workspace.name.length === 0
+  ) {
+    return null;
+  }
+  return Object.freeze({ slug: workspace.slug, name: workspace.name });
+}
+
+class WorkspaceCache {
+  constructor(connectionManager, options = {}) {
+    this.connectionManager = connectionManager;
+    this.ttlMs = Number.isFinite(options.ttlMs) && options.ttlMs >= 0
+      ? options.ttlMs
+      : DEFAULT_TTL_MS;
+    this.now = options.now || Date.now;
+    this._entry = null;
+  }
+
+  get() {
+    const state = this.connectionManager && this.connectionManager.getState();
+    if (
+      !this._entry
+      || !state
+      || !state.sessionConnected
+      || state.accountEpoch !== this._entry.accountEpoch
+      || state.activationId !== this._entry.activationId
+      || this.now() - this._entry.createdAt >= this.ttlMs
+    ) {
+      this._entry = null;
+      return null;
+    }
+    return this._entry.workspaces.map(workspace => ({ ...workspace }));
+  }
+
+  set(workspaces, account) {
+    const state = this.connectionManager && this.connectionManager.getState();
+    if (
+      !Array.isArray(workspaces)
+      || !account
+      || !state
+      || !state.sessionConnected
+      || state.accountEpoch !== account.accountEpoch
+      || state.activationId !== account.activationId
+    ) {
+      return false;
+    }
+
+    const normalized = workspaces.map(normalizeWorkspace);
+    if (normalized.some(workspace => !workspace)) {
+      return false;
+    }
+    this._entry = Object.freeze({
+      accountEpoch: account.accountEpoch,
+      activationId: account.activationId,
+      createdAt: this.now(),
+      workspaces: Object.freeze(normalized),
+    });
+    return true;
+  }
+
+  clear() {
+    this._entry = null;
+  }
+}
+
+module.exports = { DEFAULT_TTL_MS, WorkspaceCache };

--- a/util/workspaceContextProjector.js
+++ b/util/workspaceContextProjector.js
@@ -1,0 +1,98 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const vscode = require("vscode");
+
+const projectors = new WeakMap();
+
+class WorkspaceContextProjector {
+  constructor(options = {}) {
+    this._executeCommand = options.executeCommand
+      || ((...args) => vscode.commands.executeCommand(...args));
+    this._version = 0;
+    this._queue = Promise.resolve();
+    this._disposed = false;
+  }
+
+  begin(options = {}) {
+    if (this._disposed) return null;
+    return Object.freeze({
+      projector: this,
+      version: ++this._version,
+      isCurrent: typeof options.isCurrent === "function" ? options.isCurrent : null,
+    });
+  }
+
+  project(hasMultipleWorkspaces, options = {}) {
+    if (this._disposed) return Promise.resolve(false);
+
+    const operation = options.operation || this.begin(options);
+    if (!operation || operation.projector !== this) return Promise.resolve(false);
+    const version = operation.version;
+    const value = Boolean(hasMultipleWorkspaces);
+    const isCurrent = operation.isCurrent;
+    const apply = async () => {
+      if (this._disposed || version !== this._version) {
+        return false;
+      }
+      if (isCurrent && !isCurrent()) {
+        if (value) {
+          await this._executeCommand(
+            "setContext",
+            "cloudsmith.hasMultipleWorkspaces",
+            false
+          );
+        }
+        return false;
+      }
+
+      await this._executeCommand(
+        "setContext",
+        "cloudsmith.hasMultipleWorkspaces",
+        value
+      );
+
+      if (this._disposed || version !== this._version) return false;
+      if (isCurrent && !isCurrent()) {
+        // The account may change while VS Code is applying the context key.
+        // Correct it within this serialized operation before reporting completion.
+        await this._executeCommand(
+          "setContext",
+          "cloudsmith.hasMultipleWorkspaces",
+          false
+        );
+        return false;
+      }
+      return true;
+    };
+
+    const pending = this._queue.then(apply, apply);
+    this._queue = pending.then(() => undefined, () => undefined);
+    return pending;
+  }
+
+  whenIdle() {
+    return this._queue;
+  }
+
+  dispose() {
+    this._disposed = true;
+    this._version += 1;
+  }
+}
+
+function getWorkspaceContextProjector(context, options = {}) {
+  if (!context || (typeof context !== "object" && typeof context !== "function")) {
+    throw new TypeError("An extension context is required for workspace projection.");
+  }
+  let projector = projectors.get(context);
+  if (!projector) {
+    projector = new WorkspaceContextProjector(options);
+    projectors.set(context, projector);
+  }
+  return projector;
+}
+
+module.exports = {
+  getWorkspaceContextProjector,
+  WorkspaceContextProjector,
+};

--- a/util/workspaceRepositoryFetcher.js
+++ b/util/workspaceRepositoryFetcher.js
@@ -3,9 +3,28 @@ const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { formatApiError } = require("./errorFormatter");
 const { PaginatedFetch } = require("./paginatedFetch");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("./accountOperation");
 
 const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
 const UNEXPECTED_RESPONSE_FORMAT_ERROR = "Unexpected repository response format";
+const STALE_ACCOUNT_ERROR = Object.freeze({
+  kind: "stale_account",
+  message: "The active Cloudsmith account changed while repositories were loading.",
+});
+
+function staleResult() {
+  return {
+    repositories: [],
+    error: STALE_ACCOUNT_ERROR,
+    warning: null,
+    partial: false,
+    stale: true,
+  };
+}
 
 function sortRepositories(repositories) {
   return [...repositories].sort((left, right) => {
@@ -19,8 +38,19 @@ function sortRepositories(repositories) {
 }
 
 async function fetchWorkspaceRepositories(context, workspace, options = {}) {
-  const cloudsmithAPI = new CloudsmithAPI(context);
-  const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
+  const {
+    account: suppliedAccount,
+    cloudsmithAPI: suppliedApi,
+    connectionManager: suppliedManager,
+    paginatedFetch: suppliedPagination,
+    withProgress = vscode.window.withProgress.bind(vscode.window),
+    ...requestOptions
+  } = options;
+  const connectionManager = resolveConnectionManager(context, suppliedManager);
+  const account = suppliedAccount || captureAccount(connectionManager);
+  if (!account || !isAccountCurrent(connectionManager, account)) return staleResult();
+  const cloudsmithAPI = suppliedApi || new CloudsmithAPI(context);
+  const paginatedFetch = suppliedPagination || new PaginatedFetch(cloudsmithAPI);
   let endpoint;
   try {
     endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
@@ -30,20 +60,23 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
       error: Object.freeze({ kind: "invalid_request", message: "The workspace identifier is invalid." }),
       warning: null,
       partial: false,
+      stale: false,
     };
   }
 
-  return vscode.window.withProgress(
+  return withProgress(
     {
       location: vscode.ProgressLocation.Window,
       title: `Loading repositories for ${workspace}...`,
     },
     async progress => {
+      if (!isAccountCurrent(connectionManager, account)) return staleResult();
       const repositories = [];
       let page = 1;
       let knownPageTotal = null;
 
       while (true) {
+        if (!isAccountCurrent(connectionManager, account)) return staleResult();
         progress.report({
           message: knownPageTotal ? `Page ${page} of ${knownPageTotal}` : `Page ${page}`,
         });
@@ -53,8 +86,9 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
           page,
           WORKSPACE_REPOSITORY_PAGE_SIZE,
           null,
-          { ...options, validate: isRepositoryArray }
+          { ...requestOptions, validate: isRepositoryArray }
         );
+        if (!isAccountCurrent(connectionManager, account)) return staleResult();
 
         if (result.error) {
           if (page === 1) {
@@ -63,6 +97,7 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
               error: result.error,
               warning: null,
               partial: false,
+              stale: false,
             };
           }
 
@@ -75,6 +110,7 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
             error: null,
             warning: result.error,
             partial: true,
+            stale: false,
           };
         }
 
@@ -85,6 +121,7 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
               error: UNEXPECTED_RESPONSE_FORMAT_ERROR,
               warning: null,
               partial: false,
+              stale: false,
             };
           }
 
@@ -97,6 +134,7 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
             error: null,
             warning: UNEXPECTED_RESPONSE_FORMAT_ERROR,
             partial: true,
+            stale: false,
           };
         }
 
@@ -120,6 +158,7 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
         error: null,
         warning: null,
         partial: false,
+        stale: false,
       };
     }
   );
@@ -139,6 +178,7 @@ function isRepositoryArray(value) {
 
 module.exports = {
   UNEXPECTED_RESPONSE_FORMAT_ERROR,
+  STALE_ACCOUNT_ERROR,
   WORKSPACE_REPOSITORY_PAGE_SIZE,
   fetchWorkspaceRepositories,
 };

--- a/views/cloudsmithProvider.js
+++ b/views/cloudsmithProvider.js
@@ -4,19 +4,38 @@
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiEndpoint } = require("../util/apiEndpoint");
-const { ConnectionManager } = require("../util/connectionManager");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
+const { WorkspaceCache } = require("../util/workspaceCache");
 const InfoNode = require("../models/infoNode");
 const { WorkspaceInfoNode } = require("../models/workspaceInfoNode");
+const WorkspaceNode = require("../models/workspaceNode");
+const RepositoryNode = require("../models/repositoryNode");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
+const { getWorkspaceContextProjector } = require("../util/workspaceContextProjector");
 
 class CloudsmithProvider {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._workspaceCache = options.workspaceCache
+      || new WorkspaceCache(this._connectionManager, options.workspaceCacheOptions);
+    this._createCloudsmithAPI = options.createCloudsmithAPI
+      || (() => new CloudsmithAPI(this.context));
+    this._fetchWorkspaceRepositories = options.fetchWorkspaceRepositories
+      || workspaceRepositoryFetcher.fetchWorkspaceRepositories;
+    this._workspaceContextProjector = options.workspaceContextProjector
+      || getWorkspaceContextProjector(context);
     this._onDidChangeTreeData = new vscode.EventEmitter();
     this.onDidChangeTreeData = this._onDidChangeTreeData.event;
     this._defaultWorkspaceFallbackHandler = null;
     this._treeView = null;
     this._suppressMissingCredentialsWarningOnce = false;
+    this._operationId = 0;
+    this._loadingOperationId = null;
   }
 
   getTreeItem(element) {
@@ -41,13 +60,87 @@ class CloudsmithProvider {
     if (options.suppressMissingCredentialsWarning) {
       this._suppressMissingCredentialsWarningOnce = true;
     }
+    this._operationId += 1;
+    void this._projectMultipleWorkspaces(false).catch(() => {});
     this._onDidChangeTreeData.fire();
   }
 
-  _consumeConnectionOptions() {
-    const promptOnMissingCredentials = !this._suppressMissingCredentialsWarningOnce;
+  dispose() {
+    this._operationId += 1;
+    this._workspaceCache.clear();
+    this._onDidChangeTreeData.dispose();
+  }
+
+  _consumeMissingCredentialsWarningSuppression() {
+    const suppressed = this._suppressMissingCredentialsWarningOnce;
     this._suppressMissingCredentialsWarningOnce = false;
-    return { promptOnMissingCredentials };
+    return suppressed;
+  }
+
+  _beginOperation() {
+    const account = captureAccount(this._connectionManager);
+    if (!account) return null;
+    const operation = {
+      id: ++this._operationId,
+      account,
+    };
+    operation.projection = this._workspaceContextProjector.begin({
+      isCurrent: () => this._isOperationCurrent(operation),
+    });
+    return Object.freeze(operation);
+  }
+
+  _isOperationCurrent(operation) {
+    return Boolean(
+      operation
+      && operation.id === this._operationId
+      && isAccountCurrent(this._connectionManager, operation.account)
+    );
+  }
+
+  _signedOutNode() {
+    return new InfoNode(
+      "Connect to Cloudsmith",
+      "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
+      "Set up Cloudsmith authentication to get started.",
+      "plug",
+      undefined,
+      { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
+    );
+  }
+
+  _loadFailureNode(kind = "workspaces") {
+    return new InfoNode(
+      `Could not load ${kind}`,
+      "Check the connection and credentials",
+      "The Cloudsmith API returned an error. Refresh or configure credentials.",
+      "warning"
+    );
+  }
+
+  _startLoading(operation) {
+    this._loadingOperationId = operation.id;
+    if (this._treeView) this._treeView.message = "Loading...";
+  }
+
+  _finishLoading(operation) {
+    if (this._loadingOperationId !== operation.id) return;
+    this._loadingOperationId = null;
+    if (this._treeView) this._treeView.message = undefined;
+  }
+
+  _projectMultipleWorkspaces(hasMultiple, operation = null) {
+    return this._workspaceContextProjector.project(hasMultiple, {
+      operation: operation?.projection,
+    });
+  }
+
+  _createWorkspaceNodes(workspaces) {
+    return workspaces.map(workspace => new WorkspaceNode(workspace, this.context, {
+      connectionManager: this._connectionManager,
+      createCloudsmithAPI: this._createCloudsmithAPI,
+      fetchWorkspaceRepositories: this._fetchWorkspaceRepositories,
+    }));
   }
 
   setDefaultWorkspaceFallbackHandler(handler) {
@@ -59,85 +152,69 @@ class CloudsmithProvider {
   }
 
   async getWorkspaces() {
-    const context = this.context;
-    const cloudsmithAPI = new CloudsmithAPI(context);
-    const connectionManager = new ConnectionManager(context);
-    let workspaces = "";
-
-    if (this._treeView) {
-      this._treeView.message = "Loading...";
+    this._consumeMissingCredentialsWarningSuppression();
+    const operation = this._beginOperation();
+    if (!operation) {
+      if (this._treeView) this._treeView.message = undefined;
+      await this._projectMultipleWorkspaces(false);
+      return [this._signedOutNode()];
     }
 
-    const connStatus = await connectionManager.connect(this._consumeConnectionOptions());
-
-    if (connStatus === "false" || connStatus === "error") {
-      await vscode.commands.executeCommand("setContext", "cloudsmith.hasMultipleWorkspaces", false);
-      if (this._treeView) {
-        this._treeView.message = undefined;
+    this._startLoading(operation);
+    try {
+      const cached = this._workspaceCache.get();
+      if (cached) {
+        if (!this._isOperationCurrent(operation)) return [];
+        await this._projectMultipleWorkspaces(cached.length > 1, operation);
+        if (!this._isOperationCurrent(operation)) return [];
+        return this._createWorkspaceNodes(cached);
       }
-      return [new InfoNode(
-        "Connect to Cloudsmith",
-        "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
-        "Set up Cloudsmith authentication to get started.",
-        "plug",
-        undefined,
-        { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-      )];
-    }
 
-    const result = await cloudsmithAPI.get("namespaces/?sort=slug", {
-      responseType: "array",
-      validate: value => value.every(workspace => (
-        workspace
-        && typeof workspace === "object"
-        && !Array.isArray(workspace)
-        && typeof workspace.slug === "string"
-        && workspace.slug.length > 0
-      )),
-      retry: "safe-read",
-    });
-    workspaces = result.ok
-      ? result.data.map(workspace => ({
-        ...workspace,
-        name: typeof workspace.name === "string" && workspace.name.length > 0
-          ? workspace.name
-          : workspace.slug,
-      }))
-      : null;
-
-    if (this._treeView) {
-      this._treeView.message = undefined;
-    }
-
-    const WorkspaceNodes = [];
-    if (!workspaces) {
-      await vscode.commands.executeCommand("setContext", "cloudsmith.hasMultipleWorkspaces", false);
-      return [new InfoNode(
-        "Could not load workspaces",
-        "Check the connection and credentials",
-        "The Cloudsmith API returned an error. Refresh or configure credentials.",
-        "warning"
-      )];
-    }
-    await vscode.commands.executeCommand(
-      "setContext",
-      "cloudsmith.hasMultipleWorkspaces",
-      workspaces.length > 1
-    );
-    if (workspaces.length > 0) {
-      for (const workspace of workspaces) {
-        const workspaceNode = require("../models/workspaceNode");
-        const workspaceNodeInst = new workspaceNode(workspace, context);
-        WorkspaceNodes.push(workspaceNodeInst);
-      }
-      context.globalState.update('CloudsmithCache', {
-        name: 'Workspaces',
-        lastSync: Date.now(),
-        workspaces: workspaces
+      const result = await this._createCloudsmithAPI().get("namespaces/?sort=slug", {
+        responseType: "array",
+        validate: value => Array.isArray(value) && value.every(workspace => (
+          workspace
+          && typeof workspace === "object"
+          && !Array.isArray(workspace)
+          && typeof workspace.slug === "string"
+          && workspace.slug.length > 0
+        )),
+        retry: "safe-read",
       });
-    }
+      if (!this._isOperationCurrent(operation)) return [];
 
-    return WorkspaceNodes;
+      const workspaces = result.ok
+        ? result.data.map(workspace => ({
+          slug: workspace.slug,
+          name: typeof workspace.name === "string" && workspace.name.length > 0
+            ? workspace.name
+            : workspace.slug,
+        }))
+        : null;
+
+      if (!workspaces) {
+        await this._projectMultipleWorkspaces(false, operation);
+        if (!this._isOperationCurrent(operation)) return [];
+        return [this._loadFailureNode("workspaces")];
+      }
+      await this._projectMultipleWorkspaces(workspaces.length > 1, operation);
+      if (!this._isOperationCurrent(operation)) return [];
+      this._workspaceCache.set(workspaces, operation.account);
+
+      return this._createWorkspaceNodes(workspaces);
+    } catch {
+      if (!this._isOperationCurrent(operation)) return [];
+      try {
+        await this._projectMultipleWorkspaces(false, operation);
+      } catch {
+        // Loading cleanup and the fixed failure node remain authoritative.
+      }
+      return this._isOperationCurrent(operation)
+        ? [this._loadFailureNode("workspaces")]
+        : [];
+    } finally {
+      this._finishLoading(operation);
+    }
   }
 
   /**
@@ -148,85 +225,66 @@ class CloudsmithProvider {
    * @returns {Array} Array of RepositoryNode instances, or empty on error.
    */
   async getRepositories(workspaceSlug) {
-    const context = this.context;
-    const cloudsmithAPI = new CloudsmithAPI(context);
-    const connectionManager = new ConnectionManager(context);
-
-    if (this._treeView) {
-      this._treeView.message = "Loading...";
+    this._consumeMissingCredentialsWarningSuppression();
+    const operation = this._beginOperation();
+    if (!operation) {
+      if (this._treeView) this._treeView.message = undefined;
+      return [this._signedOutNode()];
     }
 
-    const connStatus = await connectionManager.connect(this._consumeConnectionOptions());
-    if (connStatus === "false" || connStatus === "error") {
-      if (this._treeView) {
-        this._treeView.message = undefined;
-      }
-      return [new InfoNode(
-        "Connect to Cloudsmith",
-        "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
-        "Set up Cloudsmith authentication to get started.",
-        "plug",
-        undefined,
-        { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-      )];
-    }
-
-    const result = await workspaceRepositoryFetcher.fetchWorkspaceRepositories(
-      context,
-      workspaceSlug
-    );
-
-    if (this._treeView) {
-      this._treeView.message = undefined;
-    }
-
-    if (result.error) {
-      if (this._defaultWorkspaceFallbackHandler) {
-        this._defaultWorkspaceFallbackHandler(workspaceSlug);
-      } else {
-        vscode.window.showWarningMessage(
-          `Could not access workspace "${workspaceSlug}". Showing all workspaces.`
-        );
-      }
-      // Fall back to full workspace tree
-      return this.getWorkspaces();
-    }
-
-    const repos = result.repositories;
-
-    const RepositoryNode = require("../models/repositoryNode");
-    let quotaData = null;
-
+    this._startLoading(operation);
     try {
-      const quotaResult = await cloudsmithAPI.get(apiEndpoint(["quota", workspaceSlug]), {
-        responseType: "object",
-        retry: "safe-read",
+      const result = await this._fetchWorkspaceRepositories(this.context, workspaceSlug, {
+        account: operation.account,
+        connectionManager: this._connectionManager,
       });
-      if (quotaResult.ok && quotaResult.data.usage && typeof quotaResult.data.usage === "object") {
-        quotaData = quotaResult.data;
+      if (!this._isOperationCurrent(operation) || result.stale) return [];
+
+      if (result.error) {
+        if (this._defaultWorkspaceFallbackHandler) {
+          this._defaultWorkspaceFallbackHandler(workspaceSlug);
+        } else {
+          vscode.window.showWarningMessage(
+            `Could not access workspace "${workspaceSlug}". Showing all workspaces.`
+          );
+        }
+        // Fall back to full workspace tree
+        return this.getWorkspaces();
       }
+
+      const repos = result.repositories;
+      let quotaData = null;
+      try {
+        const quotaResult = await this._createCloudsmithAPI().get(apiEndpoint(["quota", workspaceSlug]), {
+          responseType: "object",
+          retry: "safe-read",
+        });
+        if (quotaResult.ok && quotaResult.data.usage && typeof quotaResult.data.usage === "object") {
+          quotaData = quotaResult.data;
+        }
+      } catch {
+        // Quota access is optional for the workspace summary row.
+      }
+      if (!this._isOperationCurrent(operation)) return [];
+
+      const RepositoryNodes = [
+        new WorkspaceInfoNode(workspaceSlug, quotaData),
+      ];
+      for (const repo of repos) {
+        // Pass workspaceSlug as the workspace parameter so downstream calls work
+        RepositoryNodes.push(new RepositoryNode(repo, workspaceSlug, this.context, {
+          connectionManager: this._connectionManager,
+          createCloudsmithAPI: this._createCloudsmithAPI,
+        }));
+      }
+      return RepositoryNodes;
     } catch {
-      // Quota access is optional for the workspace summary row.
+      return this._isOperationCurrent(operation)
+        ? [this._loadFailureNode("repositories")]
+        : [];
+    } finally {
+      this._finishLoading(operation);
     }
-
-    const RepositoryNodes = [
-      new WorkspaceInfoNode(workspaceSlug, quotaData),
-    ];
-
-    for (const repo of repos) {
-      // Pass workspaceSlug as the workspace parameter so downstream calls work
-      const repoNode = new RepositoryNode(repo, workspaceSlug, context);
-      RepositoryNodes.push(repoNode);
-    }
-
-    // Also update the workspace cache so search commands can find it
-    context.globalState.update('CloudsmithCache', {
-      name: 'Workspaces',
-      lastSync: Date.now(),
-      workspaces: [{ name: workspaceSlug, slug: workspaceSlug }]
-    });
-
-    return RepositoryNodes;
   }
 }
 

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -44,6 +44,7 @@ const DependencyHealthNode = require("../models/dependencyHealthNode");
 const DependencySourceGroupNode = require("../models/dependencySourceGroupNode");
 const DependencySummaryNode = require("../models/dependencySummaryNode");
 const InfoNode = require("../models/infoNode");
+const { getConnectionManager } = require("../util/connectionManager");
 
 const DEFAULT_MAX_DEPENDENCIES_TO_SCAN = 10000;
 const LOOKUP_PAGE_SIZE = 100;
@@ -92,6 +93,7 @@ class DependencyHealthProvider {
   constructor(context, diagnosticsPublisher, options = {}) {
     this.context = context;
     this._diagnosticsPublisher = diagnosticsPublisher || null;
+    this._connectionManager = options.connectionManager || getConnectionManager(context);
     this._services = {
       enrichVulnerabilities: options.enrichVulnerabilities || enrichVulnerabilities,
       enrichLicenses: options.enrichLicenses || enrichLicenses,
@@ -128,19 +130,29 @@ class DependencyHealthProvider {
     this._lastScanTimestamp = null;
     this._nextScanOperationId = 0;
     this._activeScanCancellation = null;
+    this._activeDependencyCancellation = null;
     this._dependencyOperationRunning = false;
     this._scanOperation = createScanOperation(SCAN_STATES.IDLE, 0);
     this._hasSuccessfulScan = false;
 
-    if (this.context && this.context.secrets && typeof this.context.secrets.onDidChange === "function") {
-      this.context.secrets.onDidChange((event) => {
-        if (event.key === "cloudsmith-vsc.isConnected") {
-          this.refresh();
-        }
-      });
-    }
-
     this._updateContexts();
+  }
+
+  _captureAccountEpoch() {
+    const state = this._connectionManager && this._connectionManager.getState();
+    return state && state.sessionConnected && Number.isInteger(state.accountEpoch)
+      ? state.accountEpoch
+      : null;
+  }
+
+  _isAccountCurrent(accountEpoch) {
+    const state = this._connectionManager && this._connectionManager.getState();
+    return Boolean(
+      Number.isInteger(accountEpoch)
+      && state
+      && state.sessionConnected
+      && state.accountEpoch === accountEpoch
+    );
   }
 
   _getInitialViewMode() {
@@ -179,8 +191,10 @@ class DependencyHealthProvider {
   }
 
   getScanState() {
+    const operation = { ...this._scanOperation };
+    delete operation.accountEpoch;
     return {
-      ...this._scanOperation,
+      ...operation,
       hasSuccessfulScan: this._hasSuccessfulScan,
       successfulScope: this.getLastSuccessfulScope(),
     };
@@ -196,6 +210,35 @@ class DependencyHealthProvider {
       repository: this.lastRepo,
       projectFolder: this._projectFolderPath,
     };
+  }
+
+  async resetForAccountChange() {
+    this._nextScanOperationId += 1;
+    if (this._activeScanCancellation) {
+      this._activeScanCancellation.cancel();
+    }
+    if (this._activeDependencyCancellation) {
+      this._activeDependencyCancellation.cancel();
+    }
+    this.dependencies = [];
+    this.lastWorkspace = null;
+    this.lastRepo = null;
+    this._warnings = [];
+    this._lastManifests = [];
+    this._projectFolderPath = null;
+    this._noManifestsFolder = null;
+    this._fullTrees = [];
+    this._displayTrees = [];
+    this._summary = emptySummary();
+    this._reportData = null;
+    this._lastScanTimestamp = null;
+    this._hasSuccessfulScan = false;
+    this._scanOperation = createScanOperation(SCAN_STATES.IDLE, this._nextScanOperationId);
+    if (this._diagnosticsPublisher) {
+      this._diagnosticsPublisher.clear();
+    }
+    await this._updateContexts();
+    this.refresh();
   }
 
   async setViewMode(mode) {
@@ -366,6 +409,12 @@ class DependencyHealthProvider {
       return { status: "blocked" };
     }
 
+    const accountEpoch = this._captureAccountEpoch();
+    if (accountEpoch === null) {
+      vscode.window.showWarningMessage("Connect to Cloudsmith before scanning dependencies.");
+      return { status: "blocked" };
+    }
+
     const operationId = ++this._nextScanOperationId;
     const previousCancellation = this._activeScanCancellation;
     if (previousCancellation) {
@@ -374,6 +423,7 @@ class DependencyHealthProvider {
 
     this._scanOperation = createScanOperation(SCAN_STATES.SELECTING, operationId, {
       startedAt: Date.now(),
+      accountEpoch,
       scope: {
         workspace: cloudsmithWorkspace,
         repository: cloudsmithRepo || null,
@@ -386,7 +436,7 @@ class DependencyHealthProvider {
     let folderPath = projectFolder || this.getProjectFolder();
     if (!folderPath) {
       folderPath = await this.promptForFolder();
-      if (!this._isCurrentScan(operationId)) {
+      if (!this._isCurrentScan(operationId, accountEpoch)) {
         return { status: "superseded" };
       }
       if (!folderPath) {
@@ -402,6 +452,7 @@ class DependencyHealthProvider {
     };
     this._scanOperation = createScanOperation(SCAN_STATES.RUNNING, operationId, {
       startedAt: this._scanOperation.startedAt,
+      accountEpoch,
       scope,
     });
     await this._updateContexts();
@@ -434,7 +485,7 @@ class DependencyHealthProvider {
         }
       );
 
-      if (!this._isCurrentScan(operationId)) {
+      if (!this._isCurrentScan(operationId, accountEpoch)) {
         return { status: "superseded" };
       }
 
@@ -448,7 +499,7 @@ class DependencyHealthProvider {
         scanWorker,
         cancellationSource.token
       );
-      if (!this._isCurrentScan(operationId)) {
+      if (!this._isCurrentScan(operationId, accountEpoch)) {
         return { status: "superseded" };
       }
 
@@ -461,12 +512,12 @@ class DependencyHealthProvider {
       if (this._diagnosticsPublisher) {
         this._diagnosticsPublisher.replace(preparedDiagnostics.entries);
       }
-      this._commitSuccessfulScan(scanWorker, scope, operationId);
+      this._commitSuccessfulScan(scanWorker, scope, operationId, accountEpoch);
       await this._updateContexts();
       this.refresh();
       return { status: SCAN_STATES.SUCCEEDED };
     } catch (error) {
-      if (!this._isCurrentScan(operationId)) {
+      if (!this._isCurrentScan(operationId, accountEpoch)) {
         return { status: "superseded" };
       }
 
@@ -482,6 +533,7 @@ class DependencyHealthProvider {
         : `Dependency scan failed. ${reason}`;
       this._scanOperation = createScanOperation(SCAN_STATES.FAILED, operationId, {
         startedAt: this._scanOperation.startedAt,
+        accountEpoch,
         completedAt: Date.now(),
         failureMessage: message,
         scope,
@@ -502,8 +554,8 @@ class DependencyHealthProvider {
     }
   }
 
-  _isCurrentScan(operationId) {
-    return this._scanOperation.id === operationId;
+  _isCurrentScan(operationId, accountEpoch = this._scanOperation.accountEpoch) {
+    return this._scanOperation.id === operationId && this._isAccountCurrent(accountEpoch);
   }
 
   _createScanWorker(scope) {
@@ -537,6 +589,7 @@ class DependencyHealthProvider {
     const currentOperation = this._scanOperation;
     this._scanOperation = createScanOperation(SCAN_STATES.CANCELLED, operationId, {
       startedAt: currentOperation.startedAt,
+      accountEpoch: currentOperation.accountEpoch,
       completedAt: Date.now(),
       scope: currentOperation.scope,
       message: this._hasSuccessfulScan
@@ -547,7 +600,10 @@ class DependencyHealthProvider {
     this.refresh();
   }
 
-  _commitSuccessfulScan(scanWorker, scope, operationId) {
+  _commitSuccessfulScan(scanWorker, scope, operationId, accountEpoch) {
+    if (!this._isCurrentScan(operationId, accountEpoch)) {
+      return;
+    }
     this.lastWorkspace = scope.workspace;
     this.lastRepo = scope.repository;
     this._warnings = scanWorker._warnings;
@@ -562,6 +618,7 @@ class DependencyHealthProvider {
     this._hasSuccessfulScan = true;
     this._scanOperation = createScanOperation(SCAN_STATES.SUCCEEDED, operationId, {
       startedAt: this._scanOperation.startedAt,
+      accountEpoch,
       completedAt: Date.now(),
       scope,
     });
@@ -585,7 +642,9 @@ class DependencyHealthProvider {
           break outer;
         }
         examinedDirectDependencies += 1;
-        const healthNode = new DependencyHealthNode(dependency, null, this.context);
+        const healthNode = new DependencyHealthNode(dependency, null, this.context, {
+          connectionManager: this._connectionManager,
+        });
         if (!["quarantined", "violated", "not_found"].includes(healthNode.state)) {
           continue;
         }
@@ -1252,7 +1311,7 @@ class DependencyHealthProvider {
         dependency,
         null,
         this.context,
-        { childMode: "details" }
+        { childMode: "details", connectionManager: this._connectionManager }
       ));
   }
 
@@ -1274,6 +1333,7 @@ class DependencyHealthProvider {
       null,
       this.context,
       {
+        connectionManager: this._connectionManager,
         childMode: "tree",
         treeChildren: wrapper.children,
         duplicateReference: wrapper.duplicate,
@@ -1305,6 +1365,11 @@ class DependencyHealthProvider {
       return;
     }
 
+    const accountEpoch = this._captureAccountEpoch();
+    if (accountEpoch === null) {
+      return;
+    }
+
     if (!this.lastWorkspace) {
       vscode.window.showInformationMessage("Run a dependency scan before pulling dependencies.");
       return;
@@ -1317,6 +1382,7 @@ class DependencyHealthProvider {
     }
 
     const cancellationSource = new vscode.CancellationTokenSource();
+    this._activeDependencyCancellation = cancellationSource;
     this._dependencyOperationRunning = true;
     await this._updateContexts();
 
@@ -1341,6 +1407,10 @@ class DependencyHealthProvider {
 
             if (!execution || execution.canceled) {
               return execution || { canceled: true };
+            }
+
+            if (!this._isAccountCurrent(accountEpoch)) {
+              return { canceled: true };
             }
 
             this.lastRepo = execution.repository.slug;
@@ -1369,6 +1439,10 @@ class DependencyHealthProvider {
         return;
       }
 
+      if (!this._isAccountCurrent(accountEpoch)) {
+        return;
+      }
+
       if (result.canceled) {
         vscode.window.showInformationMessage("Dependency pull canceled.");
         return;
@@ -1381,6 +1455,9 @@ class DependencyHealthProvider {
       }
     } finally {
       cancellationSource.dispose();
+      if (this._activeDependencyCancellation === cancellationSource) {
+        this._activeDependencyCancellation = null;
+      }
       this._dependencyOperationRunning = false;
       await this._updateContexts();
       this.refresh();
@@ -1390,6 +1467,11 @@ class DependencyHealthProvider {
   async pullSingleDependency(item) {
     if (this.isScanRunning() || this._dependencyOperationRunning) {
       vscode.window.showWarningMessage("Wait for the current dependency operation to finish.");
+      return;
+    }
+
+    const accountEpoch = this._captureAccountEpoch();
+    if (accountEpoch === null) {
       return;
     }
 
@@ -1414,11 +1496,12 @@ class DependencyHealthProvider {
         repositoryHint: this.lastRepo,
         dependency,
       });
-      if (!prepared) {
+      if (!prepared || !this._isAccountCurrent(accountEpoch)) {
         return;
       }
 
       cancellationSource = new vscode.CancellationTokenSource();
+      this._activeDependencyCancellation = cancellationSource;
       const result = await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
@@ -1436,6 +1519,10 @@ class DependencyHealthProvider {
 
             if (!execution || execution.canceled) {
               return execution || { canceled: true };
+            }
+
+            if (!this._isAccountCurrent(accountEpoch)) {
+              return { canceled: true };
             }
 
             this.lastRepo = prepared.repository.slug;
@@ -1467,6 +1554,10 @@ class DependencyHealthProvider {
         return;
       }
 
+      if (!this._isAccountCurrent(accountEpoch)) {
+        return;
+      }
+
       if (result.canceled) {
         vscode.window.showInformationMessage("Dependency pull canceled.");
         return;
@@ -1485,6 +1576,9 @@ class DependencyHealthProvider {
     } finally {
       if (cancellationSource) {
         cancellationSource.dispose();
+        if (this._activeDependencyCancellation === cancellationSource) {
+          this._activeDependencyCancellation = null;
+        }
       }
       this._dependencyOperationRunning = false;
       await this._updateContexts();
@@ -1675,10 +1769,8 @@ class DependencyHealthProvider {
     }
 
     if (!this._hasSuccessfulScan && this._scanOperation.status === SCAN_STATES.IDLE) {
-      const isConnected = this.context && this.context.secrets
-        ? await this.context.secrets.get("cloudsmith-vsc.isConnected")
-        : "false";
-      if (isConnected !== "true") {
+      const state = this._connectionManager && this._connectionManager.getState();
+      if (!state || !state.sessionConnected) {
         return [
           new InfoNode(
             "Connect to Cloudsmith",
@@ -1754,6 +1846,20 @@ class DependencyHealthProvider {
     this._onDidChangeTreeData.fire();
   }
 
+  dispose() {
+    if (this._activeScanCancellation) {
+      this._activeScanCancellation.cancel();
+      this._activeScanCancellation.dispose();
+      this._activeScanCancellation = null;
+    }
+    if (this._activeDependencyCancellation) {
+      this._activeDependencyCancellation.cancel();
+      this._activeDependencyCancellation.dispose();
+      this._activeDependencyCancellation = null;
+    }
+    this._onDidChangeTreeData.dispose();
+  }
+
   _rebuildSummary() {
     this._summary = buildDependencySummary(this._fullTrees, this._displayTrees, {
       filterMode: this._filterMode,
@@ -1778,6 +1884,7 @@ function createScanOperation(status, id, values = {}) {
   return {
     status,
     id,
+    accountEpoch: Number.isInteger(values.accountEpoch) ? values.accountEpoch : null,
     startedAt: values.startedAt || null,
     completedAt: values.completedAt || null,
     scope: values.scope || null,

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -9,273 +9,1445 @@ const LoadMoreNode = require("../models/loadMoreNode");
 const InfoNode = require("../models/infoNode");
 const { formatApiError } = require("../util/errorFormatter");
 
+const MAX_RESULTS = 5000;
+const MAX_REPOSITORIES = 100;
+const MAX_WORKSPACE_LENGTH = 200;
+const MAX_REPOSITORY_LENGTH = 200;
+const MAX_QUERY_LENGTH = 2048;
+const MAX_PACKAGE_NAME_LENGTH = 2048;
+const MAX_PACKAGE_FORMAT_LENGTH = 100;
+const MAX_PACKAGE_VERSION_LENGTH = 2048;
+const MAX_PACKAGE_IDENTITY_LENGTH = 2048;
+const MAX_PACKAGE_OPTIONAL_STRING_LENGTH = 4096;
+const MAX_PACKAGE_URL_LENGTH = 8192;
+const MAX_PACKAGE_TAGS = 100;
+const MAX_PACKAGE_TAG_LENGTH = 500;
+const MULTI_REPO_CONCURRENCY = 4;
+const MAX_FAILURE_DETAILS = 20;
+
 class SearchProvider {
-    constructor(context) {
+    constructor(context, options = {}) {
         this.context = context;
+        this.connectionManager = options.connectionManager || disconnectedConnectionManager();
+        this._createCloudsmithAPI = options.createCloudsmithAPI || (() => new CloudsmithAPI(this.context));
+        this._createPaginatedFetch = options.createPaginatedFetch || (api => new PaginatedFetch(api));
+        this._withProgress = options.withProgress || ((progressOptions, task) => (
+            vscode.window.withProgress(progressOptions, task)
+        ));
+        this._notifications = options.notifications || {
+            error: message => vscode.window.showErrorMessage(message),
+            information: message => vscode.window.showInformationMessage(message),
+            warning: message => vscode.window.showWarningMessage(message),
+        };
+        this._getPageSize = options.getPageSize || (() => {
+            const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
+            return config.get("searchPageSize");
+        });
+
         this._onDidChangeTreeData = new vscode.EventEmitter();
         this.onDidChangeTreeData = this._onDidChangeTreeData.event;
-        this.searchResults = [];
-        this.pagination = null;
-        this.currentWorkspace = null;
-        this.currentQuery = null;
-        this.currentRepo = null;
-        this.currentPage = 1;
-        // Auto-refresh when connection status changes in secrets store.
-        // This ensures the welcome/connected state updates without external refresh calls.
-        this.context.secrets.onDidChange(e => {
-            if (e.key === "cloudsmith-vsc.isConnected") {
-                this.refresh();
-            }
-        });
-    }
+        this._state = freezeState({ committed: null, pending: null, failure: null });
+        this._nextOperationId = 0;
+        this._activeRoot = null;
+        this._activePage = null;
+        this._disposed = false;
+        this._account = this._readConnectedAccount();
 
-    /**
-     * Execute a search against a workspace, optionally scoped to a single repo.
-     *
-     * @param   workspace  Workspace slug
-     * @param   query      Cloudsmith search query string
-     * @param   page       Page number (default 1)
-     * @param   repo       Optional repo slug for repo-scoped search
-     */
-    async search(workspace, query, page = 1, repo = null) {
-        const cloudsmithAPI = new CloudsmithAPI(this.context);
-        const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
-
-        const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-        const pageSize = config.get("searchPageSize") || 50;
-
-        let endpoint;
-        try {
-            endpoint = repo
-                ? apiEndpoint(["packages", workspace, repo])
-                : apiEndpoint(["packages", workspace]);
-        } catch {
-            vscode.window.showErrorMessage("Could not search packages. The search scope was invalid.");
-            return;
-        }
-        const result = await vscode.window.withProgress(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Searching packages...",
-                cancellable: true,
-            },
-            (_progress, token) => paginatedFetch.fetchPage(
-                endpoint,
-                page,
-                pageSize,
-                query,
-                { cancellationToken: token, retry: "never", validate: isPackageSearchArray }
-            )
-        );
-
-        if (result.error) {
-            if (result.error.kind === "cancelled") {
+        this._connectionSubscription = this.connectionManager.onDidChange?.(state => {
+            const nextAccount = normalizeConnectedAccount(state);
+            if ((nextAccount || this._account) && !sameAccount(nextAccount, this._account)) {
+                this._account = nextAccount;
+                this.clear();
                 return;
             }
-            vscode.window.showErrorMessage(`Could not search packages. ${formatApiError(result.error)}`);
-            return;
+            this.refresh();
+        });
+    }
+
+    get state() {
+        const account = this._readConnectedAccount();
+        if (
+            !account
+            || (this._state.committed && !sameAccount(account, this._state.committed))
+            || (this._state.pending && !sameAccount(account, this._state.pending))
+            || (this._state.failure && !sameAccount(account, this._state.failure))
+        ) {
+            return EMPTY_STATE;
         }
+        return this._state;
+    }
 
-        this.currentWorkspace = workspace;
-        this.currentQuery = query;
-        this.currentPage = page;
-        this.currentRepo = repo ? repo : null;
+    // Compatibility projections for command wiring and older extension consumers.
+    get searchResults() {
+        return this._currentCommitted()?.results || EMPTY_RESULTS;
+    }
 
-        const newNodes = result.data.map(pkg => new SearchResultNode(pkg, this.context));
+    get pagination() {
+        return this._currentCommitted()?.pagination || null;
+    }
 
-        if (page > 1) {
-            // Remove existing LoadMoreNode before appending
-            this.searchResults = this.searchResults.filter(
-                node => !(node instanceof LoadMoreNode)
-            );
-            this.searchResults = this.searchResults.concat(newNodes);
-        } else {
-            this.searchResults = newNodes;
-        }
+    get currentWorkspace() {
+        return this._currentCommitted()?.descriptor.workspace || null;
+    }
 
-        this.pagination = result.pagination;
+    get currentQuery() {
+        return this._currentCommitted()?.descriptor.query || null;
+    }
 
-        // Add LoadMoreNode if more pages exist
-        if (this.pagination.page < this.pagination.pageTotal) {
-            this.searchResults.push(
-                new LoadMoreNode(this.pagination.page, this.pagination.pageTotal, this.pagination.count)
-            );
-        }
+    get currentRepo() {
+        const committed = this._currentCommitted();
+        return committed?.descriptor.kind === "repository"
+            ? committed.descriptor.repository
+            : null;
+    }
 
-        if (newNodes.length === 0 && page === 1) {
-            vscode.window.showInformationMessage(`No packages found for "${query}".`);
-        }
-
-        this.refresh();
+    get currentPage() {
+        return this._currentCommitted()?.pagination?.page || 1;
     }
 
     /**
-     * Execute a search against specific repositories within a workspace.
-     * Merges results from multiple per-repo API calls.
-     *
-     * @param   workspace  Workspace slug
-     * @param   repos      Array of repo slugs
-     * @param   query      Cloudsmith search query string
+     * Synchronously claim ownership of a new root search. Call this before any
+     * command-history or persistence await that belongs to the search intent.
      */
-    async searchRepos(workspace, repos, query) {
-        const cloudsmithAPI = new CloudsmithAPI(this.context);
-        const paginatedFetch = new PaginatedFetch(cloudsmithAPI);
+    beginSearch(descriptor) {
+        this._invalidateOperations();
 
-        const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-        const pageSize = config.get("searchPageSize") || 50;
-
-        // Fetch first page from each repo in parallel
-        const promises = repos.map(repo => {
-            let endpoint;
-            try {
-                endpoint = apiEndpoint(["packages", workspace, repo]);
-            } catch {
-                return Promise.resolve({
-                    data: [],
-                    error: { kind: "invalid_request", message: "The repository identifier was invalid." },
-                });
-            }
-            return paginatedFetch.fetchPage(endpoint, 1, pageSize, query, {
-                retry: "never",
-                validate: isPackageSearchArray,
+        let normalizedDescriptor = null;
+        let validationError = null;
+        try {
+            normalizedDescriptor = normalizeDescriptor(descriptor);
+        } catch (error) {
+            validationError = error instanceof Error ? error.message : "The search scope was invalid.";
+            normalizedDescriptor = freezeDescriptor({
+                kind: "invalid",
+                workspace: "",
+                query: "",
+                page: 1,
             });
+        }
+
+        const controller = new AbortController();
+        const operation = Object.freeze({
+            id: ++this._nextOperationId,
+            descriptor: normalizedDescriptor,
+            validationError,
+            account: this._readConnectedAccount(),
+            controller,
         });
-        const results = await Promise.all(promises);
-
-        const allNodes = [];
-        const failedRepos = [];
-        results.forEach((result, index) => {
-            if (result.error) {
-                failedRepos.push(repos[index]);
-            }
+        this._activeRoot = operation;
+        this._state = freezeState({
+            committed: this._state.committed,
+            pending: {
+                operationId: operation.id,
+                activationId: operation.account?.activationId || null,
+                accountEpoch: operation.account?.accountEpoch ?? null,
+                descriptor: operation.descriptor,
+            },
+            failure: null,
         });
-        for (const result of results) {
-            if (!result.error && result.data) {
-                const nodes = result.data.map(pkg => new SearchResultNode(pkg, this.context));
-                allNodes.push(...nodes);
+        this.refresh();
+        return operation;
+    }
+
+    async executeSearch(operation) {
+        if (!this._ownsRoot(operation)) {
+            return;
+        }
+        if (!this._isCurrentRoot(operation)) {
+            this._discardRoot(operation);
+            return;
+        }
+        if (operation.validationError) {
+            this._failRoot(operation, operation.validationError, null, "invalid_request");
+            return;
+        }
+        if (operation.descriptor.kind === "repositories") {
+            await this._executeRepositorySearch(operation);
+            return;
+        }
+        await this._executeSingleSearch(operation);
+    }
+
+    /** Execute a workspace or single-repository root search. */
+    async search(workspace, query, page = 1, repo = null) {
+        const operation = this.beginSearch({
+            kind: repo ? "repository" : "workspace",
+            workspace,
+            query,
+            page,
+            ...(repo ? { repository: repo } : {}),
+        });
+        return this.executeSearch(operation);
+    }
+
+    /** Execute a bounded first-page search against an exact repository set. */
+    async searchRepos(workspace, repos, query) {
+        const operation = this.beginSearch({
+            kind: "repositories",
+            workspace,
+            repositories: repos,
+            query,
+            page: 1,
+        });
+        return this.executeSearch(operation);
+    }
+
+    async _executeSingleSearch(operation) {
+        const { descriptor } = operation;
+        const pageSize = clampPageSize(this._getPageSize());
+        let endpoint;
+        try {
+            endpoint = descriptor.kind === "repository"
+                ? apiEndpoint(["packages", descriptor.workspace, descriptor.repository])
+                : apiEndpoint(["packages", descriptor.workspace]);
+        } catch {
+            this._failRoot(operation, "Could not search packages. The search scope was invalid.", null, "invalid_request");
+            return;
+        }
+
+        let result;
+        try {
+            const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
+            if (!this._isCurrentRoot(operation)) {
+                this._discardRoot(operation);
+                return;
             }
+            result = await this._withProgress(progressOptions(), (_progress, token) => (
+                paginatedFetch.fetchPage(
+                    endpoint,
+                    descriptor.page,
+                    pageSize,
+                    descriptor.query,
+                    {
+                        cancellationToken: token,
+                        retry: "never",
+                        signal: operation.controller.signal,
+                        validate: isPackageSearchArray,
+                    }
+                )
+            ));
+        } catch (error) {
+            if (!this._isCurrentRoot(operation)) {
+                return;
+            }
+            this._failRoot(operation, `Could not search packages. ${safeErrorMessage(error)}`, null, "unexpected");
+            return;
         }
 
-        this.searchResults = allNodes;
-        this.pagination = null; // No unified pagination for multi-repo search
-        this.currentWorkspace = workspace;
-        this.currentQuery = query;
-        this.currentPage = 1;
-        this.currentRepo = null;
-
-        if (failedRepos.length > 0) {
-            vscode.window.showWarningMessage(`Could not search some repositories: ${failedRepos.join(", ")}.`);
+        if (!this._isCurrentRoot(operation)) {
+            this._discardRoot(operation);
+            return;
+        }
+        if (result?.error) {
+            if (result.error.kind === "cancelled") {
+                this._cancelRoot(operation);
+                return;
+            }
+            this._failRoot(
+                operation,
+                `Could not search packages. ${formatApiError(result.error)}`,
+                result.error,
+                result.error.kind
+            );
+            return;
+        }
+        if (!isValidFetchedPage(result, descriptor.page, pageSize)) {
+            this._failRoot(
+                operation,
+                "Could not search packages. Cloudsmith returned an invalid result page.",
+                null,
+                "invalid_response"
+            );
+            return;
+        }
+        if (!hasExactPackageScope(result?.data, descriptor)) {
+            this._failRoot(
+                operation,
+                "Could not search packages. Cloudsmith returned packages outside the requested scope.",
+                null,
+                "invalid_response"
+            );
+            return;
         }
 
-        if (allNodes.length === 0 && failedRepos.length === 0) {
-            vscode.window.showInformationMessage(`No packages found for "${query}".`);
+        let nodes;
+        try {
+            nodes = buildUniqueNodes(
+                result.data,
+                this.context,
+                new Set(),
+                this.connectionManager
+            ).nodes;
+        } catch (error) {
+            this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
+            return;
+        }
+        if (!this._isCurrentRoot(operation)) {
+            return;
         }
 
+        const keptNodes = nodes.slice(0, MAX_RESULTS);
+        const droppedResultCount = nodes.length - keptNodes.length;
+        const pagination = freezePagination(result.pagination);
+        const capReached = keptNodes.length >= MAX_RESULTS
+            && pagination.page < pagination.pageTotal;
+        this._commitRoot(operation, {
+            descriptor,
+            results: keptNodes,
+            pagination,
+            pageable: !capReached && pagination.page < pagination.pageTotal,
+            totalCount: pagination.count,
+            diagnostics: {
+                failedRepositoryCount: 0,
+                failureDetails: [],
+                unsearchedRepositoryCount: 0,
+                droppedResultCount,
+                capReached,
+            },
+        });
+        if (keptNodes.length === 0) {
+            this._notify("information", `No packages found for "${descriptor.query}".`);
+        }
+    }
+
+    async _executeRepositorySearch(operation) {
+        const { descriptor } = operation;
+        const pageSize = clampPageSize(this._getPageSize());
+        const searchableCount = Math.min(
+            descriptor.repositories.length,
+            Math.floor(MAX_RESULTS / pageSize)
+        );
+        const searchedRepositories = descriptor.repositories.slice(0, searchableCount);
+        const unsearchedRepositoryCount = descriptor.repositories.length - searchedRepositories.length;
+        const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
+        if (!this._isCurrentRoot(operation)) {
+            this._discardRoot(operation);
+            return;
+        }
+
+        let repositoryResults;
+        try {
+            const outcome = await this._withProgress(progressOptions(), async (_progress, token) => {
+                const results = await mapWithConcurrency(
+                    searchedRepositories,
+                    MULTI_REPO_CONCURRENCY,
+                    async repository => {
+                        if (!this._isCurrentRoot(operation)) {
+                            return staleRepositoryResult(repository);
+                        }
+                        let endpoint;
+                        try {
+                            endpoint = apiEndpoint(["packages", descriptor.workspace, repository]);
+                        } catch {
+                            return failedRepositoryResult(repository, localSearchError(
+                                "invalid_request",
+                                "The repository identifier was invalid."
+                            ));
+                        }
+                        let result;
+                        try {
+                            result = await paginatedFetch.fetchPage(
+                                endpoint,
+                                1,
+                                pageSize,
+                                descriptor.query,
+                                {
+                                    cancellationToken: token,
+                                    retry: "never",
+                                    signal: operation.controller.signal,
+                                    validate: isPackageSearchArray,
+                                }
+                            );
+                        } catch (error) {
+                            return failedRepositoryResult(repository, localSearchError(
+                                "unexpected",
+                                safeErrorMessage(error)
+                            ));
+                        }
+                        if (!this._isCurrentRoot(operation)) {
+                            return staleRepositoryResult(repository);
+                        }
+                        if (result.error) {
+                            return failedRepositoryResult(repository, result.error);
+                        }
+                        if (!isValidFetchedPage(result, 1, pageSize)) {
+                            return failedRepositoryResult(repository, localSearchError(
+                                "invalid_response",
+                                "Cloudsmith returned an invalid result page."
+                            ));
+                        }
+                        if (!hasExactPackageScope(result.data, {
+                            kind: "repository",
+                            workspace: descriptor.workspace,
+                            repository,
+                        })) {
+                            return failedRepositoryResult(repository, localSearchError(
+                                "invalid_response",
+                                "Cloudsmith returned packages outside the requested scope."
+                            ));
+                        }
+                        return Object.freeze({ repository, result, stale: false });
+                    },
+                    () => this._isCurrentRoot(operation) && !token?.isCancellationRequested
+                );
+                return { results, cancelled: Boolean(token?.isCancellationRequested) };
+            });
+            if (!this._isCurrentRoot(operation)) {
+                return;
+            }
+            if (outcome.cancelled) {
+                this._cancelRoot(operation);
+                return;
+            }
+            repositoryResults = outcome.results;
+        } catch (error) {
+            if (!this._isCurrentRoot(operation)) {
+                return;
+            }
+            this._failRoot(operation, `Could not search packages. ${safeErrorMessage(error)}`, null, "unexpected");
+            return;
+        }
+
+        if (!this._isCurrentRoot(operation)) {
+            return;
+        }
+        const completedResults = repositoryResults.filter(result => result && !result.stale);
+        const failures = completedResults.filter(result => result.error);
+        const successes = completedResults.filter(result => !result.error);
+        if (successes.length === 0) {
+            const detail = failures.length > 0
+                ? ` ${formatApiError(failures[0].error)}`
+                : " No repository search completed.";
+            this._failRoot(
+                operation,
+                `Could not search the selected repositories.${detail}`,
+                failures[0]?.error || null,
+                failures[0]?.error?.kind || "search_failed"
+            );
+            return;
+        }
+
+        let built;
+        try {
+            const seen = new Set();
+            const nodes = [];
+            for (const success of successes) {
+                const next = buildUniqueNodes(
+                    success.result.data,
+                    this.context,
+                    seen,
+                    this.connectionManager
+                );
+                nodes.push(...next.nodes);
+            }
+            const keptNodes = nodes.slice(0, MAX_RESULTS);
+            built = {
+                nodes: keptNodes,
+                droppedResultCount: nodes.length - keptNodes.length,
+            };
+        } catch (error) {
+            this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
+            return;
+        }
+        if (!this._isCurrentRoot(operation)) {
+            return;
+        }
+
+        const failureDetails = failures.slice(0, MAX_FAILURE_DETAILS).map(({ repository, error }) => ({
+            repository,
+            message: formatApiError(error),
+        }));
+        const truncatedRepositories = successes.filter(({ result }) => (
+            result.pagination.page < result.pagination.pageTotal
+            || result.pagination.count > result.data.length
+        ));
+        const truncationDetails = truncatedRepositories
+            .slice(0, MAX_FAILURE_DETAILS)
+            .map(({ repository, result }) => ({
+                repository,
+                loadedCount: result.data.length,
+                totalCount: result.pagination.count,
+                page: result.pagination.page,
+                pageTotal: result.pagination.pageTotal,
+            }));
+        const matchedResultCount = boundedCountSum(
+            successes.map(({ result }) => result.pagination.count)
+        );
+        const truncatedResultCount = boundedCountSum(
+            truncatedRepositories.map(({ result }) => (
+                Math.max(0, result.pagination.count - result.data.length)
+            ))
+        );
+        const partial = failures.length > 0
+            || unsearchedRepositoryCount > 0
+            || truncatedRepositories.length > 0
+            || built.droppedResultCount > 0;
+        this._commitRoot(operation, {
+            descriptor,
+            results: built.nodes,
+            pagination: null,
+            pageable: false,
+            totalCount: matchedResultCount,
+            diagnostics: {
+                failedRepositoryCount: failures.length,
+                failureDetails,
+                unsearchedRepositoryCount,
+                truncatedRepositoryCount: truncatedRepositories.length,
+                truncationDetails,
+                truncatedResultCount,
+                droppedResultCount: built.droppedResultCount,
+                partial,
+                capReached: built.nodes.length >= MAX_RESULTS
+                    || unsearchedRepositoryCount > 0
+                    || truncatedRepositories.length > 0,
+            },
+        });
+
+        if (failures.length > 0) {
+            const names = failures.slice(0, MAX_FAILURE_DETAILS).map(result => result.repository);
+            const suffix = failures.length > names.length ? `, and ${failures.length - names.length} more` : "";
+            this._notify("warning", `Could not search some repositories: ${names.join(", ")}${suffix}.`);
+        }
+        if (built.nodes.length === 0) {
+            this._notify("information", `No packages found for "${descriptor.query}".`);
+        }
+    }
+
+    /**
+     * Load exactly one next page. Duplicate commands for the same committed
+     * session and target page receive the same promise and cannot double-fetch.
+     */
+    loadNextPage() {
+        const account = this._readConnectedAccount();
+        const committed = this._currentCommitted(account);
+        if (
+            !account
+            || !committed
+            || !committed.pageable
+            || !committed.pagination
+            || committed.descriptor.kind === "repositories"
+            || this._activeRoot
+        ) {
+            return Promise.resolve();
+        }
+        const targetPage = committed.pagination.page + 1;
+        if (
+            this._activePage
+            && this._activePage.operation.committed === committed
+            && this._activePage.operation.targetPage === targetPage
+        ) {
+            return this._activePage.promise;
+        }
+
+        this._abortPage();
+        const operation = Object.freeze({
+            id: ++this._nextOperationId,
+            committed,
+            targetPage,
+            account,
+            controller: new AbortController(),
+        });
+        const promise = Promise.resolve()
+            .then(() => this._executePage(operation))
+            .finally(() => {
+                if (this._activePage?.operation === operation) {
+                    this._activePage = null;
+                }
+            });
+        this._activePage = Object.freeze({ operation, promise });
+        this._state = freezeState({
+            committed,
+            pending: {
+                operationId: operation.id,
+                activationId: operation.account.activationId,
+                accountEpoch: operation.account.accountEpoch,
+                descriptor: committed.descriptor,
+                kind: "page",
+                targetPage,
+            },
+            failure: null,
+        });
+        this.refresh();
+        return promise;
+    }
+
+    async _executePage(operation) {
+        if (!this._isCurrentPage(operation)) {
+            this._discardPage(operation);
+            return;
+        }
+        const { committed, targetPage } = operation;
+        const { descriptor } = committed;
+        const pageSize = committed.pagination.pageSize || clampPageSize(this._getPageSize());
+        let endpoint;
+        try {
+            endpoint = descriptor.kind === "repository"
+                ? apiEndpoint(["packages", descriptor.workspace, descriptor.repository])
+                : apiEndpoint(["packages", descriptor.workspace]);
+        } catch {
+            this._failPage(operation, "Could not load more packages. The search scope was invalid.", null, "invalid_request");
+            return;
+        }
+
+        let result;
+        try {
+            const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
+            if (!this._isCurrentPage(operation)) {
+                this._discardPage(operation);
+                return;
+            }
+            result = await this._withProgress(progressOptions("Loading more packages..."), (_progress, token) => (
+                paginatedFetch.fetchPage(
+                    endpoint,
+                    targetPage,
+                    pageSize,
+                    descriptor.query,
+                    {
+                        cancellationToken: token,
+                        retry: "never",
+                        signal: operation.controller.signal,
+                        validate: isPackageSearchArray,
+                    }
+                )
+            ));
+        } catch (error) {
+            if (!this._isCurrentPage(operation)) {
+                return;
+            }
+            this._failPage(operation, `Could not load more packages. ${safeErrorMessage(error)}`, null, "unexpected");
+            return;
+        }
+
+        if (!this._isCurrentPage(operation)) {
+            this._discardPage(operation);
+            return;
+        }
+        if (result?.error) {
+            if (result.error.kind === "cancelled") {
+                this._cancelPage(operation);
+                return;
+            }
+            this._failPage(
+                operation,
+                `Could not load more packages. ${formatApiError(result.error)}`,
+                result.error,
+                result.error.kind
+            );
+            return;
+        }
+        if (!isValidFetchedPage(result, targetPage, pageSize)) {
+            this._failPage(
+                operation,
+                "Could not load more packages. Cloudsmith returned an invalid result page.",
+                null,
+                "invalid_response"
+            );
+            return;
+        }
+        if (result.pagination?.page !== targetPage || !hasExactPackageScope(result.data, descriptor)) {
+            this._failPage(
+                operation,
+                "Could not load more packages. Cloudsmith returned an unexpected page or package scope.",
+                null,
+                "invalid_response"
+            );
+            return;
+        }
+
+        let built;
+        try {
+            const seen = new Set(committed.resultKeys);
+            built = buildUniqueNodes(
+                result.data,
+                this.context,
+                seen,
+                this.connectionManager
+            );
+        } catch (error) {
+            this._failPage(operation, `Could not display more search results. ${safeErrorMessage(error)}`, null, "invalid_response");
+            return;
+        }
+        if (!this._isCurrentPage(operation)) {
+            return;
+        }
+
+        const available = Math.max(0, MAX_RESULTS - committed.results.length);
+        const appended = built.nodes.slice(0, available);
+        const results = [...committed.results, ...appended];
+        const pagination = freezePagination(result.pagination);
+        const pageDropped = built.nodes.length - appended.length;
+        const capReached = results.length >= MAX_RESULTS && pagination.page < pagination.pageTotal;
+        const nextCommitted = freezeCommitted({
+            ...committed,
+            results,
+            resultKeys: [...committed.resultKeys, ...appended.map(packageKeyFromNode)],
+            pagination,
+            pageable: !capReached && pagination.page < pagination.pageTotal,
+            totalCount: pagination.count,
+            diagnostics: {
+                ...committed.diagnostics,
+                droppedResultCount: committed.diagnostics.droppedResultCount + pageDropped,
+                capReached: committed.diagnostics.capReached || capReached,
+            },
+        });
+        this._state = freezeState({ committed: nextCommitted, pending: null, failure: null });
         this.refresh();
     }
 
-    /** Load the next page of the current search. */
-    async loadNextPage() {
-        if (!this.currentWorkspace || !this.currentQuery) {
+    _commitRoot(operation, value) {
+        if (!this._isCurrentRoot(operation)) {
             return;
         }
-        if (this.pagination && this.currentPage >= this.pagination.pageTotal) {
-            return;
-        }
-        await this.search(this.currentWorkspace, this.currentQuery, this.currentPage + 1, this.currentRepo);
+        const resultKeys = value.results.map(packageKeyFromNode);
+        const committed = freezeCommitted({
+            operationId: operation.id,
+            activationId: operation.account.activationId,
+            accountEpoch: operation.account.accountEpoch,
+            descriptor: value.descriptor,
+            results: value.results,
+            resultKeys,
+            pagination: value.pagination,
+            pageable: value.pageable,
+            totalCount: value.totalCount,
+            diagnostics: value.diagnostics,
+        });
+        this._activeRoot = null;
+        this._state = freezeState({ committed, pending: null, failure: null });
+        this.refresh();
     }
 
-    /** Clear all search results. */
+    _cancelRoot(operation) {
+        if (!this._isCurrentRoot(operation)) {
+            return;
+        }
+        this._activeRoot = null;
+        this._state = freezeState({ committed: this._state.committed, pending: null, failure: null });
+        this.refresh();
+    }
+
+    _failRoot(operation, message, _error, kind) {
+        if (!this._isCurrentRoot(operation)) {
+            return;
+        }
+        this._activeRoot = null;
+        this._state = freezeState({
+            committed: this._state.committed,
+            pending: null,
+            failure: {
+                operationId: operation.id,
+                activationId: operation.account.activationId,
+                accountEpoch: operation.account.accountEpoch,
+                descriptor: operation.descriptor,
+                kind: kind || "search_failed",
+                message,
+            },
+        });
+        this._notify("error", message);
+        this.refresh();
+    }
+
+    _failPage(operation, message, _error, kind) {
+        if (!this._isCurrentPage(operation)) {
+            return;
+        }
+        this._state = freezeState({
+            committed: operation.committed,
+            pending: null,
+            failure: {
+                operationId: operation.id,
+                activationId: operation.account.activationId,
+                accountEpoch: operation.account.accountEpoch,
+                descriptor: operation.committed.descriptor,
+                kind: kind || "page_failed",
+                message,
+            },
+        });
+        this._notify("error", message);
+        this.refresh();
+    }
+
+    _cancelPage(operation) {
+        if (!this._isCurrentPage(operation)) {
+            return;
+        }
+        this._state = freezeState({ committed: operation.committed, pending: null, failure: null });
+        this.refresh();
+    }
+
+    _isCurrentRoot(operation) {
+        return Boolean(
+            this._ownsRoot(operation)
+            && this._isAccountCurrent(operation.account)
+        );
+    }
+
+    _ownsRoot(operation) {
+        return Boolean(
+            !this._disposed
+            && operation
+            && this._activeRoot === operation
+            && !operation.controller.signal.aborted
+        );
+    }
+
+    _isCurrentPage(operation) {
+        return Boolean(
+            !this._disposed
+            && operation
+            && this._activePage?.operation === operation
+            && this._state.committed === operation.committed
+            && !operation.controller.signal.aborted
+            && this._isAccountCurrent(operation.account)
+        );
+    }
+
+    _readConnectedAccount() {
+        return normalizeConnectedAccount(this.connectionManager.getState?.());
+    }
+
+    _isAccountCurrent(account) {
+        return sameAccount(account, this._readConnectedAccount());
+    }
+
+    _currentCommitted(account = this._readConnectedAccount()) {
+        const committed = this._state.committed;
+        return account && committed && sameAccount(account, committed)
+            ? committed
+            : null;
+    }
+
+    _discardRoot(operation) {
+        if (!this._ownsRoot(operation)) return;
+        this._activeRoot = null;
+        this._state = freezeState({ committed: null, pending: null, failure: null });
+        this.refresh();
+    }
+
+    _discardPage(operation) {
+        if (this._activePage?.operation !== operation) return;
+        this._activePage = null;
+        this._state = freezeState({ committed: null, pending: null, failure: null });
+        this.refresh();
+    }
+
+    _invalidateOperations() {
+        if (this._activeRoot) {
+            this._activeRoot.controller.abort();
+            this._activeRoot = null;
+        }
+        this._abortPage();
+    }
+
+    _abortPage() {
+        if (this._activePage) {
+            this._activePage.operation.controller.abort();
+            this._activePage = null;
+        }
+    }
+
     clear() {
-        this.searchResults = [];
-        this.pagination = null;
-        this.currentWorkspace = null;
-        this.currentQuery = null;
-        this.currentPage = 1;
-        this.currentRepo = null;
+        this._invalidateOperations();
+        this._state = freezeState({ committed: null, pending: null, failure: null });
         this.refresh();
+    }
+
+    dispose() {
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+        this._invalidateOperations();
+        this._connectionSubscription?.dispose?.();
+        this._onDidChangeTreeData.dispose();
     }
 
     getTreeItem(element) {
         return element.getTreeItem();
     }
 
-    // IMPORTANT: Connection status is checked live from context.secrets every render.
-    // Do NOT cache this value or rely on external refresh calls to set a connection flag.
-    // This pattern was adopted after three regressions caused by refresh wiring changes.
     async getChildren(element) {
-        if (!element) {
-            if (this.searchResults.length === 0 && !this.currentQuery) {
-                const isConnected = await this.context.secrets.get("cloudsmith-vsc.isConnected");
-                if (isConnected !== "true") {
-                    return [new InfoNode(
-                        "Connect to Cloudsmith",
-                        "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
-                        "Set up Cloudsmith authentication to get started.",
-                        "plug",
-                        undefined,
-                        { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-                    )];
-                }
-                // Connected but no search run yet
+        if (element) {
+            return element.getChildren();
+        }
+
+        const account = this._readConnectedAccount();
+        if (!account) {
+            return [new InfoNode(
+                "Connect to Cloudsmith",
+                "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
+                "Set up Cloudsmith authentication to get started.",
+                "plug",
+                undefined,
+                { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
+            )];
+        }
+        const committed = this._currentCommitted(account);
+        const pending = sameAccount(account, this._state.pending) ? this._state.pending : null;
+        const failure = sameAccount(account, this._state.failure) ? this._state.failure : null;
+        if (!committed) {
+            if (failure) {
+                return [failureNode(failure)];
+            }
+            if (pending) {
                 return [new InfoNode(
-                    "Search packages across a Cloudsmith workspace",
-                    "Use the search icon above or Ctrl+Shift+P \u2192 Search packages.",
-                    "Search by name, format, version, license, or policy status across repositories in a workspace.",
-                    "search"
+                    "Searching packages...",
+                    "The current search is still running.",
+                    `Query: ${pending.descriptor.query || ""}`,
+                    "loading~spin"
                 )];
             }
-            // Prepend a summary node if we have search results
-            if (this.searchResults.length > 0 && this.currentQuery) {
-                const count = this.pagination ? this.pagination.count : this.searchResults.length;
-                const scopeLabel = this.currentRepo
-                    ? `${this.currentWorkspace}/${this.currentRepo}`
-                    : (this.currentWorkspace || "workspace");
-                const summaryNode = new InfoNode(
-                    `Results for: ${this.currentQuery}`,
-                    `${count} package${count !== 1 ? "s" : ""} in ${scopeLabel}`,
-                    `Query: ${this.currentQuery}\nWorkspace: ${this.currentWorkspace || ""}${this.currentRepo ? `\nRepository: ${this.currentRepo}` : ""}`,
-                    "search",
-                    "searchSummary"
-                );
-                return [summaryNode, ...this.searchResults];
-            }
-            return this.searchResults;
+            return [new InfoNode(
+                "Search packages across a Cloudsmith workspace",
+                "Use the search icon above or Ctrl+Shift+P \u2192 Search packages.",
+                "Search by name, format, version, license, or policy status across repositories in a workspace.",
+                "search"
+            )];
         }
-        return element.getChildren();
+
+        const children = [summaryNode(committed)];
+        if (pending) {
+            const description = pending.kind === "page"
+                ? `Loading page ${pending.targetPage}...`
+                : `Searching for: ${pending.descriptor.query}`;
+            children.push(new InfoNode(
+                "Search in progress",
+                description,
+                description,
+                "loading~spin"
+            ));
+        }
+        if (failure) {
+            children.push(failureNode(failure));
+        }
+        children.push(...diagnosticNodes(committed));
+        children.push(...committed.results);
+        if (committed.pageable) {
+            children.push(new LoadMoreNode(
+                committed.pagination.page,
+                committed.pagination.pageTotal,
+                committed.pagination.count
+            ));
+        }
+        return children;
     }
 
     refresh() {
-        this._onDidChangeTreeData.fire();
+        if (!this._disposed) {
+            this._onDidChangeTreeData.fire();
+        }
+    }
+
+    _notify(kind, message) {
+        try {
+            const result = this._notifications[kind]?.(message);
+            Promise.resolve(result).catch(() => {});
+        } catch {
+            // Notifications are best-effort and never own search state.
+        }
     }
 }
 
-function unwrapIdentifier(value) {
-    if (typeof value === "string" && value.length > 0) {
-        return value;
+const EMPTY_RESULTS = Object.freeze([]);
+const EMPTY_STATE = freezeState({ committed: null, pending: null, failure: null });
+
+function normalizeDescriptor(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("Could not search packages. The search scope was invalid.");
     }
-    return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
-        ? value.value
-        : null;
+    const workspace = normalizeRequiredString(
+        value.workspace,
+        "workspace",
+        MAX_WORKSPACE_LENGTH
+    );
+    if (typeof value.query !== "string" || value.query.length > MAX_QUERY_LENGTH) {
+        throw new Error("Could not search packages. The search query was invalid.");
+    }
+    const query = value.query;
+    const page = normalizePage(value.page);
+    if (value.kind === "workspace") {
+        return freezeDescriptor({ kind: "workspace", workspace, query, page });
+    }
+    if (value.kind === "repository") {
+        return freezeDescriptor({
+            kind: "repository",
+            workspace,
+            repository: normalizeRequiredString(
+                value.repository,
+                "repository",
+                MAX_REPOSITORY_LENGTH
+            ),
+            query,
+            page,
+        });
+    }
+    if (value.kind === "repositories") {
+        if (!Array.isArray(value.repositories)) {
+            throw new Error("Select between 1 and 100 repositories to search.");
+        }
+        const repositories = [...new Set(value.repositories.map(repository => (
+            normalizeRequiredString(repository, "repository", MAX_REPOSITORY_LENGTH)
+        )))];
+        if (repositories.length < 1 || repositories.length > MAX_REPOSITORIES) {
+            throw new Error("Select between 1 and 100 repositories to search.");
+        }
+        return freezeDescriptor({ kind: "repositories", workspace, repositories, query, page: 1 });
+    }
+    throw new Error("Could not search packages. The search scope was invalid.");
+}
+
+function normalizeRequiredString(value, label, maxLength) {
+    if (
+        typeof value !== "string"
+        || value.trim().length === 0
+        || value.length > maxLength
+    ) {
+        throw new Error(`The ${label} identifier was invalid.`);
+    }
+    return value.trim();
+}
+
+function normalizePage(value) {
+    if (value === undefined) {
+        return 1;
+    }
+    const page = Number(value);
+    if (!Number.isSafeInteger(page) || page < 1) {
+        throw new Error("Could not search packages. The page number was invalid.");
+    }
+    return page;
+}
+
+function clampPageSize(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return 50;
+    }
+    return Math.min(100, Math.max(1, Math.floor(numeric)));
 }
 
 function isPackageSearchArray(value) {
-    return Array.isArray(value) && value.every(pkg => (
-        pkg
-        && typeof pkg === "object"
-        && !Array.isArray(pkg)
-        && typeof pkg.name === "string"
-        && pkg.name.length > 0
-        && typeof pkg.format === "string"
-        && pkg.format.length > 0
-        && (typeof pkg.version === "string" || typeof pkg.version === "number")
-        && String(pkg.version).length > 0
-        && typeof pkg.repository === "string"
-        && pkg.repository.length > 0
-        && typeof pkg.namespace === "string"
-        && pkg.namespace.length > 0
-        && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+    return Array.isArray(value) && value.every(pkg => canonicalizeSearchPackage(pkg) !== null);
+}
+
+function requiredString(value, maxLength) {
+    return typeof value === "string" && value.length > 0 && value.length <= maxLength
+        ? value
+        : null;
+}
+
+function optionalString(value, maxLength = MAX_PACKAGE_OPTIONAL_STRING_LENGTH) {
+    return typeof value === "string" && value.length <= maxLength ? value : null;
+}
+
+function canonicalTagValue(value) {
+    if (typeof value === "string" && value.length <= MAX_PACKAGE_TAG_LENGTH) {
+        return value;
+    }
+    if (
+        Array.isArray(value)
+        && value.length <= MAX_PACKAGE_TAGS
+        && value.every(item => typeof item === "string" && item.length <= MAX_PACKAGE_TAG_LENGTH)
+    ) {
+        return [...value];
+    }
+    return null;
+}
+
+function canonicalTags(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    const tags = {};
+    const info = canonicalTagValue(value.info);
+    const version = canonicalTagValue(value.version);
+    if (info !== null) tags.info = info;
+    if (version !== null) tags.version = version;
+    return tags;
+}
+
+function canonicalizeSearchPackage(pkg) {
+    if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) return null;
+    const name = requiredString(pkg.name, MAX_PACKAGE_NAME_LENGTH);
+    const format = requiredString(pkg.format, MAX_PACKAGE_FORMAT_LENGTH);
+    const version = (typeof pkg.version === "string" || typeof pkg.version === "number")
+        ? requiredString(String(pkg.version), MAX_PACKAGE_VERSION_LENGTH)
+        : null;
+    const repository = requiredString(pkg.repository, MAX_REPOSITORY_LENGTH);
+    const namespace = requiredString(pkg.namespace, MAX_WORKSPACE_LENGTH);
+    const slugPerm = requiredString(pkg.slug_perm, MAX_PACKAGE_IDENTITY_LENGTH);
+    if (!name || !format || !version || !repository || !namespace || !slugPerm) return null;
+
+    const downloads = Number.isSafeInteger(pkg.downloads) && pkg.downloads >= 0
+        ? pkg.downloads
+        : 0;
+    const numVulnerabilities = Number.isSafeInteger(pkg.num_vulnerabilities)
+        && pkg.num_vulnerabilities >= 0
+        ? pkg.num_vulnerabilities
+        : undefined;
+    return {
+        name,
+        format,
+        version,
+        repository,
+        namespace,
+        slug_perm: slugPerm,
+        status_str: optionalString(pkg.status_str),
+        slug: optionalString(pkg.slug, MAX_PACKAGE_IDENTITY_LENGTH),
+        downloads,
+        uploaded_at: optionalString(pkg.uploaded_at),
+        status_reason: optionalString(pkg.status_reason),
+        checksum_sha256: optionalString(pkg.checksum_sha256),
+        version_digest: optionalString(pkg.version_digest),
+        cdn_url: optionalString(pkg.cdn_url, MAX_PACKAGE_URL_LENGTH),
+        filename: optionalString(pkg.filename),
+        policy_violated: pkg.policy_violated === true,
+        deny_policy_violated: pkg.deny_policy_violated === true,
+        license_policy_violated: pkg.license_policy_violated === true,
+        vulnerability_policy_violated: pkg.vulnerability_policy_violated === true,
+        num_vulnerabilities: numVulnerabilities,
+        has_vulnerabilities: pkg.has_vulnerabilities === true
+            ? true
+            : pkg.has_vulnerabilities === false
+                ? false
+                : undefined,
+        max_severity: optionalString(pkg.max_severity),
+        vulnerability_scan_results_url: optionalString(
+            pkg.vulnerability_scan_results_url,
+            MAX_PACKAGE_URL_LENGTH
+        ),
+        security_scan_status: optionalString(pkg.security_scan_status),
+        spdx_license: optionalString(pkg.spdx_license),
+        license: optionalString(pkg.license),
+        raw_license: optionalString(pkg.raw_license),
+        license_url: optionalString(pkg.license_url, MAX_PACKAGE_URL_LENGTH),
+        tags: canonicalTags(pkg.tags),
+    };
+}
+
+function isValidFetchedPage(result, requestedPage, requestedPageSize) {
+    return Boolean(
+        result
+        && isPackageSearchArray(result.data)
+        && result.data.length <= requestedPageSize
+        && result.pagination
+        && result.pagination.page === requestedPage
+        && Number.isSafeInteger(result.pagination.pageTotal)
+        && result.pagination.pageTotal >= requestedPage
+        && Number.isSafeInteger(result.pagination.count)
+        && result.pagination.count >= result.data.length
+        && Number.isSafeInteger(result.pagination.pageSize)
+        && result.pagination.pageSize >= 1
+        && result.pagination.pageSize <= 100
+    );
+}
+
+function hasExactPackageScope(packages, descriptor) {
+    return Array.isArray(packages) && packages.every(pkg => (
+        pkg.namespace === descriptor.workspace
+        && (descriptor.kind !== "repository" || pkg.repository === descriptor.repository)
     ));
 }
 
-module.exports = { SearchProvider };
+function packageKey(pkg) {
+    return JSON.stringify([pkg.namespace, pkg.repository, pkg.slug_perm]);
+}
+
+function packageKeyFromNode(node) {
+    return JSON.stringify([node.namespace, node.repository, node.slug_perm_raw]);
+}
+
+function buildUniqueNodes(packages, context, seen, connectionManager) {
+    const nodes = [];
+    for (const pkg of packages) {
+        const canonicalPackage = canonicalizeSearchPackage(pkg);
+        if (!canonicalPackage) {
+            throw new Error("Cloudsmith returned an invalid package record.");
+        }
+        const key = packageKey(canonicalPackage);
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        nodes.push(freezeSearchNode(new SearchResultNode(canonicalPackage, context, { connectionManager })));
+    }
+    return { nodes };
+}
+
+function freezeSearchNode(node) {
+    for (const key of Object.keys(node)) {
+        if (key !== "context" && key !== "_connectionManager") {
+            deepFreezeOwned(node[key]);
+        }
+    }
+    return Object.freeze(node);
+}
+
+function deepFreezeOwned(value) {
+    if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+        return value;
+    }
+    if (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype) {
+        for (const nested of Object.values(value)) {
+            deepFreezeOwned(nested);
+        }
+        Object.freeze(value);
+    }
+    return value;
+}
+
+function freezeDescriptor(descriptor) {
+    if (descriptor.repositories) {
+        Object.freeze(descriptor.repositories);
+    }
+    return Object.freeze(descriptor);
+}
+
+function freezePagination(pagination) {
+    return Object.freeze({
+        page: pagination.page,
+        pageTotal: pagination.pageTotal,
+        count: pagination.count,
+        pageSize: pagination.pageSize,
+    });
+}
+
+function freezeCommitted(value) {
+    const diagnostics = value.diagnostics || {};
+    const failureDetails = Object.freeze((diagnostics.failureDetails || []).map(detail => Object.freeze({ ...detail })));
+    const truncationDetails = Object.freeze((diagnostics.truncationDetails || []).map(detail => (
+        Object.freeze({ ...detail })
+    )));
+    return Object.freeze({
+        operationId: value.operationId,
+        activationId: value.activationId,
+        accountEpoch: value.accountEpoch,
+        descriptor: value.descriptor,
+        results: Object.freeze([...value.results]),
+        resultKeys: Object.freeze([...value.resultKeys]),
+        pagination: value.pagination ? freezePagination(value.pagination) : null,
+        pageable: Boolean(value.pageable),
+        totalCount: Number.isFinite(value.totalCount) ? value.totalCount : value.results.length,
+        diagnostics: Object.freeze({
+            failedRepositoryCount: diagnostics.failedRepositoryCount || 0,
+            failureDetails,
+            unsearchedRepositoryCount: diagnostics.unsearchedRepositoryCount || 0,
+            truncatedRepositoryCount: diagnostics.truncatedRepositoryCount || 0,
+            truncationDetails,
+            truncatedResultCount: diagnostics.truncatedResultCount || 0,
+            droppedResultCount: diagnostics.droppedResultCount || 0,
+            partial: Boolean(diagnostics.partial),
+            capReached: Boolean(diagnostics.capReached),
+        }),
+    });
+}
+
+function freezeState(value) {
+    let pending = value.pending;
+    if (pending) {
+        pending = Object.freeze({ ...pending });
+    }
+    let failure = value.failure;
+    if (failure) {
+        failure = Object.freeze({ ...failure });
+    }
+    return Object.freeze({ committed: value.committed, pending, failure });
+}
+
+function normalizeConnectedAccount(state) {
+    if (
+        !state
+        || state.sessionConnected !== true
+        || typeof state.activationId !== "string"
+        || state.activationId.length === 0
+        || !Number.isSafeInteger(state.accountEpoch)
+        || state.accountEpoch < 0
+    ) {
+        return null;
+    }
+    return Object.freeze({
+        activationId: state.activationId,
+        accountEpoch: state.accountEpoch,
+    });
+}
+
+function sameAccount(left, right) {
+    return Boolean(
+        left
+        && right
+        && left.activationId === right.activationId
+        && left.accountEpoch === right.accountEpoch
+    );
+}
+
+function disconnectedConnectionManager() {
+    return Object.freeze({
+        getState: () => Object.freeze({
+            activationId: null,
+            accountEpoch: 0,
+            sessionConnected: false,
+            status: "absent",
+        }),
+        onDidChange: () => Object.freeze({ dispose() {} }),
+    });
+}
+
+function progressOptions(title = "Searching packages...") {
+    return {
+        location: vscode.ProgressLocation.Notification,
+        title,
+        cancellable: true,
+    };
+}
+
+async function mapWithConcurrency(items, concurrency, worker, shouldContinue) {
+    const results = new Array(items.length);
+    let nextIndex = 0;
+    const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+        while (shouldContinue()) {
+            const index = nextIndex;
+            nextIndex += 1;
+            if (index >= items.length) {
+                return;
+            }
+            results[index] = await worker(items[index], index);
+            if (!shouldContinue()) {
+                return;
+            }
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+function failedRepositoryResult(repository, error) {
+    return Object.freeze({ repository, error, stale: false });
+}
+
+function staleRepositoryResult(repository) {
+    return Object.freeze({ repository, error: null, stale: true });
+}
+
+function localSearchError(kind, message) {
+    return Object.freeze({
+        kind,
+        status: null,
+        retryable: false,
+        message,
+        requestId: null,
+        retryAfterMs: null,
+        outcomeUnknown: false,
+        diagnostic: Object.freeze({}),
+    });
+}
+
+function safeErrorMessage() {
+    return "The operation failed unexpectedly. Retry the search.";
+}
+
+function boundedCountSum(counts) {
+    let total = 0;
+    for (const count of counts) {
+        if (!Number.isSafeInteger(count) || count < 0) continue;
+        if (count > Number.MAX_SAFE_INTEGER - total) return Number.MAX_SAFE_INTEGER;
+        total += count;
+    }
+    return total;
+}
+
+function summaryNode(committed) {
+    const { descriptor } = committed;
+    let scopeLabel = descriptor.workspace;
+    let tooltipScope = `Workspace: ${descriptor.workspace}`;
+    if (descriptor.kind === "repository") {
+        scopeLabel = `${descriptor.workspace}/${descriptor.repository}`;
+        tooltipScope += `\nRepository: ${descriptor.repository}`;
+    } else if (descriptor.kind === "repositories") {
+        scopeLabel = `${descriptor.workspace} (${descriptor.repositories.length} selected repositories)`;
+        tooltipScope += `\nRepositories: ${descriptor.repositories.join(", ")}`;
+    }
+    const count = committed.totalCount;
+    const loadedCount = committed.results.length;
+    const countDescription = descriptor.kind === "repositories" && committed.diagnostics.partial
+        ? count > loadedCount
+            ? `${loadedCount.toLocaleString()} of ${count.toLocaleString()} matching packages loaded (partial)`
+            : `${loadedCount.toLocaleString()} package${loadedCount !== 1 ? "s" : ""} loaded (partial)`
+        : `${count.toLocaleString()} package${count !== 1 ? "s" : ""}`;
+    return new InfoNode(
+        `Results for: ${descriptor.query}`,
+        `${countDescription} in ${scopeLabel}`,
+        `Query: ${descriptor.query}\n${tooltipScope}${committed.diagnostics.partial ? "\nPartial results" : ""}`,
+        "search",
+        "searchSummary"
+    );
+}
+
+function failureNode(failure) {
+    return new InfoNode(
+        "Search failed",
+        failure.message,
+        failure.message,
+        "error"
+    );
+}
+
+function diagnosticNodes(committed) {
+    const diagnostics = committed.diagnostics;
+    const nodes = [];
+    if (diagnostics.failedRepositoryCount > 0) {
+        const details = diagnostics.failureDetails
+            .map(detail => `${detail.repository}: ${detail.message}`)
+            .join("\n");
+        const omitted = diagnostics.failedRepositoryCount - diagnostics.failureDetails.length;
+        nodes.push(new InfoNode(
+            `${diagnostics.failedRepositoryCount} repositories could not be searched`,
+            omitted > 0 ? `${details}\n…and ${omitted} more.` : details,
+            omitted > 0 ? `${details}\n…and ${omitted} more.` : details,
+            "warning"
+        ));
+    }
+    if (diagnostics.unsearchedRepositoryCount > 0) {
+        nodes.push(new InfoNode(
+            `${diagnostics.unsearchedRepositoryCount} repositories were not searched`,
+            `The search stopped before scheduling them to stay within the ${MAX_RESULTS.toLocaleString()}-item work budget.`,
+            "Refine the query or select fewer repositories to search every selected repository.",
+            "info"
+        ));
+    }
+    if (diagnostics.truncatedRepositoryCount > 0) {
+        const details = diagnostics.truncationDetails
+            .map(detail => (
+                `${detail.repository}: loaded ${detail.loadedCount.toLocaleString()} of `
+                + `${detail.totalCount.toLocaleString()} matches `
+                + `(page ${detail.page} of ${detail.pageTotal})`
+            ))
+            .join("\n");
+        const omitted = diagnostics.truncatedRepositoryCount - diagnostics.truncationDetails.length;
+        const suffix = omitted > 0 ? `\n…and ${omitted} more.` : "";
+        nodes.push(new InfoNode(
+            `${diagnostics.truncatedRepositoryCount} repositories have additional matching pages`,
+            `${details}${suffix}`,
+            "Multi-repository search loads only the first page from each repository. Refine the query to avoid omitted matches.",
+            "info"
+        ));
+    }
+    if (diagnostics.droppedResultCount > 0) {
+        nodes.push(new InfoNode(
+            `${diagnostics.droppedResultCount} results were omitted`,
+            `Only the first ${MAX_RESULTS.toLocaleString()} results are retained.`,
+            "Refine the search query to see omitted results.",
+            "info"
+        ));
+    } else if (diagnostics.capReached && diagnostics.truncatedRepositoryCount === 0) {
+        nodes.push(new InfoNode(
+            `Showing the first ${MAX_RESULTS.toLocaleString()} results`,
+            "Additional results or repository searches are available but were not loaded.",
+            "Refine the search query to narrow the result set.",
+            "info"
+        ));
+    }
+    return nodes;
+}
+
+module.exports = {
+    SearchProvider,
+    isPackageSearchArray,
+    packageKey,
+};


### PR DESCRIPTION
## Summary

- Make credential validation and replacement atomic with an activation-owned connection state.
- Prevent stale search, pagination, provider, and account-cache work from publishing across newer operations or credential changes.
- Version and bound persisted recent-search and upstream state while keeping workspace cache account-scoped in memory.

## Validation

- `npm test` (737 passing, 7 pending)
- `npm run lint` (0 errors; 1 pre-existing warning)
- `npm audit --omit=dev` (0 vulnerabilities)
- `./node_modules/.bin/vsce package --no-dependencies --out /private/tmp/cloudsmith-vsc-2.2.0-atomic-auth-state-final-reviewed.vsix`