### PR TITLE
fix: make package promotion transactional

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -876,9 +876,11 @@ async function activate(context) {
   });
 
   let projectedAccountEpoch = connectionManager.getState().accountEpoch;
+  let promotionProvider = null;
   const handleConnectionStateChange = async (state) => {
     if (state.accountEpoch !== projectedAccountEpoch) {
       projectedAccountEpoch = state.accountEpoch;
+      promotionProvider?.resetForAccountChange();
       await resetAccountScopedState(context, {
         workspaceCache,
         searchProvider,
@@ -918,10 +920,11 @@ async function activate(context) {
   const upstreamDetailProvider = new UpstreamDetailProvider(context);
   context.subscriptions.push({ dispose: () => upstreamDetailProvider.dispose() });
 
-  // Create promotion provider
-  const promotionProvider = new PromotionProvider(context);
-
   const credentialManager = new CredentialManager(context, { connectionManager });
+  // Create promotion provider
+  promotionProvider = new PromotionProvider(context, { connectionManager, credentialManager });
+  context.subscriptions.push({ dispose: () => promotionProvider.dispose() });
+
   const ssoManager = new SSOAuthManager(context, { connectionManager });
 
   async function handleAuthenticationResult(result, options = {}) {
@@ -2540,174 +2543,9 @@ async function activate(context) {
         item = await pickRecentPackage();
         if (!item) return;
       }
-      recentPackages.add(item);
-
-      const info = extractPackageInfo(item);
-      if (
-        !info.workspace
-        || !info.repo
-        || !info.slugPerm
-        || !info.name
-        || !info.version
-        || !info.format
-      ) {
-        vscode.window.showWarningMessage("Could not determine package details.");
-        return;
-      }
-
-      // Check is_copyable upfront to avoid a wasted API round-trip
-      if (item.is_copyable === false) {
-        vscode.window.showWarningMessage(
-          "This package cannot be promoted. Write access to the target repository may be required."
-        );
-        return;
-      }
-
-      const pipeline = promotionProvider.getPipeline();
-      const cloudsmithAPI = new CloudsmithAPI(context);
-      let targetItems = [];
-
-      if (pipeline.length > 0) {
-        // Pipeline mode: suggest next eligible repo(s)
-        const currentIdx = pipeline.indexOf(info.repo);
-        const eligibleTargets = currentIdx >= 0
-          ? pipeline.slice(currentIdx + 1)
-          : pipeline.filter(r => r !== info.repo);
-
-        if (eligibleTargets.length === 0) {
-          vscode.window.showInformationMessage("Package is already in the last pipeline stage.");
-          return;
-        }
-
-        targetItems = eligibleTargets.map(r => ({ label: r, description: r, _slug: r }));
-      } else {
-        // No pipeline: show all workspace repos except the source
-        let reposEndpoint;
-        try {
-          reposEndpoint = apiEndpoint(["repos", info.workspace], { query: { sort: "name" } });
-        } catch {
-          vscode.window.showErrorMessage("The workspace identifier was invalid.");
-          return;
-        }
-        const repos = await cloudsmithAPI.get(reposEndpoint, {
-          responseType: "array",
-          validate: isRepositoryArray,
-          retry: "safe-read",
-        });
-        if (!repos.ok) {
-          vscode.window.showErrorMessage(
-            `Could not fetch workspace repositories. ${formatApiError(repos.error)}`
-          );
-          return;
-        }
-        if (repos.data.length === 0) {
-          vscode.window.showErrorMessage("No target repositories were found.");
-          return;
-        }
-
-        targetItems = repos.data
-          .filter(r => r.slug !== info.repo)
-          .map(r => ({ label: r.name, description: r.slug, _slug: r.slug }));
-      }
-
-      // Check for recent promotion history and prepend
-      const historyKey = "cloudsmith-promotionHistory";
-      const history = context.globalState.get(historyKey) || {};
-      const recentTargets = (history[info.repo] || []).slice(0, 5);
-
-      // Check where this package already exists (workspace-wide search)
-      const existingRepoMap = new Map();
-      if (info.name && info.version) {
-        let existingEndpoint;
-        try {
-          existingEndpoint = apiEndpoint(["packages", info.workspace], {
-            query: {
-              query: buildExactPackageQuery(info.name, info.version, info.format),
-              page_size: 100,
-            },
-          });
-        } catch {
-          vscode.window.showErrorMessage("The package search parameters were invalid.");
-          return;
-        }
-        const existingResults = await cloudsmithAPI.get(existingEndpoint, {
-          responseType: "array",
-          validate: isPackageLocationArray,
-          retry: "never",
-        });
-        if (!existingResults.ok) {
-          vscode.window.showErrorMessage(
-            `Could not check existing package locations. ${formatApiError(existingResults.error)}`
-          );
-          return;
-        }
-        for (const pkg of existingResults.data.filter(pkg => packageMatchesExactIdentity(pkg, info))) {
-            existingRepoMap.set(pkg.repository, pkg.status_str || "Unknown");
-        }
-      }
-
-      // Annotate target items with existence status
-      for (const ti of targetItems) {
-        const existingStatus = existingRepoMap.get(ti._slug);
-        if (existingStatus) {
-          ti.description = `${ti._slug} — already exists (${existingStatus})`;
-        } else {
-          ti.description = `${ti._slug} — not present`;
-        }
-      }
-
-      // Build final QuickPick items with recent history at the top
-      const finalItems = [];
-      if (recentTargets.length > 0) {
-        finalItems.push({ label: "Recent", kind: vscode.QuickPickItemKind.Separator });
-        for (const recentSlug of recentTargets) {
-          const matching = targetItems.find(t => t._slug === recentSlug);
-          if (matching) {
-            finalItems.push({
-              label: `$(history) ${matching.label}`,
-              description: matching.description,
-              _slug: matching._slug,
-            });
-          }
-        }
-        finalItems.push({ label: "All repositories", kind: vscode.QuickPickItemKind.Separator });
-      }
-      for (const ti of targetItems) {
-        // Skip duplicates already in recent section
-        if (!recentTargets.includes(ti._slug)) {
-          finalItems.push(ti);
-        }
-      }
-
-      const targetPick = await vscode.window.showQuickPick(finalItems, {
-        placeHolder: `Select a target repository for ${info.name} ${info.version}`,
+      await promotionProvider.runPromotionWorkflow(item, {
+        refresh: () => cloudsmithProvider.refresh(),
       });
-      if (!targetPick || !targetPick._slug) return;
-
-      const result = await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: `Promoting package to ${targetPick._slug}...` },
-        () => promotionProvider.promote(info.workspace, info.repo, info.slugPerm, targetPick._slug)
-      );
-
-      if (result && result.success) {
-        // Store in promotion history
-        const updatedHistory = context.globalState.get(historyKey) || {};
-        const repoHistory = updatedHistory[info.repo] || [];
-        // Add to front, dedupe, cap at 5
-        const updated = [targetPick._slug, ...repoHistory.filter(r => r !== targetPick._slug)].slice(0, 5);
-        updatedHistory[info.repo] = updated;
-        await context.globalState.update(historyKey, updatedHistory);
-
-        vscode.window.showInformationMessage(
-          `Package "${info.name}" promoted from ${info.repo} to ${targetPick._slug}.`
-        );
-        cloudsmithProvider.refresh();
-      } else {
-        const reason = (result && result.error) ? formatApiError(result.error) : "Unknown error";
-        vscode.window.showErrorMessage(
-          `Could not promote ${info.name} to ${targetPick._slug}. ${reason}`
-        );
-      }
     }),
 
     // Phase 12: Copy entitlement token

--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -71,6 +71,11 @@ class DependencyHealthNode {
       this.repository = this.cloudsmithMatch.repository;
       this.slug_perm = { id: "Slug", value: this.cloudsmithMatch.slug_perm };
       this.slug_perm_raw = this.cloudsmithMatch.slug_perm;
+      this.is_copyable = this.cloudsmithMatch.is_copyable === true
+        ? true
+        : this.cloudsmithMatch.is_copyable === false
+          ? false
+          : null;
       this.version = { id: "Version", value: this.cloudsmithMatch.version };
       this.status_str = { id: "Status", value: this.cloudsmithMatch.status_str };
       this.checksum_sha256 = this.cloudsmithMatch.checksum_sha256 || null;

--- a/models/packageNode.js
+++ b/models/packageNode.js
@@ -19,6 +19,11 @@ class PackageNode {
     this.uploaded_at = { id: "Uploaded at", value: pkg.uploaded_at };
     this.repository = pkg.repository;
     this.namespace = pkg.namespace;
+    this.is_copyable = pkg.is_copyable === true
+      ? true
+      : pkg.is_copyable === false
+        ? false
+        : null;
     this.status_reason = pkg.status_reason || null;
     this.checksum_sha256 = pkg.checksum_sha256 || null;
     this.version_digest = pkg.version_digest || null;

--- a/models/searchResultNode.js
+++ b/models/searchResultNode.js
@@ -17,6 +17,11 @@ class SearchResultNode {
         this.format = pkg.format;
         this.repository = pkg.repository;
         this.namespace = pkg.namespace;
+        this.is_copyable = pkg.is_copyable === true
+            ? true
+            : pkg.is_copyable === false
+                ? false
+                : null;
         this.status_str = { id: "Status", value: pkg.status_str };
         this.slug = { id: "Slug", value: pkg.slug };
         this.slug_perm = { id: "Slug", value: pkg.slug_perm };

--- a/test/packageMetadataFlow.test.js
+++ b/test/packageMetadataFlow.test.js
@@ -426,4 +426,20 @@ suite("Package Metadata Flow Test Suite", () => {
       }
     }
   });
+
+  test("package, search, and dependency models preserve only literal copyability booleans", () => {
+    for (const [value, expected] of [[true, true], [false, false], ["false", null], [undefined, null]]) {
+      const packageNode = new PackageNode({ ...pkg, is_copyable: value }, {});
+      const searchNode = new SearchResultNode({ ...pkg, is_copyable: value }, {});
+      const dependencyNode = new DependencyHealthNode({
+        name: pkg.name,
+        version: pkg.version,
+        format: pkg.format,
+        cloudsmithPackage: { ...pkg, is_copyable: value },
+      }, null, {});
+      assert.strictEqual(packageNode.is_copyable, expected);
+      assert.strictEqual(searchNode.is_copyable, expected);
+      assert.strictEqual(dependencyNode.is_copyable, expected);
+    }
+  });
 });

--- a/test/paginatedFetch.test.js
+++ b/test/paginatedFetch.test.js
@@ -6,6 +6,7 @@ suite("PaginatedFetch typed API boundary", () => {
   test("returns validated data and normalized pagination metadata", async () => {
     let requestOptions;
     const token = { isCancellationRequested: false };
+    const apiKey = "candidate-key";
     const paginated = new PaginatedFetch({
       async get(endpoint, options) {
         requestOptions = options;
@@ -26,19 +27,22 @@ suite("PaginatedFetch typed API boundary", () => {
       2,
       2,
       "name:artifact",
-      { cancellationToken: token, retry: "never" }
+      { apiKey, cancellationToken: token, retry: "never" }
     );
 
     assert.strictEqual(result.error, null);
     assert.deepStrictEqual(result.pagination, { page: 2, pageTotal: 2, count: 3, pageSize: 2 });
     assert.strictEqual(requestOptions.cancellationToken, token);
     assert.strictEqual(requestOptions.retry, "never");
+    assert.strictEqual(requestOptions.apiKey, apiKey);
   });
 
   test("keeps typed transport failures distinct from empty pages", async () => {
     const failure = apiFailure("rate_limited", { status: 429 }).error;
+    let requestOptions;
     const paginated = new PaginatedFetch({
-      async get() {
+      async get(_endpoint, options) {
+        requestOptions = options;
         return { ...apiFailure("rate_limited", { status: 429 }), error: failure };
       },
     });
@@ -47,6 +51,7 @@ suite("PaginatedFetch typed API boundary", () => {
 
     assert.strictEqual(result.error, failure);
     assert.deepStrictEqual(result.data, []);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(requestOptions, "apiKey"), false);
   });
 
   test("rejects malformed arrays and incomplete or contradictory pagination metadata", async () => {

--- a/test/promotionContracts.test.js
+++ b/test/promotionContracts.test.js
@@ -1,0 +1,277 @@
+const assert = require("assert");
+const {
+  PromotionContractError,
+  createOutcome,
+  createSourceLocator,
+  createStage,
+  createTagPlan,
+  normalizeFreshSource,
+  normalizePipeline,
+  normalizeTargetPackage,
+  preflightFingerprint,
+} = require("../util/promotionContracts");
+
+suite("Promotion contracts", () => {
+  const locator = Object.freeze({
+    workspace: "workspace",
+    repository: "source",
+    packageIdentifier: "source-package-id",
+  });
+
+  function sourceRecord(overrides = {}) {
+    return {
+      namespace: "workspace",
+      repository: "source",
+      slug_perm: "source-package-id",
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+      is_copyable: true,
+      checksum_sha256: "checksum-a",
+      tags: { info: [] },
+      ...overrides,
+    };
+  }
+
+  test("builds the same scalar locator from package, search, dependency, and recent shapes", () => {
+    const shapes = [
+      { namespace: "workspace", repository: "source", slug_perm: { id: "Slug", value: "source-package-id" } },
+      { namespace: "workspace", repository: "source", slug_perm_raw: "source-package-id" },
+      { cloudsmithWorkspace: "workspace", cloudsmithRepo: "source", slug_perm: "source-package-id" },
+      { cloudsmithMatch: { namespace: "workspace", repository: "source", slug_perm: "source-package-id" } },
+    ];
+    for (const shape of shapes) {
+      assert.deepStrictEqual(createSourceLocator(shape), locator);
+    }
+  });
+
+  test("accepts agreeing aliases and rejects conflicting or malformed aliases", () => {
+    const matching = createSourceLocator({
+      namespace: "workspace",
+      cloudsmithWorkspace: "workspace",
+      repository: "source",
+      cloudsmithRepo: "source",
+      slug_perm: { value: "source-package-id" },
+      slug_perm_raw: "source-package-id",
+    });
+    assert.deepStrictEqual(matching, locator);
+
+    for (const item of [
+      { namespace: "workspace", cloudsmithWorkspace: "other", repository: "source", slug_perm: "source-package-id" },
+      { namespace: "workspace", repository: "source", slug_perm: "source-package-id", slug_perm_raw: "other-id" },
+      { namespace: "workspace", repository: "source", slug_perm: { value: {} }, slug_perm_raw: "source-package-id" },
+      { namespace: "workspace", repository: "source", slug: "source-package-id" },
+    ]) {
+      assert.throws(() => createSourceLocator(item), PromotionContractError);
+    }
+  });
+
+  test("rejects unsafe path identities before they can become endpoints", () => {
+    for (const unsafe of [
+      "../source",
+      "a/b",
+      "a\\b",
+      "%252f",
+      " source",
+      "source\u0000",
+      "source\u061ctarget",
+      "source\u202etarget",
+    ]) {
+      assert.throws(() => createSourceLocator({
+        namespace: "workspace",
+        repository: unsafe,
+        slug_perm: "source-package-id",
+      }), PromotionContractError);
+    }
+  });
+
+  test("fresh source is the only authority for identity and strict copyability", () => {
+    const source = normalizeFreshSource(sourceRecord(), locator);
+    assert.strictEqual(source.copyable, true);
+    assert(Object.isFrozen(source));
+    assert(Object.isFrozen(source.fingerprint));
+    assert(Object.isFrozen(source.tags));
+
+    for (const is_copyable of ["true", "false", 0, 1, null, undefined]) {
+      assert.throws(
+        () => normalizeFreshSource(sourceRecord({ is_copyable }), locator),
+        PromotionContractError
+      );
+    }
+    assert.strictEqual(normalizeFreshSource(sourceRecord({ is_copyable: false }), locator).copyable, false);
+  });
+
+  test("rejects fresh identity mismatch, malformed versions, and missing immutable evidence", () => {
+    for (const record of [
+      sourceRecord({ slug_perm: "different" }),
+      sourceRecord({ namespace: "other" }),
+      sourceRecord({ repository: "other" }),
+      sourceRecord({ version: Number.NaN }),
+      sourceRecord({ version: Number.POSITIVE_INFINITY }),
+      sourceRecord({ version: {} }),
+      sourceRecord({ checksum_sha256: null, version_digest: null }),
+    ]) {
+      assert.throws(() => normalizeFreshSource(record, locator), PromotionContractError);
+    }
+  });
+
+  test("target package derives every field from one validated target record", () => {
+    const source = normalizeFreshSource(sourceRecord(), locator);
+    const target = Object.freeze({ workspace: "workspace", repository: "target" });
+    const packageRecord = {
+      ...sourceRecord(),
+      repository: "target",
+      slug_perm: "target-package-id",
+    };
+    const normalized = normalizeTargetPackage(packageRecord, source, target);
+    assert.strictEqual(normalized.packageIdentifier, "target-package-id");
+    assert.strictEqual(normalized.repository, "target");
+    assert(Object.isFrozen(normalized));
+
+    assert.throws(
+      () => normalizeTargetPackage({ ...packageRecord, slug_perm: "source-package-id" }, source, target),
+      PromotionContractError
+    );
+    assert.throws(
+      () => normalizeTargetPackage({ ...packageRecord, checksum_sha256: "different" }, source, target),
+      PromotionContractError
+    );
+    const sourceWithBoth = normalizeFreshSource(
+      sourceRecord({ version_digest: "digest-a" }),
+      locator
+    );
+    assert.throws(
+      () => normalizeTargetPackage({
+        ...packageRecord,
+        version_digest: "digest-b",
+      }, sourceWithBoth, target),
+      PromotionContractError
+    );
+  });
+
+  test("pipeline and expanded tag plans are bounded, unique, and frozen", () => {
+    assert.deepStrictEqual(normalizePipeline(["source", "target"]), ["source", "target"]);
+    assert.deepStrictEqual(normalizePipeline(undefined), []);
+    assert.throws(() => normalizePipeline(["source", "source"]), PromotionContractError);
+    assert.throws(() => normalizePipeline("source"), PromotionContractError);
+    assert.throws(() => normalizePipeline(null), PromotionContractError);
+
+    assert.throws(
+      () => normalizeFreshSource(sourceRecord({
+        tags: { info: Array.from({ length: 1001 }, (_, index) => `tag-${index}`) },
+      }), locator),
+      PromotionContractError
+    );
+
+    const plan = createTagPlan({
+      onPromote: ["promoted-to-{target}", "promoted-to-{target}"],
+      onReceive: ["promoted-from-{source}-{date}"],
+    }, "source", "target", "2026-08-09");
+    assert.deepStrictEqual(plan.source, ["promoted-to-target"]);
+    assert.deepStrictEqual(plan.target, ["promoted-from-source-2026-08-09"]);
+    assert(Object.isFrozen(plan));
+    assert.throws(() => createTagPlan({ onPromote: ["{unknown}"], onReceive: [] }, "source", "target", "2026-08-09"));
+  });
+
+  test("preflight fingerprint includes account and frozen tag plan", () => {
+    const source = normalizeFreshSource(sourceRecord(), locator);
+    const preflight = Object.freeze({
+      source,
+      target: Object.freeze({ workspace: "workspace", repository: "target" }),
+      targetPackageState: "absent",
+      targetPackageCount: 0,
+    });
+    const account = Object.freeze({ activationId: "activation", accountEpoch: 1 });
+    const first = createTagPlan({ onPromote: [], onReceive: [] }, "source", "target", "2026-08-09");
+    const second = createTagPlan({ onPromote: ["tag"], onReceive: [] }, "source", "target", "2026-08-09");
+    assert.notStrictEqual(
+      preflightFingerprint(preflight, account, first),
+      preflightFingerprint(preflight, account, second)
+    );
+  });
+
+  test("structured outcomes and nested stages cannot be mutated", () => {
+    const source = normalizeFreshSource(sourceRecord(), locator);
+    const target = Object.freeze({ workspace: "workspace", repository: "target", name: "Target" });
+    const outcome = createOutcome({
+      source,
+      target,
+      preflight: createStage("succeeded", { evidence: "fresh_read" }),
+      confirmation: createStage("succeeded", { evidence: "user_confirmation" }),
+      copy: createStage("succeeded", { required: true, attempted: true }),
+      sourceTag: createStage("not_required"),
+      targetTag: createStage("not_required"),
+      reconciliation: createStage("succeeded", { evidence: "fresh_read" }),
+      overall: "succeeded",
+      remoteState: "changed",
+    });
+    assert(Object.isFrozen(outcome));
+    assert(Object.isFrozen(outcome.copy));
+    assert.strictEqual(outcome.copy.status, "succeeded");
+    assert.throws(() => createOutcome({
+      ...outcome,
+      confirmation: createStage("not_attempted"),
+    }), PromotionContractError);
+    assert.throws(() => createStage("maybe"), PromotionContractError);
+    assert.throws(() => createStage("failed", { attempted: "true" }), PromotionContractError);
+    assert.throws(() => createOutcome({ overall: true }), PromotionContractError);
+    assert.throws(() => createOutcome({ overall: "succeeded" }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      overall: "succeeded",
+      copy: { status: "succeeded", required: "true", attempted: true },
+      reconciliation: createStage("succeeded"),
+      remoteState: "changed",
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      overall: "partial",
+      copy: createStage("succeeded", { required: true, attempted: true }),
+      sourceTag: createStage("failed", { required: true }),
+      targetTag: createStage("ambiguous", { required: true, attempted: true }),
+      reconciliation: createStage("succeeded"),
+      remoteState: "changed",
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      overall: "ambiguous",
+      reconciliation: createStage("ambiguous"),
+      remoteState: "possibly_changed",
+    }), PromotionContractError);
+    const attemptedFailure = {
+      source,
+      target,
+      preflight: createStage("succeeded", { evidence: "fresh_read" }),
+      confirmation: createStage("succeeded", { evidence: "user_confirmation" }),
+      copy: createStage("failed", { required: true, attempted: true }),
+      overall: "failed",
+      errorCode: "copy_failed",
+      remoteState: "unchanged",
+    };
+    assert.throws(() => createOutcome({
+      ...attemptedFailure,
+      confirmation: createStage("not_attempted"),
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      ...attemptedFailure,
+      source: { ...source, copyable: false },
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      ...attemptedFailure,
+      target: { ...target, repository: source.repository },
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      ...attemptedFailure,
+      target: { ...target, workspace: "another-workspace" },
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      ...attemptedFailure,
+      copy: createStage("failed", { required: false, attempted: true }),
+    }), PromotionContractError);
+    assert.throws(() => createOutcome({
+      overall: "failed",
+      remoteState: "",
+    }), PromotionContractError);
+    assert.throws(
+      () => createOutcome({ overall: "failed", errorCode: "raw API diagnostic" }),
+      PromotionContractError
+    );
+  });
+});

--- a/test/promotionProvider.test.js
+++ b/test/promotionProvider.test.js
@@ -2,185 +2,768 @@ const assert = require("assert");
 const { PromotionProvider } = require("../views/promotionProvider");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
-suite("PromotionProvider typed transport", () => {
-  function createProvider() {
-    const provider = new PromotionProvider({
-      secrets: {
-        async get() {
-          return "candidate-key";
-        },
-      },
-    });
-    provider.getTagTemplates = () => ({ onPromote: [], onReceive: [] });
-    return provider;
+suite("Safe package promotion workflow", () => {
+  function deferred() {
+    let resolve;
+    const promise = new Promise(settle => { resolve = settle; });
+    return { promise, resolve };
   }
 
-  test("copy write is dispatched once and preserves ambiguous-outcome errors", async () => {
-    const provider = createProvider();
-    let postCalls = 0;
-    provider.api = {
-      async get() {
-        return apiSuccess({
-          name: "artifact",
-          version: "1.0.0",
-          format: "npm",
-          slug_perm: "artifact-id",
-        });
+  function page(data, options = {}) {
+    const pageNumber = options.page || 1;
+    const pageTotal = options.pageTotal || 1;
+    return apiSuccess(data, {
+      headers: options.malformedHeaders ? {} : {
+        "x-pagination-page": String(pageNumber),
+        "x-pagination-pagetotal": String(pageTotal),
+        "x-pagination-count": String(options.count ?? data.length),
+        "x-pagination-pagesize": String(options.pageSize || 100),
       },
-      async post(_endpoint, _json, options) {
-        postCalls += 1;
-        assert.strictEqual(options.responseType, "object");
-        return apiFailure("server_error", {
-          status: 503,
-          outcomeUnknown: true,
-          message: "The request may have completed in Cloudsmith. Check the remote state before trying again.",
-        });
+    });
+  }
+
+  function createHarness(options = {}) {
+    const calls = { get: [], post: [], quickPick: [], warning: [], info: [], error: [], progress: [] };
+    const sourceTags = new Set(options.sourceTags || []);
+    const targetTags = new Set(options.targetTags || []);
+    let targetExists = options.targetExists === true;
+    let targetQueryCount = 0;
+    let sourceReadCount = 0;
+    let state = {
+      activationId: "activation-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    const manager = {
+      getState() { return { ...state }; },
+      changeAccount() {
+        state = { activationId: "activation-b", accountEpoch: 2, sessionConnected: true };
       },
     };
 
-    const result = await provider.promote(
-      "workspace",
-      "source",
-      "artifact-id",
-      "target"
-    );
-
-    assert.strictEqual(result.success, false);
-    assert.strictEqual(result.error.outcomeUnknown, true);
-    assert.strictEqual(postCalls, 1);
-  });
-
-  test("malformed successful write responses cannot be reported as promotion success", async () => {
-    const provider = createProvider();
-    let postCalls = 0;
-    provider.api = {
-      async get() {
-        return apiSuccess({ name: "artifact", version: "1.0.0", format: "npm" });
-      },
-      async post() {
-        postCalls += 1;
-        return apiFailure("invalid_response", {
-          status: 200,
-          outcomeUnknown: true,
-          message: "The request may have completed in Cloudsmith. Check the remote state before trying again.",
-        });
-      },
-    };
-
-    const result = await provider.promote(
-      "workspace",
-      "source",
-      "artifact-id",
-      "target"
-    );
-
-    assert.strictEqual(result.success, false);
-    assert.strictEqual(result.error.kind, "invalid_response");
-    assert.strictEqual(result.error.outcomeUnknown, true);
-    assert.strictEqual(postCalls, 1);
-  });
-
-  test("promotion status keeps transport failure distinct from package absence", async () => {
-    const provider = createProvider();
-    provider.getPipeline = () => ["dev", "production"];
-    provider.api = {
-      async get() {
-        return apiFailure("rate_limited", { status: 429, retryable: true });
-      },
-    };
-
-    const result = await provider.getPromotionStatus(
-      "workspace",
-      "artifact",
-      "1.0.0",
-      "npm"
-    );
-
-    assert.deepStrictEqual(result.items, []);
-    assert.strictEqual(result.error.kind, "rate_limited");
-  });
-
-  test("promotion status filters same-name versions by exact format", async () => {
-    const provider = createProvider();
-    provider.getPipeline = () => ["dev"];
-    provider.api = {
-      async get() {
-        return apiSuccess([
-          { name: "artifact", version: "1.0.0", format: "python", repository: "dev", status_str: "Quarantined" },
-          { name: "artifact", version: "1.0.0", format: "npm", repository: "dev", status_str: "Completed" },
-        ]);
-      },
-    };
-
-    const result = await provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");
-
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.items[0].found, true);
-    assert.strictEqual(result.items[0].status, "Completed");
-  });
-
-  test("a validated copy response completes without retrying or tagging", async () => {
-    const provider = createProvider();
-    let postCalls = 0;
-    provider.api = {
-      async get() {
-        return apiSuccess({ name: "artifact", version: "1.0.0", format: "npm" });
-      },
-      async post() {
-        postCalls += 1;
-        return apiSuccess({
-          name: "artifact",
-          version: "1.0.0",
-          format: "npm",
-          repository: "target",
-          slug_perm: "copied-id",
-        });
-      },
-    };
-
-    const result = await provider.promote(
-      "workspace",
-      "source",
-      "artifact-id",
-      "target"
-    );
-
-    assert.deepStrictEqual(result, { success: true, error: null });
-    assert.strictEqual(postCalls, 1);
-  });
-
-  test("copy and tag validators require usable package identities and identifiers", async () => {
-    const provider = createProvider();
-    const validPackage = {
+    const sourceRecord = (overrides = {}) => ({
+      namespace: "workspace",
+      repository: "source",
+      slug_perm: "source-package-id",
       name: "artifact",
       version: "1.0.0",
       format: "npm",
+      is_copyable: true,
+      checksum_sha256: "checksum-a",
+      tags: { info: [...sourceTags] },
+      ...overrides,
+    });
+    const targetRecord = (overrides = {}) => ({
+      namespace: "workspace",
       repository: "target",
-      slug_perm: "copied-id",
-    };
-    let copyValidated = false;
-    let tagValidated = false;
-    provider.api = {
-      async get() {
-        return apiSuccess(validPackage);
-      },
-      async post(endpoint, _json, options) {
-        assert.strictEqual(options.validate({}), false);
-        assert.strictEqual(options.validate(validPackage), true);
-        if (endpoint.endsWith("/copy/")) {
-          copyValidated = true;
-          return apiSuccess(validPackage);
+      slug_perm: "target-package-id",
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+      checksum_sha256: "checksum-a",
+      tags: { info: [...targetTags] },
+      status_str: "Completed",
+      ...overrides,
+    });
+
+    const api = {
+      async get(endpoint, requestOptions) {
+        calls.get.push({ endpoint, options: requestOptions });
+        if (requestOptions?.cancellationToken?.isCancellationRequested) {
+          return apiFailure("cancelled", { outcomeUnknown: false });
         }
-        tagValidated = true;
-        return apiSuccess(validPackage);
+        if (endpoint === "packages/workspace/source/source-package-id/") {
+          sourceReadCount += 1;
+          if (options.sourceFailureAt === sourceReadCount) {
+            return apiFailure(options.sourceFailureKind || "not_found", {
+              status: options.sourceFailureStatus ?? 404,
+              outcomeUnknown: false,
+            });
+          }
+          const overrides = typeof options.sourceOverrides === "function"
+            ? options.sourceOverrides(sourceReadCount)
+            : options.sourceOverrides || {};
+          return apiSuccess(sourceRecord(overrides));
+        }
+        if (endpoint === "repos/workspace/target/") {
+          if (options.targetRepositoryFailure) {
+            return apiFailure("forbidden", { status: 403, outcomeUnknown: false });
+          }
+          return apiSuccess({ name: "Target", slug: "target", namespace: "workspace" });
+        }
+        if (endpoint.startsWith("packages/workspace/target/?")) {
+          targetQueryCount += 1;
+          if (options.targetQueryFailureAt === targetQueryCount) {
+            return apiFailure("network_error", { outcomeUnknown: false });
+          }
+          if (options.malformedPaginationAt === targetQueryCount) {
+            return page([], { malformedHeaders: true });
+          }
+          if (options.targetAppearsOnQuery === targetQueryCount) targetExists = true;
+          const data = targetExists ? [targetRecord()] : [];
+          if (options.duplicateTargetAt === targetQueryCount && targetExists) {
+            data.push(targetRecord({ slug_perm: "second-target-package-id" }));
+          }
+          const result = page(data, {
+            pageTotal: options.targetPageTotalAt === targetQueryCount ? 21 : 1,
+            count: options.targetPageTotalAt === targetQueryCount ? 2100 : data.length,
+          });
+          if (options.cancelPreflightAfterReads && requestOptions?.cancellationToken) {
+            requestOptions.cancellationToken.isCancellationRequested = true;
+          }
+          return result;
+        }
+        if (endpoint.startsWith("packages/workspace/?")) {
+          if (options.presenceHintFailure) {
+            return apiFailure("network_error", { outcomeUnknown: false });
+          }
+          const data = options.hintExists || targetExists ? [targetRecord()] : [];
+          return page(data);
+        }
+        throw new Error(`Unexpected GET ${endpoint}`);
+      },
+      async post(endpoint, json, requestOptions) {
+        calls.post.push({ endpoint, json, options: requestOptions });
+        if (endpoint.endsWith("/copy/")) {
+          if (options.changeAccountAfterCopy) manager.changeAccount();
+          if (options.copyThrows) {
+            if (options.copyCompletesRemotely) targetExists = true;
+            throw new Error("write socket closed");
+          }
+          if (options.copyFailure) {
+            if (options.copyCompletesRemotely) targetExists = true;
+            return apiFailure(options.copyFailureKind || "forbidden", {
+              status: options.copyFailureStatus ?? 403,
+              outcomeUnknown: options.copyAmbiguous === true,
+            });
+          }
+          targetExists = true;
+          if (options.copyMalformedResponse) return apiSuccess({});
+          return apiSuccess(targetRecord(options.copyResponseOverrides));
+        }
+        if (endpoint === "packages/workspace/source/source-package-id/tag/") {
+          if (options.sourceTagFailure) {
+            if (options.sourceTagAppliedRemotely) {
+              for (const tag of json.tags) sourceTags.add(tag);
+            }
+            return apiFailure(options.sourceTagFailureKind || "forbidden", {
+              status: options.sourceTagFailureStatus ?? 403,
+              outcomeUnknown: options.sourceTagAmbiguous === true,
+            });
+          }
+          if (options.sourceTagMalformedResponse) return apiSuccess({});
+          if (options.sourceTagPretendSuccess) return apiSuccess(sourceRecord());
+          for (const tag of json.tags) sourceTags.add(tag);
+          return apiSuccess(sourceRecord());
+        }
+        if (endpoint === "packages/workspace/target/target-package-id/tag/") {
+          if (options.targetTagFailure) {
+            if (options.targetTagAppliedRemotely) {
+              for (const tag of json.tags) targetTags.add(tag);
+            }
+            return apiFailure(options.targetTagFailureKind || "forbidden", {
+              status: options.targetTagFailureStatus ?? 403,
+              outcomeUnknown: options.targetTagAmbiguous === true,
+            });
+          }
+          for (const tag of json.tags) targetTags.add(tag);
+          return apiSuccess(targetRecord(options.targetTagResponseOverrides));
+        }
+        throw new Error(`Unexpected POST ${endpoint}`);
       },
     };
-    provider.getTagTemplates = () => ({ onPromote: ["promoted"], onReceive: [] });
 
-    const result = await provider.promote("workspace", "source", "artifact-id", "target");
+    const confirmation = options.confirmationDeferred;
+    const window = {
+      async withProgress(progressOptions, task) {
+        calls.progress.push(progressOptions);
+        if (
+          options.progressThrowsBeforeExecution
+          && progressOptions.title.startsWith("Promoting ")
+        ) {
+          throw new Error("progress renderer unavailable");
+        }
+        const cancellationToken = {
+          isCancellationRequested: options.cancelPreflight === true
+            && progressOptions.title === "Checking promotion requirements...",
+          onCancellationRequested() { return { dispose() {} }; },
+        };
+        const result = await task({ report() {} }, cancellationToken);
+        if (
+          options.progressThrowsAfterExecution
+          && progressOptions.title.startsWith("Promoting ")
+        ) {
+          throw new Error("progress renderer unavailable");
+        }
+        return result;
+      },
+      async showQuickPick(items) {
+        calls.quickPick.push(items);
+        if (options.cancelTargetSelection) return undefined;
+        return items.find(item => item._target?.repository === "target");
+      },
+      async showWarningMessage(message, dialogOptions, action) {
+        calls.warning.push({ message, options: dialogOptions, action });
+        if (action === "Promote package") {
+          if (options.changeAccountAtConfirmation) manager.changeAccount();
+          if (confirmation) return confirmation.promise;
+          return options.confirm === false ? undefined : "Promote package";
+        }
+        return undefined;
+      },
+      async showInformationMessage(message) { calls.info.push(message); },
+      async showErrorMessage(message) { calls.error.push(message); },
+    };
+    const workspace = {
+      getConfiguration() {
+        return {
+          get(name) {
+            if (name === "promotionPipeline") {
+              return Object.prototype.hasOwnProperty.call(options, "pipeline")
+                ? options.pipeline
+                : [];
+            }
+            if (name === "promotionTags") {
+              return options.tags || { onPromote: [], onReceive: [] };
+            }
+            return undefined;
+          },
+        };
+      },
+    };
+    const repositoryResult = options.repositoryResult || {
+      repositories: [
+        { name: "Source", slug: "source", namespace: "workspace" },
+        { name: "Target", slug: "target", namespace: "workspace" },
+      ],
+      error: null,
+      warning: null,
+      partial: false,
+      stale: false,
+    };
+    const provider = new PromotionProvider({}, {
+      api,
+      connectionManager: manager,
+      credentialManager: { async getApiKey() { return "credential-sentinel"; } },
+      fetchWorkspaceRepositories: async () => repositoryResult,
+      window,
+      workspace,
+      withProgress: window.withProgress,
+      now: () => Date.parse("2026-08-09T12:00:00Z"),
+    });
+    const item = {
+      namespace: "workspace",
+      repository: "source",
+      slug_perm: { id: "Slug", value: "source-package-id" },
+      slug_perm_raw: "source-package-id",
+      name: "stale-display-name",
+      version: { value: "0.0.1" },
+      format: "raw",
+      is_copyable: false,
+    };
+    return {
+      provider,
+      calls,
+      manager,
+      item,
+      sourceRecord,
+      targetRecord,
+      sourceTags,
+      targetTags,
+      targetExists: () => targetExists,
+      targetQueryCount: () => targetQueryCount,
+    };
+  }
 
-    assert.strictEqual(result.success, true);
-    assert.strictEqual(copyValidated, true);
-    assert.strictEqual(tagValidated, true);
+  test("full success uses fresh canonical identity, confirms, writes once per stage, and verifies", async () => {
+    const harness = createHarness({
+      tags: {
+        onPromote: ["promoted-to-{target}", "approved-{date}"],
+        onReceive: ["promoted-from-{source}"],
+      },
+    });
+    let refreshes = 0;
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item, {
+      refresh() { refreshes += 1; },
+    });
+
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(outcome.copy.status, "succeeded");
+    assert.strictEqual(outcome.sourceTag.status, "succeeded");
+    assert.strictEqual(outcome.targetTag.status, "succeeded");
+    assert.strictEqual(outcome.reconciliation.status, "succeeded");
+    assert.strictEqual(outcome.source.name, "artifact");
+    assert.strictEqual(outcome.source.version, "1.0.0");
+    assert.strictEqual(refreshes, 1);
+    assert.strictEqual(harness.provider._recentTargets.length, 1);
+    assert(Object.isFrozen(outcome));
+    assert.deepStrictEqual(harness.calls.post.map(call => call.json), [
+      { destination: "workspace/target", republish: false },
+      { action: "add", tags: ["promoted-to-target", "approved-2026-08-09"] },
+      { action: "add", tags: ["promoted-from-source"] },
+    ]);
+    assert(harness.calls.post.every(call => call.options.retry === "never"));
+    const confirmation = harness.calls.warning.find(call => call.action === "Promote package");
+    assert(confirmation.message.includes("artifact"));
+    assert(confirmation.options.detail.includes("Version: 1.0.0"));
+    assert(confirmation.options.detail.includes("Source: workspace/source"));
+    assert(confirmation.options.detail.includes("Target: workspace/target"));
+    assert(confirmation.options.detail.includes("Target package: Not present"));
+    assert(confirmation.options.detail.includes("Cloudsmith verifies this when promotion begins"));
+    assert.strictEqual(harness.calls.info.length, 1);
+    assert.strictEqual(
+      harness.calls.progress.find(entry => entry.title.startsWith("Promoting ")).cancellable,
+      false
+    );
+  });
+
+  test("no configured tags is a verified full success without tag writes", async () => {
+    const harness = createHarness();
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(outcome.sourceTag.status, "not_required");
+    assert.strictEqual(outcome.targetTag.status, "not_required");
+    assert.strictEqual(harness.calls.post.length, 1);
+  });
+
+  test("cancellation at target selection, preflight, or confirmation performs no writes", async () => {
+    for (const options of [
+      { cancelTargetSelection: true },
+      { cancelPreflight: true },
+      { cancelPreflightAfterReads: true },
+      { confirm: false },
+    ]) {
+      const harness = createHarness(options);
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "cancelled");
+      assert.strictEqual(harness.calls.post.length, 0);
+    }
+  });
+
+  test("no write occurs while final confirmation is pending", async () => {
+    const gate = deferred();
+    const harness = createHarness({ confirmationDeferred: gate });
+    const pending = harness.provider.runPromotionWorkflow(harness.item);
+    for (let attempt = 0; attempt < 20 && harness.calls.warning.length === 0; attempt += 1) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.strictEqual(harness.calls.post.length, 0);
+    gate.resolve(undefined);
+    const outcome = await pending;
+    assert.strictEqual(outcome.overall, "cancelled");
+    assert.strictEqual(harness.calls.post.length, 0);
+  });
+
+  test("fresh non-copyable, missing, malformed, and identity-changed packages stop before writes", async () => {
+    const cases = [
+      { sourceOverrides: { is_copyable: false }, expected: "package_not_copyable" },
+      { sourceFailureAt: 1, expected: "source_missing" },
+      { sourceOverrides: { is_copyable: "false" }, expected: "malformed_copyability" },
+      { sourceOverrides: { slug_perm: "different" }, expected: "source_identity_changed" },
+      { sourceOverrides: { checksum_sha256: null, version_digest: null }, expected: "missing_package_fingerprint" },
+    ];
+    for (const testCase of cases) {
+      const harness = createHarness(testCase);
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.errorCode, testCase.expected);
+      assert.strictEqual(harness.calls.post.length, 0);
+    }
+  });
+
+  test("target existence hint and fresh target race both block before copy", async () => {
+    const hinted = createHarness({ targetExists: true });
+    const hintedOutcome = await hinted.provider.runPromotionWorkflow(hinted.item);
+    assert.strictEqual(hintedOutcome.errorCode, "target_package_exists");
+    assert.strictEqual(hinted.calls.post.length, 0);
+    assert.strictEqual(hinted.calls.warning.some(call => call.action === "Promote package"), false);
+    assert(hinted.calls.quickPick[0].find(item => item._target.repository === "target").detail.includes("unavailable"));
+
+    const raced = createHarness({ presenceHintFailure: true, targetAppearsOnQuery: 1 });
+    const racedOutcome = await raced.provider.runPromotionWorkflow(raced.item);
+    assert.strictEqual(racedOutcome.errorCode, "target_package_exists");
+    assert.strictEqual(raced.calls.post.length, 0);
+  });
+
+  test("missing target, permission failure, partial repository enumeration, and malformed pagination fail closed", async () => {
+    const cases = [
+      { targetRepositoryFailure: true },
+      { repositoryResult: { repositories: [], error: null, warning: {}, partial: true, stale: false } },
+      { malformedPaginationAt: 1 },
+      { targetPageTotalAt: 1 },
+    ];
+    for (const options of cases) {
+      const harness = createHarness({ ...options, presenceHintFailure: true });
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "failed");
+      assert.strictEqual(harness.calls.post.length, 0);
+    }
+  });
+
+  test("post-confirmation target drift invalidates approval before every write", async () => {
+    const harness = createHarness({ presenceHintFailure: true, targetAppearsOnQuery: 2 });
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(outcome.errorCode, "preflight_changed");
+    assert.strictEqual(harness.calls.post.length, 0);
+    assert.strictEqual(harness.calls.warning.filter(call => call.action === "Promote package").length, 1);
+  });
+
+  test("definite copy failure is complete failure and never attempts tags or refresh", async () => {
+    const harness = createHarness({
+      copyFailure: true,
+      tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+    });
+    let refreshes = 0;
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item, {
+      refresh() { refreshes += 1; },
+    });
+    assert.strictEqual(outcome.overall, "failed");
+    assert.strictEqual(outcome.copy.status, "failed");
+    assert.strictEqual(harness.calls.post.length, 1);
+    assert.strictEqual(refreshes, 0);
+    assert.strictEqual(harness.calls.info.length, 0);
+  });
+
+  test("ambiguous copy is read back once but never attributed as success or tagged", async () => {
+    for (const completesRemotely of [false, true]) {
+      const harness = createHarness({
+        copyFailure: true,
+        copyAmbiguous: true,
+        copyFailureKind: "timeout",
+        copyFailureStatus: null,
+        copyCompletesRemotely: completesRemotely,
+        tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+      });
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "ambiguous");
+      assert.strictEqual(outcome.copy.status, "ambiguous");
+      assert.strictEqual(outcome.reconciliation.status, completesRemotely ? "succeeded" : "ambiguous");
+      assert.strictEqual(harness.calls.post.length, 1);
+      assert.strictEqual(harness.calls.info.length, 0);
+    }
+  });
+
+  test("thrown or malformed copy completion is ambiguous and never blindly retried", async () => {
+    for (const options of [
+      { copyThrows: true, copyCompletesRemotely: true },
+      { copyMalformedResponse: true },
+    ]) {
+      const harness = createHarness(options);
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "ambiguous");
+      assert.strictEqual(outcome.copy.status, "ambiguous");
+      assert.strictEqual(harness.calls.post.filter(call => call.endpoint.endsWith("/copy/")).length, 1);
+    }
+  });
+
+  test("post-copy duplicate or unreadable target state stops before all tag writes", async () => {
+    for (const options of [
+      { duplicateTargetAt: 3 },
+      { targetQueryFailureAt: 3 },
+    ]) {
+      const harness = createHarness({
+        ...options,
+        tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+      });
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "ambiguous");
+      assert.strictEqual(outcome.copy.status, "succeeded");
+      assert.strictEqual(outcome.sourceTag.status, "not_attempted");
+      assert.strictEqual(outcome.targetTag.status, "not_attempted");
+      assert.strictEqual(harness.calls.post.length, 1);
+    }
+  });
+
+  test("source and target tag failures are independent and partial never becomes success", async () => {
+    const variants = [
+      { sourceTagFailure: true, expectedSource: "failed", expectedTarget: "succeeded" },
+      { targetTagFailure: true, expectedSource: "succeeded", expectedTarget: "failed" },
+      { sourceTagFailure: true, targetTagFailure: true, expectedSource: "failed", expectedTarget: "failed" },
+    ];
+    for (const variant of variants) {
+      const harness = createHarness({
+        ...variant,
+        tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+      });
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "partial");
+      assert.strictEqual(outcome.sourceTag.status, variant.expectedSource);
+      assert.strictEqual(outcome.targetTag.status, variant.expectedTarget);
+      assert.strictEqual(harness.calls.post.length, 3);
+      assert.strictEqual(harness.calls.info.length, 0);
+      assert.strictEqual(harness.provider._recentTargets.length, 0);
+    }
+  });
+
+  test("an ambiguous tag becomes success only when final reads observe every requested tag", async () => {
+    const reconciled = createHarness({
+      sourceTagFailure: true,
+      sourceTagAmbiguous: true,
+      sourceTagFailureKind: "timeout",
+      sourceTagFailureStatus: null,
+      sourceTagAppliedRemotely: true,
+      tags: { onPromote: ["source-tag"], onReceive: [] },
+    });
+    const reconciledOutcome = await reconciled.provider.runPromotionWorkflow(reconciled.item);
+    assert.strictEqual(reconciledOutcome.overall, "succeeded");
+    assert.strictEqual(reconciledOutcome.sourceTag.status, "succeeded");
+    assert.strictEqual(reconciledOutcome.sourceTag.evidence, "fresh_read");
+
+    const unresolved = createHarness({
+      sourceTagFailure: true,
+      sourceTagAmbiguous: true,
+      sourceTagFailureKind: "timeout",
+      sourceTagFailureStatus: null,
+      tags: { onPromote: ["source-tag"], onReceive: [] },
+    });
+    const unresolvedOutcome = await unresolved.provider.runPromotionWorkflow(unresolved.item);
+    assert.strictEqual(unresolvedOutcome.overall, "ambiguous");
+    assert.strictEqual(unresolvedOutcome.sourceTag.status, "ambiguous");
+  });
+
+  test("malformed or contradictory successful tag responses remain ambiguous until verified", async () => {
+    for (const options of [
+      { sourceTagMalformedResponse: true },
+      { sourceTagPretendSuccess: true },
+    ]) {
+      const harness = createHarness({
+        ...options,
+        tags: { onPromote: ["source-tag"], onReceive: [] },
+      });
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "ambiguous");
+      assert.strictEqual(outcome.sourceTag.status, "ambiguous");
+      assert.strictEqual(harness.calls.info.length, 0);
+    }
+  });
+
+  test("a failed mandatory final read prevents full success", async () => {
+    const harness = createHarness({ targetQueryFailureAt: 4 });
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(outcome.overall, "ambiguous");
+    assert.strictEqual(outcome.copy.status, "succeeded");
+    assert.strictEqual(outcome.reconciliation.status, "ambiguous");
+    assert.strictEqual(harness.calls.info.length, 0);
+  });
+
+  test("pre-existing tags are proven by fresh reads and not written again", async () => {
+    const harness = createHarness({
+      sourceTags: ["source-tag"],
+      targetTags: ["target-tag"],
+      tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+    });
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(outcome.sourceTag.status, "not_required");
+    assert.strictEqual(outcome.targetTag.status, "not_required");
+    assert.strictEqual(harness.calls.post.length, 1);
+  });
+
+  test("manual retry after ambiguous copy performs reads only and cannot duplicate copy", async () => {
+    const harness = createHarness({
+      copyFailure: true,
+      copyAmbiguous: true,
+      copyFailureKind: "timeout",
+      copyFailureStatus: null,
+      copyCompletesRemotely: true,
+    });
+    const first = await harness.provider.runPromotionWorkflow(harness.item);
+    const second = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(first.overall, "ambiguous");
+    assert.strictEqual(second.errorCode, "target_package_exists");
+    assert.strictEqual(harness.calls.post.filter(call => call.endpoint.endsWith("/copy/")).length, 1);
+  });
+
+  test("duplicate invocation is rejected while confirmation is active and guard cleans up", async () => {
+    const gate = deferred();
+    const harness = createHarness({ confirmationDeferred: gate });
+    const firstPending = harness.provider.runPromotionWorkflow(harness.item);
+    for (let attempt = 0; attempt < 20 && harness.calls.warning.length === 0; attempt += 1) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    const duplicate = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(duplicate.errorCode, "promotion_busy");
+    assert.strictEqual(harness.calls.post.length, 0);
+    gate.resolve(undefined);
+    await firstPending;
+
+    const later = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(later.overall, "cancelled");
+    assert.strictEqual(harness.calls.quickPick.length, 2);
+  });
+
+  test("result publication completes before the operation guard is released", async () => {
+    const refreshGate = deferred();
+    const harness = createHarness();
+    const firstPending = harness.provider.runPromotionWorkflow(harness.item, {
+      refresh: () => refreshGate.promise,
+    });
+    for (let attempt = 0; attempt < 30 && harness.calls.post.length === 0; attempt += 1) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    const duplicate = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(duplicate.errorCode, "promotion_busy");
+    refreshGate.resolve();
+    assert.strictEqual((await firstPending).overall, "succeeded");
+  });
+
+  test("account change during awaited refresh suppresses stale package result details", async () => {
+    const refreshGate = deferred();
+    const harness = createHarness();
+    const pending = harness.provider.runPromotionWorkflow(harness.item, {
+      refresh: () => refreshGate.promise,
+    });
+    for (let attempt = 0; attempt < 30 && harness.calls.post.length === 0; attempt += 1) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    const warningCountBeforeAccountChange = harness.calls.warning.length;
+    harness.manager.changeAccount();
+    refreshGate.resolve();
+
+    const outcome = await pending;
+
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(harness.calls.info.length, 0);
+    const laterWarnings = harness.calls.warning.slice(warningCountBeforeAccountChange);
+    assert(laterWarnings.some(call => (
+      call.message.includes("active Cloudsmith account changed")
+    )));
+    assert.strictEqual(laterWarnings.some(call => call.message.includes("artifact")), false);
+  });
+
+  test("account change before dispatch prevents writes", async () => {
+    const harness = createHarness({ changeAccountAtConfirmation: true });
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    assert.strictEqual(outcome.errorCode, "account_changed");
+    assert.strictEqual(harness.calls.post.length, 0);
+  });
+
+  test("account change after copy suppresses later writes and stale package publication", async () => {
+    const harness = createHarness({
+      changeAccountAfterCopy: true,
+      tags: { onPromote: ["source-tag"], onReceive: ["target-tag"] },
+    });
+    let refreshes = 0;
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item, {
+      refresh() { refreshes += 1; },
+    });
+    assert.strictEqual(outcome.overall, "ambiguous");
+    assert.strictEqual(harness.calls.post.length, 1);
+    assert.strictEqual(refreshes, 0);
+    assert.strictEqual(harness.calls.info.length, 0);
+    assert(harness.calls.warning.some(call => call.message.includes("active Cloudsmith account changed")));
+  });
+
+  test("pipeline and tag configuration are validated before confirmation or writes", async () => {
+    for (const options of [
+      { pipeline: ["source", "source"] },
+      { pipeline: "source" },
+      { pipeline: { source: "target" } },
+      { pipeline: null },
+      { pipeline: ["source", "missing"] },
+      { pipeline: ["target"] },
+      { tags: { onPromote: ["{unknown}"], onReceive: [] } },
+    ]) {
+      const harness = createHarness(options);
+      const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+      assert.strictEqual(outcome.overall, "failed");
+      assert.strictEqual(harness.calls.post.length, 0);
+    }
+  });
+
+  test("target tag write evidence requires the expected target package identifier", async () => {
+    const harness = createHarness({
+      targetTagResponseOverrides: { slug_perm: "different-target-package-id" },
+      tags: { onPromote: [], onReceive: ["target-tag"] },
+    });
+
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(outcome.targetTag.status, "succeeded");
+    assert.strictEqual(outcome.targetTag.evidence, "fresh_read");
+  });
+
+  test("final reads can reconcile an unattempted tag verification failure", async () => {
+    const harness = createHarness({
+      sourceTags: ["source-tag"],
+      sourceFailureAt: 4,
+      sourceFailureKind: "network_error",
+      sourceFailureStatus: null,
+      tags: { onPromote: ["source-tag"], onReceive: [] },
+    });
+
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+
+    assert.strictEqual(outcome.overall, "succeeded");
+    assert.strictEqual(outcome.sourceTag.status, "succeeded");
+    assert.strictEqual(outcome.sourceTag.attempted, false);
+    assert.strictEqual(outcome.sourceTag.evidence, "fresh_read");
+    assert.strictEqual(harness.calls.post.length, 1);
+  });
+
+  test("recent target ranking is scoped to the canonical package identifier", () => {
+    const harness = createHarness();
+    harness.provider._recentTargets.push({
+      activationId: "activation-a",
+      accountEpoch: 1,
+      workspace: "workspace",
+      sourceRepository: "source",
+      packageIdentifier: "another-package-id",
+      targetRepository: "target",
+    });
+
+    assert.deepStrictEqual(harness.provider._recentFor(
+      { activationId: "activation-a", accountEpoch: 1 },
+      { workspace: "workspace", repository: "source", packageIdentifier: "source-package-id" }
+    ), []);
+  });
+
+  test("progress failures preserve whether a write was issued and any settled outcome", async () => {
+    const beforeExecution = createHarness({ progressThrowsBeforeExecution: true });
+    const beforeOutcome = await beforeExecution.provider.runPromotionWorkflow(beforeExecution.item);
+    assert.strictEqual(beforeOutcome.overall, "failed");
+    assert.strictEqual(beforeOutcome.copy.status, "not_attempted");
+    assert.strictEqual(beforeOutcome.remoteState, "unchanged");
+    assert.strictEqual(beforeExecution.calls.post.length, 0);
+
+    const afterExecution = createHarness({ progressThrowsAfterExecution: true });
+    const afterOutcome = await afterExecution.provider.runPromotionWorkflow(afterExecution.item);
+    assert.strictEqual(afterOutcome.overall, "succeeded");
+    assert.strictEqual(afterOutcome.copy.status, "succeeded");
+    assert.strictEqual(afterExecution.calls.post.length, 1);
+  });
+
+  test("credentials and raw API diagnostics never enter outcomes or user messages", async () => {
+    const harness = createHarness({ copyFailure: true });
+    const outcome = await harness.provider.runPromotionWorkflow(harness.item);
+    const serialized = JSON.stringify({
+      outcome,
+      warning: harness.calls.warning,
+      info: harness.calls.info,
+      error: harness.calls.error,
+    });
+    assert.strictEqual(serialized.includes("credential-sentinel"), false);
+    assert.strictEqual(serialized.includes("Test forbidden failure"), false);
+  });
+
+  test("promotion status retains typed transport failure and exact format filtering", async () => {
+    const failed = createHarness({ pipeline: ["source", "target"] });
+    failed.provider.api = { async get() { return apiFailure("rate_limited", { status: 429 }); } };
+    const failure = await failed.provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");
+    assert.deepStrictEqual(failure.items, []);
+    assert.strictEqual(failure.error.kind, "rate_limited");
+
+    const filtered = createHarness({ pipeline: ["source", "target"] });
+    filtered.provider.api = {
+      async get() {
+        return apiSuccess([
+          { name: "artifact", version: "1.0.0", format: "python", repository: "source" },
+          { name: "artifact", version: "1.0.0", format: "npm", repository: "source", status_str: "Completed" },
+        ]);
+      },
+    };
+    const status = await filtered.provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");
+    assert.strictEqual(status.items[0].found, true);
+    assert.strictEqual(status.items[0].status, "Completed");
   });
 });

--- a/test/recentPackages.test.js
+++ b/test/recentPackages.test.js
@@ -64,4 +64,49 @@ suite("RecentPackages Test Suite", () => {
     assert.strictEqual(all[0].namespace, "workspace-b");
     assert.strictEqual(all[1].namespace, "workspace-a");
   });
+
+  test("add() derives compatible identity aliases from one canonical value", () => {
+    recentPackages.add({
+      name: "artifact",
+      format: "npm",
+      version: "1.0.0",
+      namespace: "workspace",
+      cloudsmithWorkspace: "workspace",
+      repository: "source",
+      cloudsmithRepo: "source",
+      slug_perm: { value: "package-id" },
+      slug_perm_raw: "package-id",
+      is_copyable: true,
+    });
+
+    const [stored] = recentPackages.getAll();
+    assert.strictEqual(stored.namespace, "workspace");
+    assert.strictEqual(stored.cloudsmithWorkspace, "workspace");
+    assert.strictEqual(stored.repository, "source");
+    assert.strictEqual(stored.cloudsmithRepo, "source");
+    assert.strictEqual(stored.slug_perm, "package-id");
+    assert.strictEqual(stored.slug_perm_raw, "package-id");
+    assert.strictEqual(stored.is_copyable, true);
+  });
+
+  test("add() cannot persist contradictory or malformed package aliases as trusted identity", () => {
+    recentPackages.add({
+      name: "artifact",
+      format: "npm",
+      version: "1.0.0",
+      namespace: "workspace",
+      cloudsmithWorkspace: "other-workspace",
+      repository: "source",
+      slug_perm: { value: {} },
+      slug_perm_raw: "package-id",
+      is_copyable: "false",
+    });
+
+    const [stored] = recentPackages.getAll();
+    assert.strictEqual(stored.namespace, null);
+    assert.strictEqual(stored.cloudsmithWorkspace, null);
+    assert.strictEqual(stored.slug_perm, null);
+    assert.strictEqual(stored.slug_perm_raw, null);
+    assert.strictEqual(stored.is_copyable, null);
+  });
 });

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -56,6 +56,7 @@ suite("SearchProvider atomic search state", () => {
 
   test("canonicalizes every retained field without freezing the API response", async () => {
     const responsePackage = pkg("artifact", {
+      is_copyable: true,
       tags: { info: ["upstream"], nested: { source: "api" } },
       license: "MIT",
       licenseInfo: { metadata: { label: "caller-owned", nested: { secret: true } } },
@@ -89,6 +90,7 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(committedNode.max_severity, null);
     assert.strictEqual(committedNode.vulnerability_scan_results_url, null);
     assert.strictEqual(committedNode.cdn_url, null);
+    assert.strictEqual(committedNode.is_copyable, true);
     assert.strictEqual(Object.isFrozen(responsePackage), false);
     assert.strictEqual(Object.isFrozen(responsePackage.tags), false);
     assert.strictEqual(Object.isFrozen(responsePackage.tags.info), false);

--- a/test/workspaceRepositoryFetcher.test.js
+++ b/test/workspaceRepositoryFetcher.test.js
@@ -202,6 +202,25 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
     );
   });
 
+  test("returns partial state when a short page contradicts authoritative later pages", async () => {
+    let calls = 0;
+    PaginatedFetch.prototype.fetchPage = async () => {
+      calls += 1;
+      return {
+        data: [{ name: "repo-a", slug: "repo-a" }],
+        pagination: { page: 1, pageTotal: 2, count: 2, pageSize: 2 },
+      };
+    };
+
+    const result = await fetchRepositories();
+
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.warning.kind, "pagination_incomplete");
+    assert.deepStrictEqual(result.repositories, [{ name: "repo-a", slug: "repo-a" }]);
+  });
+
   test("returns an error when the first page fails", async () => {
     const failure = apiFailure("server_error", {
       status: 500,
@@ -335,5 +354,23 @@ suite("WorkspaceRepositoryFetcher Test Suite", () => {
     assert.strictEqual(result.stale, true);
     assert.deepStrictEqual(result.repositories, []);
     assert.strictEqual(result.error.kind, "stale_account");
+  });
+
+  test("returns partial state instead of looping beyond the repository page ceiling", async () => {
+    let calls = 0;
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
+      calls += 1;
+      return {
+        data: [{ name: `repo-${page}`, slug: `repo-${page}` }],
+        pagination: { page, pageTotal: 21, count: 21, pageSize: 1 },
+      };
+    };
+
+    const result = await fetchRepositories();
+
+    assert.strictEqual(calls, workspaceRepositoryFetcher.MAX_WORKSPACE_REPOSITORY_PAGES);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.repositories.length, workspaceRepositoryFetcher.MAX_WORKSPACE_REPOSITORY_PAGES);
+    assert.strictEqual(result.warning.kind, "pagination_limit");
   });
 });

--- a/util/paginatedFetch.js
+++ b/util/paginatedFetch.js
@@ -36,13 +36,17 @@ class PaginatedFetch {
             };
         }
 
-        const result = await this.api.get(url, {
+        const requestOptions = {
             responseType: "array",
             validate: typeof options.validate === "function" ? options.validate : isRecordArray,
             retry: options.retry || "never",
             signal: options.signal,
             cancellationToken: options.cancellationToken,
-        });
+        };
+        if (Object.prototype.hasOwnProperty.call(options, "apiKey")) {
+            requestOptions.apiKey = options.apiKey;
+        }
+        const result = await this.api.get(url, requestOptions);
 
         if (!result.ok) {
             return {

--- a/util/promotionContracts.js
+++ b/util/promotionContracts.js
@@ -1,0 +1,583 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const { encodeApiPathSegment } = require("./apiEndpoint");
+
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const DISPLAY_CONTROL_PATTERN = /[\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
+const ENCODED_SEPARATOR_PATTERN = /%(?:2f|5c)/i;
+const UNKNOWN_PLACEHOLDER_PATTERN = /\{[^{}]*\}/;
+const MAX_WORKSPACE_LENGTH = 256;
+const MAX_REPOSITORY_LENGTH = 256;
+const MAX_PACKAGE_IDENTIFIER_LENGTH = 512;
+const MAX_PACKAGE_NAME_LENGTH = 512;
+const MAX_PACKAGE_VERSION_LENGTH = 512;
+const MAX_PACKAGE_FORMAT_LENGTH = 64;
+const MAX_FINGERPRINT_LENGTH = 1024;
+const MAX_PIPELINE_STAGES = 50;
+const MAX_TAGS_PER_STAGE = 20;
+const MAX_PACKAGE_TAGS = 1000;
+const MAX_TAG_TEMPLATE_LENGTH = 256;
+const MAX_TAG_LENGTH = 256;
+const STAGE_STATUSES = new Set([
+  "not_attempted",
+  "not_required",
+  "succeeded",
+  "failed",
+  "ambiguous",
+  "cancelled",
+]);
+const OVERALL_STATUSES = new Set(["succeeded", "failed", "partial", "ambiguous", "cancelled"]);
+const REMOTE_STATES = new Set(["unchanged", "changed", "possibly_changed", "present"]);
+const EVIDENCE_VALUES = new Set([
+  "none",
+  "fresh_read",
+  "write_response",
+  "write_dispatched",
+  "malformed_write_response",
+  "target_state_only",
+  "user_confirmation",
+]);
+
+const DEFAULT_TAG_TEMPLATES = Object.freeze({
+  onPromote: Object.freeze(["promoted-to-{target}", "approved-{date}"]),
+  onReceive: Object.freeze(["promoted-from-{source}"]),
+});
+
+class PromotionContractError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = "PromotionContractError";
+    this.code = code;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function unwrapLegacyValue(value) {
+  let current = value;
+  for (let depth = 0; depth < 2; depth += 1) {
+    if (!isRecord(current) || !Object.prototype.hasOwnProperty.call(current, "value")) break;
+    current = current.value;
+  }
+  if (isRecord(current)) throw new PromotionContractError("malformed_source_locator");
+  return current;
+}
+
+function scalarString(value, maximumLength, code, options = {}) {
+  let normalized = value;
+  if (options.allowFiniteNumber && typeof normalized === "number") {
+    if (!Number.isFinite(normalized)) throw new PromotionContractError(code);
+    normalized = String(normalized);
+  }
+  if (
+    typeof normalized !== "string"
+    || normalized.length === 0
+    || normalized.length > maximumLength
+    || normalized !== normalized.trim()
+    || CONTROL_CHARACTER_PATTERN.test(normalized)
+    || DISPLAY_CONTROL_PATTERN.test(normalized)
+  ) {
+    throw new PromotionContractError(code);
+  }
+  return normalized;
+}
+
+function pathIdentity(value, maximumLength, code) {
+  const normalized = scalarString(value, maximumLength, code);
+  if (
+    normalized === "."
+    || normalized === ".."
+    || normalized.includes("/")
+    || normalized.includes("\\")
+    || ENCODED_SEPARATOR_PATTERN.test(normalized)
+  ) {
+    throw new PromotionContractError(code);
+  }
+  try {
+    encodeApiPathSegment(normalized);
+  } catch {
+    throw new PromotionContractError(code);
+  }
+  return normalized;
+}
+
+function collectLegacyAliases(values, normalizer, code) {
+  const normalized = [];
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    let candidate;
+    try {
+      candidate = normalizer(unwrapLegacyValue(value));
+    } catch {
+      throw new PromotionContractError(code);
+    }
+    normalized.push(candidate);
+  }
+  if (normalized.length === 0 || normalized.some(value => value !== normalized[0])) {
+    throw new PromotionContractError(code);
+  }
+  return normalized[0];
+}
+
+function createSourceLocator(item) {
+  if (!isRecord(item)) throw new PromotionContractError("malformed_source_locator");
+  const match = isRecord(item.cloudsmithMatch) ? item.cloudsmithMatch : {};
+  const workspace = collectLegacyAliases(
+    [item.namespace, item.cloudsmithWorkspace, match.namespace],
+    value => pathIdentity(value, MAX_WORKSPACE_LENGTH, "malformed_source_workspace"),
+    "conflicting_source_workspace"
+  );
+  const repository = collectLegacyAliases(
+    [item.repository, item.cloudsmithRepo, match.repository],
+    value => pathIdentity(value, MAX_REPOSITORY_LENGTH, "malformed_source_repository"),
+    "conflicting_source_repository"
+  );
+  const packageIdentifier = collectLegacyAliases(
+    [item.slug_perm, item.slug_perm_raw, match.slug_perm, match.slug_perm_raw],
+    value => pathIdentity(value, MAX_PACKAGE_IDENTIFIER_LENGTH, "malformed_source_identifier"),
+    "conflicting_source_identifier"
+  );
+  return deepFreeze({ workspace, repository, packageIdentifier });
+}
+
+function freshIdentifier(record, code) {
+  const candidates = [];
+  for (const field of ["slug_perm", "slug_perm_raw"]) {
+    if (!Object.prototype.hasOwnProperty.call(record, field) || record[field] == null) continue;
+    candidates.push(pathIdentity(record[field], MAX_PACKAGE_IDENTIFIER_LENGTH, code));
+  }
+  if (candidates.length === 0 || candidates.some(value => value !== candidates[0])) {
+    throw new PromotionContractError(code);
+  }
+  return candidates[0];
+}
+
+function canonicalTags(value) {
+  if (value == null) return Object.freeze([]);
+  if (!isRecord(value)) throw new PromotionContractError("malformed_package_tags");
+  const tags = [];
+  for (const field of ["info", "version"]) {
+    if (!Object.prototype.hasOwnProperty.call(value, field) || value[field] == null) continue;
+    const fieldValue = Array.isArray(value[field]) ? value[field] : [value[field]];
+    for (const tag of fieldValue) {
+      if (tags.length >= MAX_PACKAGE_TAGS) {
+        throw new PromotionContractError("malformed_package_tags");
+      }
+      tags.push(scalarString(tag, MAX_TAG_LENGTH, "malformed_package_tags"));
+    }
+  }
+  return Object.freeze([...new Set(tags)]);
+}
+
+function immutableFingerprint(record) {
+  const checksum = record.checksum_sha256 == null
+    ? null
+    : scalarString(record.checksum_sha256, MAX_FINGERPRINT_LENGTH, "malformed_package_fingerprint");
+  const versionDigest = record.version_digest == null
+    ? null
+    : scalarString(record.version_digest, MAX_FINGERPRINT_LENGTH, "malformed_package_fingerprint");
+  if (!checksum && !versionDigest) throw new PromotionContractError("missing_package_fingerprint");
+  return deepFreeze({ checksum, versionDigest });
+}
+
+function normalizeFreshSource(record, locator) {
+  if (!isRecord(record) || !locator) throw new PromotionContractError("malformed_source_package");
+  const packageIdentifier = freshIdentifier(record, "malformed_source_identifier");
+  const workspace = pathIdentity(record.namespace, MAX_WORKSPACE_LENGTH, "malformed_source_workspace");
+  const repository = pathIdentity(record.repository, MAX_REPOSITORY_LENGTH, "malformed_source_repository");
+  if (
+    packageIdentifier !== locator.packageIdentifier
+    || workspace !== locator.workspace
+    || repository !== locator.repository
+  ) {
+    throw new PromotionContractError("source_identity_changed");
+  }
+  if (typeof record.is_copyable !== "boolean") {
+    throw new PromotionContractError("malformed_copyability");
+  }
+  return deepFreeze({
+    workspace,
+    repository,
+    packageIdentifier,
+    name: scalarString(record.name, MAX_PACKAGE_NAME_LENGTH, "malformed_source_package"),
+    version: scalarString(
+      record.version,
+      MAX_PACKAGE_VERSION_LENGTH,
+      "malformed_source_package",
+      { allowFiniteNumber: true }
+    ),
+    format: scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_source_package"),
+    copyable: record.is_copyable,
+    fingerprint: immutableFingerprint(record),
+    tags: canonicalTags(record.tags),
+  });
+}
+
+function normalizeTargetRepository(record, workspace, selectedRepository) {
+  if (!isRecord(record)) throw new PromotionContractError("malformed_target_repository");
+  const repository = pathIdentity(record.slug, MAX_REPOSITORY_LENGTH, "malformed_target_repository");
+  if (repository !== selectedRepository) throw new PromotionContractError("target_identity_changed");
+  if (record.namespace != null) {
+    const returnedWorkspace = pathIdentity(
+      typeof record.namespace === "string" ? record.namespace : record.namespace.slug,
+      MAX_WORKSPACE_LENGTH,
+      "malformed_target_repository"
+    );
+    if (returnedWorkspace !== workspace) throw new PromotionContractError("target_identity_changed");
+  }
+  return deepFreeze({
+    workspace,
+    repository,
+    name: scalarString(record.name, MAX_REPOSITORY_LENGTH, "malformed_target_repository"),
+  });
+}
+
+function fingerprintsMatch(source, target) {
+  const comparable = [
+    [source.checksum, target.checksum],
+    [source.versionDigest, target.versionDigest],
+  ].filter(([left, right]) => left && right);
+  return comparable.length > 0 && comparable.every(([left, right]) => left === right);
+}
+
+function normalizeTargetPackage(record, source, target) {
+  if (!isRecord(record)) throw new PromotionContractError("malformed_target_package");
+  const workspace = pathIdentity(record.namespace, MAX_WORKSPACE_LENGTH, "malformed_target_package");
+  const repository = pathIdentity(record.repository, MAX_REPOSITORY_LENGTH, "malformed_target_package");
+  const packageIdentifier = freshIdentifier(record, "malformed_target_identifier");
+  const name = scalarString(record.name, MAX_PACKAGE_NAME_LENGTH, "malformed_target_package");
+  const version = scalarString(
+    record.version,
+    MAX_PACKAGE_VERSION_LENGTH,
+    "malformed_target_package",
+    { allowFiniteNumber: true }
+  );
+  const format = scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_target_package");
+  const fingerprint = immutableFingerprint(record);
+  if (
+    workspace !== target.workspace
+    || repository !== target.repository
+    || name !== source.name
+    || version !== source.version
+    || format !== source.format
+    || packageIdentifier === source.packageIdentifier
+    || !fingerprintsMatch(source.fingerprint, fingerprint)
+  ) {
+    throw new PromotionContractError("target_package_identity_mismatch");
+  }
+  return deepFreeze({
+    workspace,
+    repository,
+    packageIdentifier,
+    name,
+    version,
+    format,
+    fingerprint,
+    tags: canonicalTags(record.tags),
+  });
+}
+
+function normalizePipeline(value) {
+  if (value === undefined) return Object.freeze([]);
+  if (!Array.isArray(value) || value.length > MAX_PIPELINE_STAGES) {
+    throw new PromotionContractError("malformed_pipeline");
+  }
+  const pipeline = value.map(stage => pathIdentity(
+    stage,
+    MAX_REPOSITORY_LENGTH,
+    "malformed_pipeline"
+  ));
+  if (new Set(pipeline).size !== pipeline.length) {
+    throw new PromotionContractError("malformed_pipeline");
+  }
+  return Object.freeze(pipeline);
+}
+
+function normalizeTagTemplates(value) {
+  const templates = value == null ? DEFAULT_TAG_TEMPLATES : value;
+  if (!isRecord(templates)) throw new PromotionContractError("malformed_tag_configuration");
+  const normalizeStage = field => {
+    const list = templates[field];
+    if (!Array.isArray(list) || list.length > MAX_TAGS_PER_STAGE) {
+      throw new PromotionContractError("malformed_tag_configuration");
+    }
+    return list.map(template => scalarString(
+      template,
+      MAX_TAG_TEMPLATE_LENGTH,
+      "malformed_tag_configuration"
+    ));
+  };
+  return deepFreeze({ onPromote: normalizeStage("onPromote"), onReceive: normalizeStage("onReceive") });
+}
+
+function expandTag(template, sourceRepository, targetRepository, date) {
+  const expanded = template
+    .replace(/\{source\}/g, sourceRepository)
+    .replace(/\{target\}/g, targetRepository)
+    .replace(/\{date\}/g, date);
+  if (UNKNOWN_PLACEHOLDER_PATTERN.test(expanded)) {
+    throw new PromotionContractError("malformed_tag_configuration");
+  }
+  return scalarString(expanded, MAX_TAG_LENGTH, "malformed_tag_configuration");
+}
+
+function createTagPlan(value, sourceRepository, targetRepository, date) {
+  const templates = normalizeTagTemplates(value);
+  const expandStage = stage => Object.freeze([
+    ...new Set(templates[stage].map(template => (
+      expandTag(template, sourceRepository, targetRepository, date)
+    ))),
+  ]);
+  return deepFreeze({
+    source: expandStage("onPromote"),
+    target: expandStage("onReceive"),
+    date,
+  });
+}
+
+function missingTags(existing, required) {
+  const existingSet = new Set(existing);
+  return Object.freeze(required.filter(tag => !existingSet.has(tag)));
+}
+
+function createStage(status, options = {}) {
+  const evidence = options.evidence === undefined ? "none" : options.evidence;
+  if (
+    !STAGE_STATUSES.has(status)
+    || !EVIDENCE_VALUES.has(evidence)
+    || (Object.prototype.hasOwnProperty.call(options, "required") && typeof options.required !== "boolean")
+    || (Object.prototype.hasOwnProperty.call(options, "attempted") && typeof options.attempted !== "boolean")
+  ) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  return deepFreeze({
+    status,
+    required: options.required === true,
+    attempted: options.attempted === true,
+    evidence,
+    errorCode: safeErrorCode(options.errorCode),
+  });
+}
+
+function createOutcome(value) {
+  if (!isRecord(value) || !OVERALL_STATUSES.has(value.overall)) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const remoteState = value.remoteState === undefined ? "unchanged" : value.remoteState;
+  if (!REMOTE_STATES.has(remoteState)) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const outcome = {
+    source: normalizeOutcomeSource(value.source),
+    target: normalizeOutcomeTarget(value.target),
+    preflight: normalizeOutcomeStage(value.preflight, createStage("not_attempted")),
+    confirmation: normalizeOutcomeStage(value.confirmation, createStage("not_attempted")),
+    copy: normalizeOutcomeStage(value.copy, createStage("not_attempted", { required: true })),
+    sourceTag: normalizeOutcomeStage(value.sourceTag, createStage("not_attempted")),
+    targetTag: normalizeOutcomeStage(value.targetTag, createStage("not_attempted")),
+    reconciliation: normalizeOutcomeStage(value.reconciliation, createStage("not_attempted")),
+    overall: value.overall,
+    errorCode: safeErrorCode(value.errorCode),
+    remoteState,
+  };
+  validateOutcomeAggregation(outcome);
+  return deepFreeze(outcome);
+}
+
+function normalizeOutcomeSource(value) {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value) || typeof value.copyable !== "boolean" || !Array.isArray(value.tags)) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  if (!isRecord(value.fingerprint)) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const checksum = value.fingerprint.checksum == null
+    ? null
+    : scalarString(
+      value.fingerprint.checksum,
+      MAX_FINGERPRINT_LENGTH,
+      "malformed_promotion_outcome"
+    );
+  const versionDigest = value.fingerprint.versionDigest == null
+    ? null
+    : scalarString(
+      value.fingerprint.versionDigest,
+      MAX_FINGERPRINT_LENGTH,
+      "malformed_promotion_outcome"
+    );
+  if (!checksum && !versionDigest) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const fingerprint = deepFreeze({ checksum, versionDigest });
+  if (value.tags.length > MAX_PACKAGE_TAGS) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const tags = value.tags.map(tag => (
+    scalarString(tag, MAX_TAG_LENGTH, "malformed_promotion_outcome")
+  ));
+  return deepFreeze({
+    workspace: pathIdentity(value.workspace, MAX_WORKSPACE_LENGTH, "malformed_promotion_outcome"),
+    repository: pathIdentity(value.repository, MAX_REPOSITORY_LENGTH, "malformed_promotion_outcome"),
+    packageIdentifier: pathIdentity(
+      value.packageIdentifier,
+      MAX_PACKAGE_IDENTIFIER_LENGTH,
+      "malformed_promotion_outcome"
+    ),
+    name: scalarString(value.name, MAX_PACKAGE_NAME_LENGTH, "malformed_promotion_outcome"),
+    version: scalarString(value.version, MAX_PACKAGE_VERSION_LENGTH, "malformed_promotion_outcome"),
+    format: scalarString(value.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_promotion_outcome"),
+    copyable: value.copyable,
+    fingerprint,
+    tags: Object.freeze([...new Set(tags)]),
+  });
+}
+
+function normalizeOutcomeTarget(value) {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value)) throw new PromotionContractError("malformed_promotion_outcome");
+  return deepFreeze({
+    workspace: pathIdentity(value.workspace, MAX_WORKSPACE_LENGTH, "malformed_promotion_outcome"),
+    repository: pathIdentity(value.repository, MAX_REPOSITORY_LENGTH, "malformed_promotion_outcome"),
+    name: scalarString(value.name, MAX_REPOSITORY_LENGTH, "malformed_promotion_outcome"),
+  });
+}
+
+function normalizeOutcomeStage(value, fallback) {
+  if (value === undefined || value === null) return fallback;
+  if (!isRecord(value)) throw new PromotionContractError("malformed_promotion_outcome");
+  if (
+    (Object.prototype.hasOwnProperty.call(value, "required") && typeof value.required !== "boolean")
+    || (Object.prototype.hasOwnProperty.call(value, "attempted") && typeof value.attempted !== "boolean")
+    || (Object.prototype.hasOwnProperty.call(value, "evidence") && typeof value.evidence !== "string")
+  ) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  return createStage(value.status, {
+    required: value.required,
+    attempted: value.attempted,
+    evidence: value.evidence,
+    errorCode: value.errorCode,
+  });
+}
+
+function validateOutcomeAggregation(outcome) {
+  const tagStages = [outcome.sourceTag, outcome.targetTag];
+  const requiredTags = tagStages.filter(stage => stage.required);
+  const remoteStages = [outcome.copy, ...tagStages, outcome.reconciliation];
+  const hasAmbiguous = remoteStages.some(stage => stage.status === "ambiguous");
+  const copySucceeded = outcome.copy.status === "succeeded";
+  const hasWriteIdentity = Boolean(outcome.source && outcome.target);
+  const validAttemptedCopy = !outcome.copy.attempted || (
+    hasWriteIdentity
+    && outcome.source.copyable === true
+    && outcome.source.workspace === outcome.target.workspace
+    && outcome.source.repository !== outcome.target.repository
+    && outcome.copy.required
+    && outcome.preflight.status === "succeeded"
+    && outcome.preflight.evidence === "fresh_read"
+    && outcome.confirmation.status === "succeeded"
+    && outcome.confirmation.evidence === "user_confirmation"
+  );
+  if (!validAttemptedCopy) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  const allTagsComplete = tagStages.every(stage => (
+    stage.status === "succeeded" || stage.status === "not_required"
+  ));
+  const allTagsResolved = tagStages.every(stage => (
+    stage.status === "succeeded" || stage.status === "not_required" || stage.status === "failed"
+  ));
+  let valid = false;
+  if (outcome.overall === "succeeded") {
+    valid = hasWriteIdentity
+      && copySucceeded
+      && outcome.copy.attempted
+      && outcome.reconciliation.status === "succeeded"
+      && allTagsComplete
+      && outcome.remoteState !== "unchanged";
+  } else if (outcome.overall === "partial") {
+    valid = hasWriteIdentity
+      && copySucceeded
+      && outcome.copy.attempted
+      && outcome.reconciliation.status === "succeeded"
+      && requiredTags.some(stage => stage.status === "failed")
+      && allTagsResolved
+      && !hasAmbiguous
+      && outcome.remoteState !== "unchanged";
+  } else if (outcome.overall === "ambiguous") {
+    valid = hasWriteIdentity
+      && hasAmbiguous
+      && outcome.copy.attempted
+      && (outcome.copy.status === "succeeded" || outcome.copy.status === "ambiguous")
+      && outcome.remoteState !== "unchanged";
+  } else if (outcome.overall === "failed") {
+    valid = !copySucceeded
+      && !hasAmbiguous
+      && tagStages.every(stage => (
+        stage.status === "not_attempted" || stage.status === "not_required"
+      ))
+      && outcome.reconciliation.status === "not_attempted"
+      && outcome.remoteState === "unchanged";
+  } else if (outcome.overall === "cancelled") {
+    valid = remoteStages.every(stage => (
+      stage.status === "not_attempted" || stage.status === "not_required"
+    )) && outcome.remoteState === "unchanged";
+  }
+  if (!valid) throw new PromotionContractError("malformed_promotion_outcome");
+}
+
+function safeErrorCode(value) {
+  if (value == null) return null;
+  if (typeof value !== "string" || !/^[a-z0-9_]{1,64}$/.test(value)) {
+    throw new PromotionContractError("malformed_promotion_outcome");
+  }
+  return value;
+}
+
+function preflightFingerprint(preflight, account, tagPlan) {
+  return JSON.stringify([
+    preflight.source.workspace,
+    preflight.source.repository,
+    preflight.source.packageIdentifier,
+    preflight.source.name,
+    preflight.source.version,
+    preflight.source.format,
+    preflight.source.copyable,
+    preflight.source.fingerprint.checksum,
+    preflight.source.fingerprint.versionDigest,
+    preflight.target.workspace,
+    preflight.target.repository,
+    preflight.targetPackageState,
+    preflight.targetPackageCount,
+    account.activationId,
+    account.accountEpoch,
+    tagPlan.source,
+    tagPlan.target,
+    tagPlan.date,
+  ]);
+}
+
+module.exports = {
+  PromotionContractError,
+  createOutcome,
+  createSourceLocator,
+  createStage,
+  createTagPlan,
+  deepFreeze,
+  fingerprintsMatch,
+  missingTags,
+  normalizeFreshSource,
+  normalizePipeline,
+  normalizeTargetPackage,
+  normalizeTargetRepository,
+  preflightFingerprint,
+};

--- a/util/recentPackages.js
+++ b/util/recentPackages.js
@@ -61,10 +61,12 @@ function add(pkg) {
   if (!pkg || !pkg.name) {
     return;
   }
-  const workspace = pkg.cloudsmithWorkspace || pkg.namespace || "";
+  const workspace = canonicalAlias([pkg.cloudsmithWorkspace, pkg.namespace]);
+  const repository = canonicalAlias([pkg.cloudsmithRepo, pkg.repository]);
+  const packageIdentifier = canonicalAlias([pkg.slug_perm, pkg.slug_perm_raw]);
   const version = unwrapValue(pkg.version) || pkg.declaredVersion || "";
   // Deduplicate by workspace + name + version + repository
-  const key = `${workspace}:${pkg.name}:${version}:${pkg.repository || ""}`;
+  const key = `${workspace || ""}:${pkg.name}:${version}:${repository || ""}`;
   const idx = _recent.findIndex(p =>
     `${p.cloudsmithWorkspace || p.namespace || ""}:${p.name}:${p.version || ""}:${p.repository || ""}` === key
   );
@@ -76,11 +78,16 @@ function add(pkg) {
     name: pkg.name,
     format: pkg.format,
     version: version || null,
-    namespace: pkg.namespace,
-    repository: pkg.repository,
-    slug_perm: unwrapValue(pkg.slug_perm),
-    slug_perm_raw: pkg.slug_perm_raw || unwrapValue(pkg.slug_perm) || null,
+    namespace: workspace,
+    repository,
+    slug_perm: packageIdentifier,
+    slug_perm_raw: packageIdentifier,
     slug: unwrapValue(pkg.slug) || null,
+    is_copyable: pkg.is_copyable === true
+      ? true
+      : pkg.is_copyable === false
+        ? false
+        : null,
     num_vulnerabilities: pkg.num_vulnerabilities || 0,
     max_severity: pkg.max_severity || null,
     checksum_sha256: getNestedField(pkg, "checksum_sha256") || null,
@@ -91,12 +98,34 @@ function add(pkg) {
     cdn_url: getNestedField(pkg, "cdn_url") || null,
     filename: getNestedField(pkg, "filename") || null,
     status_str: unwrapValue(pkg.status_str) || pkg.status_str_raw || getNestedField(pkg, "status_str") || null,
-    cloudsmithWorkspace: pkg.cloudsmithWorkspace || pkg.namespace || null,
-    cloudsmithRepo: pkg.cloudsmithRepo || pkg.repository || null,
+    cloudsmithWorkspace: workspace,
+    cloudsmithRepo: repository,
   });
   if (_recent.length > MAX_RECENT) {
     _recent.length = MAX_RECENT;
   }
+}
+
+function canonicalAlias(values) {
+  const supplied = values.filter(value => value !== undefined && value !== null);
+  const present = supplied.map(value => {
+    let current = value;
+    for (let depth = 0; depth < 2; depth += 1) {
+      if (
+        !current
+        || typeof current !== "object"
+        || Array.isArray(current)
+        || !Object.prototype.hasOwnProperty.call(current, "value")
+      ) {
+        break;
+      }
+      current = current.value;
+    }
+    return typeof current === "string" && current.length > 0 ? current : null;
+  });
+  if (present.some(value => value === null)) return null;
+  if (present.length === 0 || present.some(value => value !== present[0])) return null;
+  return present[0];
 }
 
 /**

--- a/util/workspaceRepositoryFetcher.js
+++ b/util/workspaceRepositoryFetcher.js
@@ -10,6 +10,7 @@ const {
 } = require("./accountOperation");
 
 const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
+const MAX_WORKSPACE_REPOSITORY_PAGES = 20;
 const UNEXPECTED_RESPONSE_FORMAT_ERROR = "Unexpected repository response format";
 const STALE_ACCOUNT_ERROR = Object.freeze({
   kind: "stale_account",
@@ -146,8 +147,34 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
         knownPageTotal = pageTotal;
         repositories.push(...pageData);
 
-        if (pageData.length < actualPageSize || currentPage >= pageTotal) {
+        if (currentPage >= pageTotal) {
           break;
+        }
+
+        if (pageData.length < actualPageSize) {
+          return {
+            repositories: sortRepositories(repositories),
+            error: null,
+            warning: Object.freeze({
+              kind: "pagination_incomplete",
+              message: "Repository pagination ended before the authoritative final page.",
+            }),
+            partial: true,
+            stale: false,
+          };
+        }
+
+        if (page >= MAX_WORKSPACE_REPOSITORY_PAGES) {
+          return {
+            repositories: sortRepositories(repositories),
+            error: null,
+            warning: Object.freeze({
+              kind: "pagination_limit",
+              message: "Repository enumeration exceeded the safe page limit.",
+            }),
+            partial: true,
+            stale: false,
+          };
         }
 
         page += 1;
@@ -179,6 +206,7 @@ function isRepositoryArray(value) {
 module.exports = {
   UNEXPECTED_RESPONSE_FORMAT_ERROR,
   STALE_ACCOUNT_ERROR,
+  MAX_WORKSPACE_REPOSITORY_PAGES,
   WORKSPACE_REPOSITORY_PAGE_SIZE,
   fetchWorkspaceRepositories,
 };

--- a/views/promotionProvider.js
+++ b/views/promotionProvider.js
@@ -1,343 +1,1409 @@
-// Cross-repository promotion provider.
-// Shows a package's lifecycle across repos (dev -> staging -> production)
-// and enables one-click promotion with automatic tagging.
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
-const { apiEndpoint, encodeApiPathSegment } = require("../util/apiEndpoint");
-const { formatApiError } = require("../util/errorFormatter");
+const { apiEndpoint } = require("../util/apiEndpoint");
+const { CredentialManager } = require("../util/credentialManager");
+const { PaginatedFetch } = require("../util/paginatedFetch");
+const { fetchWorkspaceRepositories } = require("../util/workspaceRepositoryFetcher");
 const { buildExactPackageQuery, packageMatchesExactIdentity } = require("../util/packageQuery");
+const { captureAccount, isAccountCurrent, resolveConnectionManager } = require("../util/accountOperation");
+const {
+  PromotionContractError,
+  createOutcome,
+  createSourceLocator,
+  createStage,
+  createTagPlan,
+  deepFreeze,
+  missingTags,
+  normalizeFreshSource,
+  normalizePipeline,
+  normalizeTargetPackage,
+  normalizeTargetRepository,
+  preflightFingerprint,
+} = require("../util/promotionContracts");
+
+const EXACT_PACKAGE_PAGE_SIZE = 100;
+const MAX_EXACT_PACKAGE_PAGES = 20;
+const MAX_EXACT_PACKAGE_ITEMS = EXACT_PACKAGE_PAGE_SIZE * MAX_EXACT_PACKAGE_PAGES;
+const MAX_RECENT_TARGETS = 20;
 
 class PromotionProvider {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
-    this.api = new CloudsmithAPI(context);
+    this.api = options.api || new CloudsmithAPI(context);
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._credentialManager = options.credentialManager
+      || new CredentialManager(context, { connectionManager: this._connectionManager });
+    this._paginatedFetch = options.paginatedFetch || new PaginatedFetch(this.api);
+    this._fetchWorkspaceRepositories = options.fetchWorkspaceRepositories || fetchWorkspaceRepositories;
+    this._window = options.window || vscode.window;
+    this._workspace = options.workspace || vscode.workspace;
+    this._withProgress = options.withProgress || this._window.withProgress.bind(this._window);
+    this._now = options.now || (() => Date.now());
+    this._activeOperations = new Map();
+    this._recentTargets = [];
+    this._operationSequence = 0;
+    this._disposed = false;
   }
 
-  _getPackageIdentifier(pkg) {
-    if (!pkg || typeof pkg !== "object") {
-      return null;
-    }
-    if (typeof pkg.slug_perm === "string") {
-      return pkg.slug_perm;
-    }
-    if (pkg.slug_perm && typeof pkg.slug_perm === "object" && pkg.slug_perm.value) {
-      return String(pkg.slug_perm.value);
-    }
-    if (typeof pkg.slug_perm_raw === "string") {
-      return pkg.slug_perm_raw;
-    }
-    if (typeof pkg.slug === "string") {
-      return pkg.slug;
-    }
-    return null;
+  dispose() {
+    this._disposed = true;
+    this._activeOperations.clear();
+    this._recentTargets.length = 0;
   }
 
-  _normalizePackage(pkg) {
-    if (!pkg || typeof pkg !== "object") {
-      return null;
-    }
-
-    return {
-      name: pkg.name || null,
-      version: pkg.version || null,
-      format: pkg.format || null,
-      repository: pkg.repository || null,
-      slug_perm: this._getPackageIdentifier(pkg),
-    };
+  resetForAccountChange() {
+    this._recentTargets.length = 0;
   }
 
-  _replacePlaceholders(template, sourceRepo, targetRepo, dateStr) {
-    return template
-      .replace(/\{target\}/g, targetRepo)
-      .replace(/\{source\}/g, sourceRepo)
-      .replace(/\{date\}/g, dateStr);
-  }
-
-  async _tagPackage(workspace, repo, identifier, tags, apiKey, label) {
-    if (!identifier) {
-      console.warn(`[Promotion] Skipping ${label} tags because package identifier was not available.`);
-      return false;
-    }
-
-    let endpoint;
-    try {
-      endpoint = apiEndpoint(["packages", workspace, repo, identifier, "tag"]);
-    } catch {
-      console.warn(`[Promotion] Skipping ${label} tags because the package endpoint was invalid.`);
-      return false;
-    }
-    const tagResult = await this.api.post(
-      endpoint,
-      { action: "add", tags },
-      {
-        apiKey,
-        responseType: "object",
-        validate: isPackageWriteRecord,
-      }
-    );
-
-    if (!tagResult.ok) {
-      console.warn(`[Promotion] Failed to apply ${label} tags: ${formatApiError(tagResult.error)}`);
-      return false;
-    }
-
-    return true;
-  }
-
-  async _locateCopiedPackage(workspace, targetRepo, packageInfo, apiKey) {
-    if (!packageInfo || !packageInfo.name || !packageInfo.version || !packageInfo.format) {
-      return null;
-    }
-
-    let endpoint;
-    try {
-      const query = buildExactPackageQuery(packageInfo.name, packageInfo.version, packageInfo.format);
-      endpoint = apiEndpoint(["packages", workspace, targetRepo], {
-        query: { query, page_size: 100 },
-      });
-    } catch {
-      return null;
-    }
-    const results = await this.api.get(
-      endpoint,
-      {
-        apiKey,
-        responseType: "array",
-        validate: isPackageWriteArray,
-        retry: "never",
-      }
-    );
-
-    if (!results.ok) {
-      console.warn(`[Promotion] Could not locate copied package: ${formatApiError(results.error)}`);
-      return null;
-    }
-
-    if (results.data.length === 0) {
-      console.warn(`[Promotion] Could not locate copied package in ${workspace}/${targetRepo}: no matching package found.`);
-      return null;
-    }
-
-    const exactResults = results.data.filter(pkg => packageMatchesExactIdentity(pkg, packageInfo));
-    if (exactResults.length === 0) {
-      console.warn(
-        `[Promotion] Could not locate copied package in ${workspace}/${targetRepo}: query returned packages but none matched ${packageInfo.name}@${packageInfo.version} (${packageInfo.format}).`
-      );
-      return null;
-    }
-
-    if (packageInfo.slug_perm) {
-      const exactMatch = exactResults.find(pkg => this._getPackageIdentifier(pkg) === packageInfo.slug_perm);
-      if (exactMatch) {
-        return exactMatch;
-      }
-    }
-
-    return exactResults.find(pkg => pkg.repository === targetRepo) || exactResults[0] || null;
-  }
-
-  /**
-   * Get the configured promotion pipeline from settings.
-   * Validates repo slugs against cached data and warns about invalid entries.
-   * @returns {string[]} Ordered list of repository slugs.
-   */
   getPipeline() {
-    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-    const pipeline = config.get("promotionPipeline") || [];
-    if (pipeline.length > 0 && !this._pipelineValidated) {
-      this._pipelineValidated = true;
-      this._validatePipeline(pipeline);
-    }
-    return pipeline;
+    const config = this._workspace.getConfiguration("cloudsmith-vsc");
+    return config.get("promotionPipeline");
   }
 
-  /**
-   * Validate pipeline repo slugs against cached workspace data.
-   * Shows a warning for any invalid entries.
-   */
-  async _validatePipeline(pipeline) {
-    const defaultWs = vscode.workspace.getConfiguration("cloudsmith-vsc").get("defaultWorkspace");
-    if (!defaultWs) {
-      return;
-    }
-    let endpoint;
-    try {
-      endpoint = apiEndpoint(["repos", defaultWs], { query: { sort: "name" } });
-    } catch {
-      return;
-    }
-    const repos = await this.api.get(endpoint, {
-      responseType: "array",
-      validate: isRepositoryArray,
-      retry: "safe-read",
-    });
-    if (!repos.ok) {
-      return;
-    }
-    const validSlugs = new Set(repos.data.map(r => r.slug));
-    const invalidSlugs = pipeline.filter(s => !validSlugs.has(s));
-    if (invalidSlugs.length > 0) {
-      vscode.window.showWarningMessage(
-        `Promotion pipeline contains unknown repositories: ${invalidSlugs.join(", ")}. Check the cloudsmith-vsc.promotionPipeline setting.`
-      );
-    }
-  }
-
-  /**
-   * Get the configured tag templates from settings.
-   * @returns {Object} Tag templates with onPromote and onReceive arrays.
-   */
   getTagTemplates() {
-    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-    return config.get("promotionTags") || {
-      onPromote: ["promoted-to-{target}", "approved-{date}"],
-      onReceive: ["promoted-from-{source}"],
-    };
+    const config = this._workspace.getConfiguration("cloudsmith-vsc");
+    return config.get("promotionTags");
   }
 
-  /**
-   * Get promotion status for a package across all pipeline repos.
-   *
-   * @param   {string} workspace  Workspace slug.
-   * @param   {string} name       Package name.
-   * @param   {string} version    Package version.
-   * @param   {string} format     Package format.
-   * @returns {Object}            Structured status items and an optional error.
-   */
   async getPromotionStatus(workspace, name, version, format) {
-    const pipeline = this.getPipeline();
-    if (pipeline.length === 0) {
-      return { items: [], error: null };
+    let pipeline;
+    try {
+      pipeline = normalizePipeline(this.getPipeline());
+    } catch (error) {
+      return { items: [], error };
     }
+    if (pipeline.length === 0) return { items: [], error: null };
     if (!name || !version || !format) {
       return { items: [], error: new Error("Package identity is incomplete.") };
     }
 
-    // Search workspace-wide for this package name+version
     let endpoint;
     try {
       const query = buildExactPackageQuery(name, version, format);
-      endpoint = apiEndpoint(["packages", workspace], {
-        query: { query, page_size: 100 },
-      });
+      endpoint = apiEndpoint(["packages", workspace], { query: { query, page_size: 100 } });
     } catch (error) {
       return { items: [], error };
     }
-    const results = await this.api.get(
-      endpoint,
-      { responseType: "array", validate: isPromotionStatusArray, retry: "never" }
-    );
-
-    if (!results.ok) {
-      return { items: [], error: results.error };
-    }
-
-    // Build a map of repo slug -> package data
-    const repoMap = new Map();
-    const exactResults = results.data.filter(pkg =>
-      packageMatchesExactIdentity(pkg, { name, version, format })
-    );
-    for (const pkg of exactResults) {
-      repoMap.set(pkg.repository, pkg);
-    }
-
-    // Map pipeline repos to their status
-    return { items: pipeline.map(repo => {
-      const pkg = repoMap.get(repo) || null;
-      return {
-        repo,
-        found: !!pkg,
-        status: pkg ? (pkg.status_str || "Unknown") : "Not present",
-        quarantined: pkg ? (pkg.status_str === "Quarantined") : false,
-        policyViolated: pkg ? (pkg.policy_violated || false) : false,
-        pkg,
-      };
-    }), error: null };
-  }
-
-  /**
-   * Promote a package from one repo to another with tagging.
-   *
-   * @param   {string} workspace   Workspace slug.
-   * @param   {string} sourceRepo  Source repository slug.
-   * @param   {string} slugPerm    Package slug_perm identifier.
-   * @param   {string} targetRepo  Target repository slug.
-   * @returns {boolean}            True if promotion succeeded.
-   */
-  async promote(workspace, sourceRepo, slugPerm, targetRepo) {
-    const credentialManager = require("../util/credentialManager");
-    const cm = new credentialManager.CredentialManager(this.context);
-    const apiKey = await cm.getApiKey();
-    const templates = this.getTagTemplates();
-    const dateStr = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
-
-    let sourceEndpoint;
-    let copyEndpoint;
-    try {
-      sourceEndpoint = apiEndpoint(["packages", workspace, sourceRepo, slugPerm]);
-      copyEndpoint = apiEndpoint(["packages", workspace, sourceRepo, slugPerm, "copy"]);
-      encodeApiPathSegment(targetRepo);
-    } catch (error) {
-      return { success: false, error };
-    }
-    const sourcePackageResult = await this.api.get(sourceEndpoint, {
-      apiKey,
-      responseType: "object",
-      validate: isPackageIdentityRecord,
+    const results = await this.api.get(endpoint, {
+      responseType: "array",
+      validate: isPromotionStatusArray,
       retry: "never",
     });
-    const sourcePackage = this._normalizePackage(
-      sourcePackageResult.ok ? sourcePackageResult.data : null
-    );
+    if (!results.ok) return { items: [], error: results.error };
 
-    // Step 1: Copy the package to the target repo
-    const copyPayload = {
-      destination: `${workspace}/${targetRepo}`,
+    const repoMap = new Map();
+    for (const pkg of results.data.filter(candidate => (
+      packageMatchesExactIdentity(candidate, { name, version, format })
+    ))) {
+      repoMap.set(pkg.repository, pkg);
+    }
+    return {
+      items: pipeline.map(repo => {
+        const pkg = repoMap.get(repo) || null;
+        return {
+          repo,
+          found: Boolean(pkg),
+          status: pkg ? (pkg.status_str || "Unknown") : "Not present",
+          quarantined: pkg ? pkg.status_str === "Quarantined" : false,
+          policyViolated: pkg ? pkg.policy_violated === true : false,
+          pkg,
+        };
+      }),
+      error: null,
     };
+  }
 
-    const copyResult = await this.api.post(copyEndpoint, copyPayload, {
-      apiKey,
-      responseType: "object",
-      validate: isPackageWriteRecord,
-    });
-
-    if (!copyResult.ok) {
-      console.warn(`[Promotion] Copy failed: ${formatApiError(copyResult.error)}`);
-      return { success: false, error: copyResult.error };
+  async runPromotionWorkflow(item, options = {}) {
+    let locator;
+    try {
+      locator = createSourceLocator(item);
+    } catch (error) {
+      const outcome = failureOutcome(errorCode(error, "malformed_source_locator"));
+      await this._showFailure(outcome);
+      return outcome;
     }
 
-    if (templates.onPromote && templates.onPromote.length > 0) {
-      const tags = templates.onPromote.map(tmpl =>
-        this._replacePlaceholders(tmpl, sourceRepo, targetRepo, dateStr)
+    const operation = this._acquireOperation(locator);
+    if (!operation) {
+      const outcome = failureOutcome("promotion_busy");
+      await this._window.showInformationMessage(
+        "A promotion is already in progress for this package. Wait for it to finish and try again."
       );
-      await this._tagPackage(workspace, sourceRepo, slugPerm, tags, apiKey, "onPromote");
+      return outcome;
     }
 
-    if (templates.onReceive && templates.onReceive.length > 0) {
-      const copiedPackage = this._normalizePackage(copyResult.data) || sourcePackage;
-      const locatedPackage = await this._locateCopiedPackage(
-        workspace,
-        targetRepo,
-        copiedPackage,
+    let account = null;
+    try {
+      account = captureAccount(this._connectionManager);
+      if (!account) return await this._publishFailure(failureOutcome("authentication_unavailable"));
+
+      const apiKey = await this._credentialManager.getApiKey();
+      if (!apiKey || !this._isCurrent(operation, account)) {
+        return await this._publishStaleOrFailure(operation, account, "authentication_unavailable");
+      }
+
+      const sourceRead = await this._readSource(locator, apiKey, null, account);
+      if (!sourceRead.ok) {
+        const outcome = failureOutcome(sourceRead.errorCode);
+        return await this._publish(outcome, operation, account, options);
+      }
+      if (!sourceRead.source.copyable) {
+        const outcome = failureOutcome("package_not_copyable", { source: sourceRead.source });
+        return await this._publish(outcome, operation, account, options);
+      }
+
+      let pipeline;
+      try {
+        pipeline = normalizePipeline(this.getPipeline());
+      } catch (error) {
+        const outcome = failureOutcome(errorCode(error, "malformed_pipeline"), { source: sourceRead.source });
+        return await this._publish(outcome, operation, account, options);
+      }
+
+      const candidatesResult = await this._loadTargetCandidates(
+        sourceRead.source,
+        pipeline,
+        account,
         apiKey
       );
+      if (!candidatesResult.ok) {
+        const outcome = failureOutcome(candidatesResult.errorCode, { source: sourceRead.source });
+        return await this._publish(outcome, operation, account, options);
+      }
+      if (candidatesResult.targets.length === 0) {
+        const outcome = failureOutcome("no_target_repositories", { source: sourceRead.source });
+        return await this._publish(outcome, operation, account, options);
+      }
 
-      if (locatedPackage) {
-        const tags = templates.onReceive.map(tmpl =>
-          this._replacePlaceholders(tmpl, sourceRepo, targetRepo, dateStr)
+      const presenceHints = await this._loadPresenceHints(sourceRead.source, apiKey, account);
+      if (!this._isCurrent(operation, account)) {
+        return await this._publish(this._staleOutcome(), operation, account, options);
+      }
+      const selectedTarget = await this._selectTarget(
+        sourceRead.source,
+        candidatesResult.targets,
+        presenceHints,
+        account
+      );
+      if (!selectedTarget) {
+        return createOutcome({
+          source: sourceRead.source,
+          overall: "cancelled",
+          confirmation: createStage("cancelled"),
+          remoteState: "unchanged",
+        });
+      }
+      if (presenceHints?.has(selectedTarget.repository)) {
+        const outcome = failureOutcome("target_package_exists", {
+          source: sourceRead.source,
+          target: selectedTarget,
+        });
+        return await this._publish(outcome, operation, account, options);
+      }
+
+      let tagPlan;
+      try {
+        const date = new Date(this._now()).toISOString().slice(0, 10);
+        tagPlan = createTagPlan(
+          this.getTagTemplates(),
+          sourceRead.source.repository,
+          selectedTarget.repository,
+          date
         );
-        const identifier = this._getPackageIdentifier(locatedPackage);
-        await this._tagPackage(workspace, targetRepo, identifier, tags, apiKey, "onReceive");
-      } else {
-        console.warn(
-          `[Promotion] Skipping onReceive tags for ${workspace}/${targetRepo} because the copied package could not be located.`
+      } catch (error) {
+        const outcome = failureOutcome(errorCode(error, "malformed_tag_configuration"), {
+          source: sourceRead.source,
+          target: selectedTarget,
+        });
+        return await this._publish(outcome, operation, account, options);
+      }
+
+      const firstPreflightResult = await this._withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Checking promotion requirements...",
+          cancellable: true,
+        },
+        (_progress, cancellationToken) => this.preflight(
+          locator,
+          selectedTarget,
+          tagPlan,
+          account,
+          apiKey,
+          cancellationToken
+        )
+      );
+      if (!firstPreflightResult.ok) {
+        if (firstPreflightResult.errorCode === "cancelled") {
+          return createOutcome({
+            source: sourceRead.source,
+            target: selectedTarget,
+            preflight: createStage("cancelled"),
+            overall: "cancelled",
+            remoteState: "unchanged",
+          });
+        }
+        const outcome = failureOutcome(firstPreflightResult.errorCode, {
+          source: firstPreflightResult.source || sourceRead.source,
+          target: selectedTarget,
+          preflight: createStage("failed", { errorCode: firstPreflightResult.errorCode }),
+        });
+        return await this._publish(outcome, operation, account, options);
+      }
+      if (!this._isCurrent(operation, account)) {
+        return await this._publish(this._staleOutcome(), operation, account, options);
+      }
+
+      const confirmation = await this._confirm(firstPreflightResult.preflight, tagPlan);
+      if (confirmation !== "Promote package") {
+        return createOutcome({
+          source: firstPreflightResult.preflight.source,
+          target: firstPreflightResult.preflight.target,
+          preflight: createStage("succeeded", { evidence: "fresh_read" }),
+          confirmation: createStage("cancelled"),
+          overall: "cancelled",
+          remoteState: "unchanged",
+        });
+      }
+      if (!this._isCurrent(operation, account)) {
+        return await this._publish(this._staleOutcome(), operation, account, options);
+      }
+
+      const finalPreflightResult = await this.preflight(
+        locator,
+        selectedTarget,
+        tagPlan,
+        account,
+        apiKey,
+        null
+      );
+      if (
+        !finalPreflightResult.ok
+        || preflightFingerprint(firstPreflightResult.preflight, account, tagPlan)
+          !== preflightFingerprint(finalPreflightResult.preflight, account, tagPlan)
+      ) {
+        const outcome = failureOutcome("preflight_changed", {
+          source: firstPreflightResult.preflight.source,
+          target: firstPreflightResult.preflight.target,
+          preflight: createStage("failed", { errorCode: "preflight_changed" }),
+          confirmation: createStage("succeeded", { evidence: "user_confirmation" }),
+        });
+        return await this._publish(outcome, operation, account, options);
+      }
+      if (!this._isCurrent(operation, account)) {
+        return await this._publish(this._staleOutcome(), operation, account, options);
+      }
+
+      let outcome;
+      const executionState = {
+        writeIssued: false,
+        copy: null,
+        sourceTag: null,
+        targetTag: null,
+        reconciliation: null,
+        outcome: null,
+      };
+      try {
+        outcome = await this._withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: `Promoting ${finalPreflightResult.preflight.source.name}...`,
+            cancellable: false,
+          },
+          async progress => {
+            const result = await this.execute(
+              finalPreflightResult.preflight,
+              tagPlan,
+              account,
+              apiKey,
+              operation,
+              progress,
+              executionState
+            );
+            executionState.outcome = result;
+            return result;
+          }
+        );
+      } catch {
+        outcome = executionState.outcome || interruptedExecutionOutcome(
+          finalPreflightResult.preflight,
+          tagPlan,
+          executionState
         );
       }
+      return await this._publish(outcome, operation, account, options);
+    } catch {
+      const outcome = failureOutcome("unexpected_error");
+      if (account && this._isCurrent(operation, account)) {
+        return await this._publish(outcome, operation, account, options);
+      }
+      return outcome;
+    } finally {
+      this._releaseOperation(operation);
+    }
+  }
+
+  async preflight(locator, selectedTarget, tagPlan, account, apiKey, cancellationToken) {
+    if (!this._isAccountCurrent(account)) return preflightFailure("account_changed");
+    const sourceRead = await this._readSource(locator, apiKey, cancellationToken, account);
+    if (!sourceRead.ok) return preflightFailure(sourceRead.errorCode, sourceRead.source);
+    if (!sourceRead.source.copyable) {
+      return preflightFailure("package_not_copyable", sourceRead.source);
+    }
+    if (sourceRead.source.repository === selectedTarget.repository) {
+      return preflightFailure("invalid_target", sourceRead.source);
     }
 
-    return { success: true, error: null };
+    const [targetRead, packageRead] = await Promise.all([
+      this._readTargetRepository(selectedTarget, apiKey, cancellationToken, account),
+      this._findTargetPackages(
+        sourceRead.source,
+        selectedTarget,
+        apiKey,
+        cancellationToken,
+        account,
+        { stopOnPresence: true }
+      ),
+    ]);
+    if (cancellationToken?.isCancellationRequested) {
+      return preflightFailure("cancelled", sourceRead.source);
+    }
+    if (!this._isAccountCurrent(account)) return preflightFailure("account_changed", sourceRead.source);
+    if (!targetRead.ok) return preflightFailure(targetRead.errorCode, sourceRead.source);
+    if (!packageRead.ok || !packageRead.complete) {
+      return preflightFailure(packageRead.errorCode || "target_state_unknown", sourceRead.source);
+    }
+    if (packageRead.packages.length > 0) {
+      return preflightFailure("target_package_exists", sourceRead.source);
+    }
+
+    const preflight = deepFreeze({
+      source: sourceRead.source,
+      target: targetRead.target,
+      targetPackageState: "absent",
+      targetPackageCount: 0,
+      permissions: deepFreeze({
+        sourceCopyability: "passed",
+        targetReadable: "passed",
+        targetWrite: "not_exposed",
+      }),
+      tagPlan,
+      checkedAtMs: this._now(),
+    });
+    return deepFreeze({ ok: true, preflight, errorCode: null });
   }
+
+  async execute(preflight, tagPlan, account, apiKey, operation, progress, executionState = {}) {
+    const base = {
+      source: preflight.source,
+      target: preflight.target,
+      preflight: createStage("succeeded", { evidence: "fresh_read" }),
+      confirmation: createStage("succeeded", { evidence: "user_confirmation" }),
+    };
+    if (!this._isCurrent(operation, account)) {
+      return createOutcome({ ...base, overall: "failed", errorCode: "account_changed" });
+    }
+
+    reportProgress(progress, "Copying package...");
+    let copyResult;
+    const copyEndpoint = apiEndpoint([
+      "packages",
+      preflight.source.workspace,
+      preflight.source.repository,
+      preflight.source.packageIdentifier,
+      "copy",
+    ]);
+    try {
+      executionState.writeIssued = true;
+      copyResult = await this.api.post(
+        copyEndpoint,
+        { destination: `${preflight.target.workspace}/${preflight.target.repository}`, republish: false },
+        { apiKey, responseType: "object", validate: isRecord, retry: "never" }
+      );
+    } catch {
+      copyResult = null;
+    }
+
+    if (!copyResult || !copyResult.ok) {
+      const ambiguous = !copyResult || !isDefiniteWriteFailure(copyResult.error);
+      if (!ambiguous) {
+        return createOutcome({
+          ...base,
+          copy: createStage("failed", {
+            required: true,
+            attempted: true,
+            evidence: "write_response",
+            errorCode: "copy_failed",
+          }),
+          overall: "failed",
+          errorCode: "copy_failed",
+          remoteState: "unchanged",
+        });
+      }
+      return this._ambiguousCopyOutcome(preflight, tagPlan, account, apiKey, base);
+    }
+
+    let targetPackage;
+    try {
+      targetPackage = normalizeTargetPackage(copyResult.data, preflight.source, preflight.target);
+    } catch {
+      return this._ambiguousCopyOutcome(preflight, tagPlan, account, apiKey, base);
+    }
+
+    executionState.copy = createStage("succeeded", {
+      required: true,
+      attempted: true,
+      evidence: "write_response",
+    });
+
+    if (!this._isCurrent(operation, account)) {
+      return createOutcome({
+        ...base,
+        copy: createStage("succeeded", { required: true, attempted: true, evidence: "write_response" }),
+        reconciliation: createStage("ambiguous", { errorCode: "account_changed" }),
+        overall: "ambiguous",
+        errorCode: "account_changed",
+        remoteState: "changed",
+      });
+    }
+    const postCopyRead = await this._findTargetPackages(
+      preflight.source,
+      preflight.target,
+      apiKey,
+      null,
+      account,
+      { stopOnPresence: false }
+    );
+    if (
+      !postCopyRead.ok
+      || !postCopyRead.complete
+      || postCopyRead.packages.length !== 1
+      || postCopyRead.packages[0].packageIdentifier !== targetPackage.packageIdentifier
+    ) {
+      return createOutcome({
+        ...base,
+        copy: createStage("succeeded", { required: true, attempted: true, evidence: "write_response" }),
+        sourceTag: createStage(tagPlan.source.length ? "not_attempted" : "not_required", {
+          required: tagPlan.source.length > 0,
+        }),
+        targetTag: createStage(tagPlan.target.length ? "not_attempted" : "not_required", {
+          required: tagPlan.target.length > 0,
+        }),
+        reconciliation: createStage("ambiguous", { errorCode: "post_copy_state_unknown" }),
+        overall: "ambiguous",
+        errorCode: "post_copy_state_unknown",
+        remoteState: "changed",
+      });
+    }
+    targetPackage = postCopyRead.packages[0];
+
+    let sourceTag = createStage(
+      tagPlan.source.length > 0 ? "not_attempted" : "not_required",
+      { required: tagPlan.source.length > 0 }
+    );
+    let targetTag = createStage(
+      tagPlan.target.length > 0 ? "not_attempted" : "not_required",
+      { required: tagPlan.target.length > 0 }
+    );
+    executionState.sourceTag = sourceTag;
+    executionState.targetTag = targetTag;
+
+    if (tagPlan.source.length > 0) {
+      reportProgress(progress, "Checking source tags...");
+      sourceTag = await this._applySourceTags(
+        preflight.source,
+        tagPlan.source,
+        account,
+        apiKey,
+        operation
+      );
+      executionState.sourceTag = sourceTag;
+    }
+    if (tagPlan.target.length > 0 && this._isCurrent(operation, account)) {
+      reportProgress(progress, "Checking target tags...");
+      targetTag = await this._applyTargetTags(
+        preflight.source,
+        preflight.target,
+        targetPackage.packageIdentifier,
+        tagPlan.target,
+        account,
+        apiKey,
+        operation
+      );
+      executionState.targetTag = targetTag;
+    }
+
+    if (!this._isCurrent(operation, account)) {
+      return createOutcome({
+        ...base,
+        copy: createStage("succeeded", { required: true, attempted: true, evidence: "write_response" }),
+        sourceTag,
+        targetTag,
+        reconciliation: createStage("ambiguous", { errorCode: "account_changed" }),
+        overall: "ambiguous",
+        errorCode: "account_changed",
+        remoteState: "changed",
+      });
+    }
+
+    reportProgress(progress, "Verifying promotion state...");
+    const reconciliation = await this._reconcileFinalState(
+      preflight.source,
+      preflight.target,
+      targetPackage.packageIdentifier,
+      tagPlan,
+      account,
+      apiKey
+    );
+    executionState.reconciliation = reconciliation.ok
+      ? createStage("succeeded", { evidence: "fresh_read" })
+      : createStage("ambiguous", { errorCode: reconciliation.errorCode });
+    if (!reconciliation.ok) {
+      return createOutcome({
+        ...base,
+        copy: createStage("succeeded", { required: true, attempted: true, evidence: "write_response" }),
+        sourceTag,
+        targetTag,
+        reconciliation: createStage("ambiguous", { errorCode: reconciliation.errorCode }),
+        overall: "ambiguous",
+        errorCode: reconciliation.errorCode,
+        remoteState: "changed",
+      });
+    }
+
+    sourceTag = reconcileTagStage(sourceTag, reconciliation.sourceMissing);
+    targetTag = reconcileTagStage(targetTag, reconciliation.targetMissing);
+    executionState.sourceTag = sourceTag;
+    executionState.targetTag = targetTag;
+    const hasAmbiguousTag = [sourceTag, targetTag].some(stage => stage.status === "ambiguous");
+    const hasFailedTag = [sourceTag, targetTag].some(stage => stage.status === "failed");
+    const overall = hasAmbiguousTag ? "ambiguous" : hasFailedTag ? "partial" : "succeeded";
+    return createOutcome({
+      ...base,
+      copy: createStage("succeeded", { required: true, attempted: true, evidence: "write_response" }),
+      sourceTag,
+      targetTag,
+      reconciliation: createStage("succeeded", { evidence: "fresh_read" }),
+      overall,
+      errorCode: overall === "succeeded" ? null : "tagging_incomplete",
+      remoteState: "changed",
+    });
+  }
+
+  async _ambiguousCopyOutcome(preflight, tagPlan, account, apiKey, base) {
+    let reconciliation = createStage("ambiguous", { errorCode: "copy_outcome_unknown" });
+    let remoteState = "possibly_changed";
+    if (this._isAccountCurrent(account)) {
+      const targetRead = await this._findTargetPackages(
+        preflight.source,
+        preflight.target,
+        apiKey,
+        null,
+        account,
+        { stopOnPresence: false }
+      );
+      if (targetRead.ok && targetRead.complete && targetRead.packages.length === 1) {
+        reconciliation = createStage("succeeded", { evidence: "target_state_only" });
+        remoteState = "present";
+      }
+    }
+    return createOutcome({
+      ...base,
+      copy: createStage("ambiguous", {
+        required: true,
+        attempted: true,
+        evidence: "write_dispatched",
+        errorCode: "copy_outcome_unknown",
+      }),
+      sourceTag: createStage(tagPlan.source.length ? "not_attempted" : "not_required", {
+        required: tagPlan.source.length > 0,
+      }),
+      targetTag: createStage(tagPlan.target.length ? "not_attempted" : "not_required", {
+        required: tagPlan.target.length > 0,
+      }),
+      reconciliation,
+      overall: "ambiguous",
+      errorCode: "copy_outcome_unknown",
+      remoteState,
+    });
+  }
+
+  async _applySourceTags(source, requiredTags, account, apiKey, operation) {
+    if (!this._isCurrent(operation, account)) return createStage("not_attempted", { required: true });
+    const fresh = await this._readSource(
+      { workspace: source.workspace, repository: source.repository, packageIdentifier: source.packageIdentifier },
+      apiKey,
+      null,
+      account
+    );
+    if (!fresh.ok || !sameSource(source, fresh.source)) {
+      return createStage("failed", { required: true, errorCode: "source_tag_state_unverified" });
+    }
+    const missing = missingTags(fresh.source.tags, requiredTags);
+    if (missing.length === 0) {
+      return createStage("not_required", { required: true, evidence: "fresh_read" });
+    }
+    if (!this._isCurrent(operation, account)) return createStage("not_attempted", { required: true });
+    return this._postTags(
+      source,
+      source.packageIdentifier,
+      missing,
+      account,
+      apiKey,
+      "source",
+      value => normalizeFreshSource(value, {
+        workspace: source.workspace,
+        repository: source.repository,
+        packageIdentifier: source.packageIdentifier,
+      })
+    );
+  }
+
+  async _applyTargetTags(source, target, targetIdentifier, requiredTags, account, apiKey, operation) {
+    if (!this._isCurrent(operation, account)) return createStage("not_attempted", { required: true });
+    const fresh = await this._findTargetPackages(
+      source,
+      target,
+      apiKey,
+      null,
+      account,
+      { stopOnPresence: false }
+    );
+    if (
+      !fresh.ok
+      || !fresh.complete
+      || fresh.packages.length !== 1
+      || fresh.packages[0].packageIdentifier !== targetIdentifier
+    ) {
+      return createStage("failed", { required: true, errorCode: "target_tag_state_unverified" });
+    }
+    const missing = missingTags(fresh.packages[0].tags, requiredTags);
+    if (missing.length === 0) {
+      return createStage("not_required", { required: true, evidence: "fresh_read" });
+    }
+    if (!this._isCurrent(operation, account)) return createStage("not_attempted", { required: true });
+    return this._postTags(
+      target,
+      targetIdentifier,
+      missing,
+      account,
+      apiKey,
+      "target",
+      value => {
+        const normalized = normalizeTargetPackage(value, source, target);
+        if (normalized.packageIdentifier !== targetIdentifier) {
+          throw new PromotionContractError("target_package_identity_mismatch");
+        }
+        return normalized;
+      }
+    );
+  }
+
+  async _postTags(scope, identifier, tags, account, apiKey, side, normalizeResponse) {
+    if (!this._isAccountCurrent(account)) return createStage("not_attempted", { required: true });
+    const endpoint = apiEndpoint(["packages", scope.workspace, scope.repository, identifier, "tag"]);
+    let result;
+    try {
+      result = await this.api.post(
+        endpoint,
+        { action: "add", tags },
+        { apiKey, responseType: "object", validate: isRecord, retry: "never" }
+      );
+    } catch {
+      result = null;
+    }
+    if (!result || !result.ok) {
+      if (!result || !isDefiniteWriteFailure(result.error)) {
+        return createStage("ambiguous", {
+          required: true,
+          attempted: true,
+          evidence: "write_dispatched",
+          errorCode: `${side}_tag_outcome_unknown`,
+        });
+      }
+      return createStage("failed", {
+        required: true,
+        attempted: true,
+        evidence: "write_response",
+        errorCode: `${side}_tag_failed`,
+      });
+    }
+    try {
+      const normalized = normalizeResponse(result.data);
+      if (missingTags(normalized.tags, tags).length > 0) {
+        return createStage("ambiguous", {
+          required: true,
+          attempted: true,
+          evidence: "malformed_write_response",
+          errorCode: `${side}_tag_outcome_unknown`,
+        });
+      }
+    } catch {
+      return createStage("ambiguous", {
+        required: true,
+        attempted: true,
+        evidence: "malformed_write_response",
+        errorCode: `${side}_tag_outcome_unknown`,
+      });
+    }
+    return createStage("succeeded", {
+      required: true,
+      attempted: true,
+      evidence: "write_response",
+    });
+  }
+
+  async _reconcileFinalState(source, target, targetIdentifier, tagPlan, account, apiKey) {
+    if (!this._isAccountCurrent(account)) return { ok: false, errorCode: "account_changed" };
+    const [sourceRead, targetRead] = await Promise.all([
+      this._readSource(
+        { workspace: source.workspace, repository: source.repository, packageIdentifier: source.packageIdentifier },
+        apiKey,
+        null,
+        account
+      ),
+      this._findTargetPackages(source, target, apiKey, null, account, { stopOnPresence: false }),
+    ]);
+    if (
+      !this._isAccountCurrent(account)
+      || !sourceRead.ok
+      || !sameSource(source, sourceRead.source)
+      || !targetRead.ok
+      || !targetRead.complete
+      || targetRead.packages.length !== 1
+      || targetRead.packages[0].packageIdentifier !== targetIdentifier
+    ) {
+      return { ok: false, errorCode: "reconciliation_incomplete" };
+    }
+    return deepFreeze({
+      ok: true,
+      sourceMissing: missingTags(sourceRead.source.tags, tagPlan.source),
+      targetMissing: missingTags(targetRead.packages[0].tags, tagPlan.target),
+    });
+  }
+
+  async _readSource(locator, apiKey, cancellationToken, account) {
+    if (!this._isAccountCurrent(account)) return { ok: false, errorCode: "account_changed" };
+    const endpoint = apiEndpoint([
+      "packages",
+      locator.workspace,
+      locator.repository,
+      locator.packageIdentifier,
+    ]);
+    let result;
+    try {
+      result = await this.api.get(endpoint, {
+        apiKey,
+        responseType: "object",
+        validate: isRecord,
+        retry: "never",
+        cancellationToken,
+      });
+    } catch {
+      return { ok: false, errorCode: "source_unverified" };
+    }
+    if (!result.ok) return { ok: false, errorCode: readErrorCode(result.error, "source") };
+    try {
+      return { ok: true, source: normalizeFreshSource(result.data, locator) };
+    } catch (error) {
+      return { ok: false, errorCode: errorCode(error, "malformed_source_package") };
+    }
+  }
+
+  async _readTargetRepository(target, apiKey, cancellationToken, account) {
+    if (!this._isAccountCurrent(account)) return { ok: false, errorCode: "account_changed" };
+    const endpoint = apiEndpoint(["repos", target.workspace, target.repository]);
+    let result;
+    try {
+      result = await this.api.get(endpoint, {
+        apiKey,
+        responseType: "object",
+        validate: isRecord,
+        retry: "never",
+        cancellationToken,
+      });
+    } catch {
+      return { ok: false, errorCode: "target_unverified" };
+    }
+    if (!result.ok) return { ok: false, errorCode: readErrorCode(result.error, "target") };
+    try {
+      return {
+        ok: true,
+        target: normalizeTargetRepository(result.data, target.workspace, target.repository),
+      };
+    } catch (error) {
+      return { ok: false, errorCode: errorCode(error, "malformed_target_repository") };
+    }
+  }
+
+  async _findTargetPackages(source, target, apiKey, cancellationToken, account, options) {
+    let endpoint;
+    let query;
+    try {
+      endpoint = apiEndpoint(["packages", target.workspace, target.repository]);
+      query = buildExactPackageQuery(source.name, source.version, source.format);
+    } catch {
+      return { ok: false, complete: false, packages: [], errorCode: "invalid_package_query" };
+    }
+    const packages = [];
+    let itemCount = 0;
+    for (let page = 1; page <= MAX_EXACT_PACKAGE_PAGES; page += 1) {
+      if (!this._isAccountCurrent(account)) {
+        return { ok: false, complete: false, packages: [], errorCode: "account_changed" };
+      }
+      let result;
+      try {
+        result = await this._paginatedFetch.fetchPage(
+          endpoint,
+          page,
+          EXACT_PACKAGE_PAGE_SIZE,
+          query,
+          {
+            apiKey,
+            validate: isRecordArray,
+            retry: "never",
+            cancellationToken,
+          }
+        );
+      } catch {
+        return { ok: false, complete: false, packages: [], errorCode: "target_state_unverified" };
+      }
+      if (result.error) {
+        return {
+          ok: false,
+          complete: false,
+          packages: [],
+          errorCode: readErrorCode(result.error, "target_state"),
+        };
+      }
+      itemCount += result.data.length;
+      if (itemCount > MAX_EXACT_PACKAGE_ITEMS) {
+        return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
+      }
+      for (const candidate of result.data) {
+        if (!packageMatchesExactIdentity(candidate, source)) continue;
+        try {
+          packages.push(normalizeTargetPackage(candidate, source, target));
+        } catch (error) {
+          return {
+            ok: false,
+            complete: false,
+            packages: [],
+            errorCode: errorCode(error, "malformed_target_package"),
+          };
+        }
+        if (options.stopOnPresence) {
+          return { ok: true, complete: true, packages: Object.freeze(packages) };
+        }
+        if (packages.length > 1) {
+          return { ok: true, complete: true, packages: Object.freeze(packages) };
+        }
+      }
+      if (page >= result.pagination.pageTotal) {
+        return { ok: true, complete: true, packages: Object.freeze(packages) };
+      }
+      if (result.pagination.pageTotal > MAX_EXACT_PACKAGE_PAGES) {
+        return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
+      }
+    }
+    return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
+  }
+
+  async _loadPresenceHints(source, apiKey, account) {
+    let endpoint;
+    let query;
+    try {
+      endpoint = apiEndpoint(["packages", source.workspace]);
+      query = buildExactPackageQuery(source.name, source.version, source.format);
+    } catch {
+      return null;
+    }
+    const repositories = new Set();
+    for (let page = 1; page <= MAX_EXACT_PACKAGE_PAGES; page += 1) {
+      if (!this._isAccountCurrent(account)) return null;
+      let result;
+      try {
+        result = await this._paginatedFetch.fetchPage(
+          endpoint,
+          page,
+          EXACT_PACKAGE_PAGE_SIZE,
+          query,
+          { apiKey, validate: isPackageLocationArray, retry: "never" }
+        );
+      } catch {
+        return null;
+      }
+      if (result.error || result.pagination.pageTotal > MAX_EXACT_PACKAGE_PAGES) return null;
+      for (const pkg of result.data) {
+        if (packageMatchesExactIdentity(pkg, source)) repositories.add(pkg.repository);
+      }
+      if (page >= result.pagination.pageTotal) return repositories;
+    }
+    return null;
+  }
+
+  async _loadTargetCandidates(source, pipeline, account, apiKey) {
+    if (!this._isAccountCurrent(account)) return { ok: false, errorCode: "account_changed" };
+    let result;
+    try {
+      result = await this._fetchWorkspaceRepositories(this.context, source.workspace, {
+        account,
+        apiKey,
+        cloudsmithAPI: this.api,
+        connectionManager: this._connectionManager,
+        withProgress: this._withProgress,
+        retry: "safe-read",
+      });
+    } catch {
+      return { ok: false, errorCode: "repository_list_incomplete" };
+    }
+    if (result.stale) return { ok: false, errorCode: "account_changed" };
+    if (result.error || result.warning || result.partial) {
+      return { ok: false, errorCode: "repository_list_incomplete" };
+    }
+    const repositories = new Map();
+    try {
+      for (const record of result.repositories) {
+        const target = normalizeTargetRepository(record, source.workspace, record.slug);
+        if (repositories.has(target.repository)) {
+          return { ok: false, errorCode: "repository_list_incomplete" };
+        }
+        repositories.set(target.repository, target);
+      }
+    } catch (error) {
+      return { ok: false, errorCode: errorCode(error, "repository_list_incomplete") };
+    }
+
+    if (pipeline.length > 0) {
+      if (pipeline.some(repository => !repositories.has(repository))) {
+        return { ok: false, errorCode: "pipeline_repository_missing" };
+      }
+      const sourceIndex = pipeline.indexOf(source.repository);
+      if (sourceIndex < 0) return { ok: false, errorCode: "source_not_in_pipeline" };
+      return {
+        ok: true,
+        targets: Object.freeze(pipeline.slice(sourceIndex + 1).map(repository => repositories.get(repository))),
+      };
+    }
+    return {
+      ok: true,
+      targets: Object.freeze([...repositories.values()].filter(target => (
+        target.repository !== source.repository
+      ))),
+    };
+  }
+
+  async _selectTarget(source, targets, presenceHints, account) {
+    const recent = this._recentFor(account, source);
+    const ordered = [
+      ...recent.map(repository => targets.find(target => target.repository === repository)).filter(Boolean),
+      ...targets.filter(target => !recent.includes(target.repository)),
+    ];
+    const items = ordered.map(target => {
+      const present = presenceHints?.has(target.repository) === true;
+      return {
+        label: target.name,
+        description: `${target.workspace}/${target.repository}`,
+        detail: present
+          ? `Already contains ${source.name} ${source.version} — unavailable`
+          : "Package presence will be verified before promotion",
+        _target: target,
+      };
+    });
+    const picked = await this._window.showQuickPick(items, {
+      placeHolder: `Select a target repository for ${source.name} ${source.version}`,
+      matchOnDescription: true,
+      matchOnDetail: true,
+    });
+    return picked?._target || null;
+  }
+
+  async _confirm(preflight, tagPlan) {
+    const writes = [
+      "copy the package",
+      ...(tagPlan.source.length ? [`add ${tagPlan.source.length} source tag(s)`] : []),
+      ...(tagPlan.target.length ? [`add ${tagPlan.target.length} target tag(s)`] : []),
+    ].join("; ");
+    const detail = [
+      `Package: ${preflight.source.name}`,
+      `Version: ${preflight.source.version}`,
+      `Source: ${preflight.source.workspace}/${preflight.source.repository}`,
+      `Target: ${preflight.target.workspace}/${preflight.target.repository}`,
+      "Target package: Not present",
+      "Preflight: Package, copyability, target repository, and target absence were verified",
+      "Target write access: Cloudsmith verifies this when promotion begins",
+      `Writes: ${writes}`,
+      "The copy can complete even if a later tag write is denied.",
+    ].join("\n");
+    return this._window.showWarningMessage(
+      `Promote “${preflight.source.name}” ${preflight.source.version} to ${preflight.target.repository}?`,
+      { modal: true, detail },
+      "Promote package"
+    );
+  }
+
+  _acquireOperation(locator) {
+    if (this._disposed) return null;
+    let workspace = this._activeOperations.get(locator.workspace);
+    if (!workspace) {
+      workspace = new Map();
+      this._activeOperations.set(locator.workspace, workspace);
+    }
+    let repository = workspace.get(locator.repository);
+    if (!repository) {
+      repository = new Map();
+      workspace.set(locator.repository, repository);
+    }
+    if (repository.has(locator.packageIdentifier)) return null;
+    const operation = Object.freeze({ locator, id: ++this._operationSequence });
+    repository.set(locator.packageIdentifier, operation);
+    return operation;
+  }
+
+  _releaseOperation(operation) {
+    const workspace = this._activeOperations.get(operation.locator.workspace);
+    const repository = workspace?.get(operation.locator.repository);
+    if (repository?.get(operation.locator.packageIdentifier) !== operation) return;
+    repository.delete(operation.locator.packageIdentifier);
+    if (repository.size === 0) workspace.delete(operation.locator.repository);
+    if (workspace.size === 0) this._activeOperations.delete(operation.locator.workspace);
+  }
+
+  _isAccountCurrent(account) {
+    return !this._disposed && isAccountCurrent(this._connectionManager, account);
+  }
+
+  _isCurrent(operation, account) {
+    if (!this._isAccountCurrent(account)) return false;
+    const workspace = this._activeOperations.get(operation.locator.workspace);
+    const repository = workspace?.get(operation.locator.repository);
+    return repository?.get(operation.locator.packageIdentifier) === operation;
+  }
+
+  _recentFor(account, source) {
+    return this._recentTargets
+      .filter(entry => (
+        entry.activationId === account.activationId
+        && entry.accountEpoch === account.accountEpoch
+        && entry.workspace === source.workspace
+        && entry.sourceRepository === source.repository
+        && entry.packageIdentifier === source.packageIdentifier
+      ))
+      .map(entry => entry.targetRepository)
+      .slice(0, 5);
+  }
+
+  _recordRecent(account, outcome) {
+    this._recentTargets = [
+      {
+        activationId: account.activationId,
+        accountEpoch: account.accountEpoch,
+        workspace: outcome.source.workspace,
+        sourceRepository: outcome.source.repository,
+        packageIdentifier: outcome.source.packageIdentifier,
+        targetRepository: outcome.target.repository,
+      },
+      ...this._recentTargets.filter(entry => !(
+        entry.activationId === account.activationId
+        && entry.accountEpoch === account.accountEpoch
+        && entry.workspace === outcome.source.workspace
+        && entry.sourceRepository === outcome.source.repository
+        && entry.packageIdentifier === outcome.source.packageIdentifier
+        && entry.targetRepository === outcome.target.repository
+      )),
+    ].slice(0, MAX_RECENT_TARGETS);
+  }
+
+  async _publish(outcome, operation, account, options) {
+    if (!this._isCurrent(operation, account)) {
+      return this._suppressStalePublication(outcome);
+    }
+    if (outcome.overall === "succeeded") this._recordRecent(account, outcome);
+    let refreshFailed = false;
+    if (["changed", "possibly_changed", "present"].includes(outcome.remoteState)) {
+      try {
+        await Promise.resolve(options.refresh?.());
+      } catch {
+        refreshFailed = true;
+      }
+      if (!this._isCurrent(operation, account)) {
+        return this._suppressStalePublication(outcome);
+      }
+      if (refreshFailed) {
+        try {
+          await this._window.showWarningMessage(
+            "Promotion finished, but the package view could not be refreshed. Refresh it manually."
+          );
+        } catch {
+          // Notification failures must not change the remote outcome.
+        }
+      }
+      if (!this._isCurrent(operation, account)) {
+        return this._suppressStalePublication(outcome);
+      }
+    }
+    if (!this._isCurrent(operation, account)) return this._suppressStalePublication(outcome);
+    await this._showOutcome(outcome);
+    return outcome;
+  }
+
+  async _suppressStalePublication(outcome) {
+    if (!this._disposed) {
+      try {
+        await this._window.showWarningMessage(
+          "The active Cloudsmith account changed. Promotion results were not applied to the current view."
+        );
+      } catch {
+        // Notification failures must not change the remote outcome.
+      }
+    }
+    return outcome;
+  }
+
+  async _publishFailure(outcome) {
+    await this._showFailure(outcome);
+    return outcome;
+  }
+
+  async _publishStaleOrFailure(operation, account, code) {
+    const outcome = failureOutcome(code);
+    if (account && !this._isCurrent(operation, account)) return outcome;
+    await this._showFailure(outcome);
+    return outcome;
+  }
+
+  _staleOutcome() {
+    return createOutcome({ overall: "failed", errorCode: "account_changed", remoteState: "unchanged" });
+  }
+
+  async _showOutcome(outcome) {
+    try {
+      if (outcome.overall === "cancelled") return;
+      if (outcome.overall === "succeeded") {
+        await this._window.showInformationMessage(
+          `Promoted “${outcome.source.name}” ${outcome.source.version} from ${outcome.source.workspace}/${outcome.source.repository} to ${outcome.target.workspace}/${outcome.target.repository}. All required tags were verified.`
+        );
+        return;
+      }
+      if (outcome.overall === "partial") {
+        await this._window.showWarningMessage(
+          "The package was copied, but promotion tagging is incomplete.",
+          {
+            modal: true,
+            detail: `${stageSummary(outcome)}\n\nAdd the missing configured tags directly in Cloudsmith. Do not repeat the copy.`,
+          }
+        );
+        return;
+      }
+      if (outcome.overall === "ambiguous") {
+        await this._window.showWarningMessage(
+          "Promotion completion could not be confirmed.",
+          {
+            modal: true,
+            detail: `${stageSummary(outcome)}\n\nInspect the target repository before retrying. Repeating the copy may create a duplicate.`,
+          }
+        );
+        return;
+      }
+      await this._showFailure(outcome);
+    } catch {
+      // Notification failures must not change the remote outcome.
+    }
+  }
+
+  async _showFailure(outcome) {
+    try {
+      const message = failureMessage(outcome.errorCode);
+      if ([
+        "malformed_source_locator",
+        "conflicting_source_workspace",
+        "conflicting_source_repository",
+        "conflicting_source_identifier",
+        "malformed_copyability",
+        "malformed_source_package",
+        "missing_package_fingerprint",
+        "source_identity_changed",
+        "package_not_copyable",
+        "target_package_exists",
+        "preflight_changed",
+        "malformed_pipeline",
+        "malformed_tag_configuration",
+      ].includes(outcome.errorCode)) {
+        await this._window.showWarningMessage(message);
+        return;
+      }
+      await this._window.showErrorMessage(message);
+    } catch {
+      // Notification failures must not change the remote outcome.
+    }
+  }
+}
+
+function preflightFailure(errorCodeValue, source = null) {
+  return deepFreeze({ ok: false, preflight: null, source, errorCode: errorCodeValue });
+}
+
+function reportProgress(progress, message) {
+  try {
+    progress?.report({ message });
+  } catch {
+    // Progress rendering is advisory and must not change remote-write semantics.
+  }
+}
+
+function interruptedExecutionOutcome(preflight, tagPlan, executionState) {
+  const base = {
+    source: preflight.source,
+    target: preflight.target,
+    preflight: createStage("succeeded", { evidence: "fresh_read" }),
+    confirmation: createStage("succeeded", { evidence: "user_confirmation" }),
+  };
+  if (!executionState.writeIssued) {
+    return createOutcome({
+      ...base,
+      copy: createStage("not_attempted", { required: true }),
+      sourceTag: createStage(tagPlan.source.length ? "not_attempted" : "not_required", {
+        required: tagPlan.source.length > 0,
+      }),
+      targetTag: createStage(tagPlan.target.length ? "not_attempted" : "not_required", {
+        required: tagPlan.target.length > 0,
+      }),
+      overall: "failed",
+      errorCode: "write_workflow_interrupted",
+      remoteState: "unchanged",
+    });
+  }
+  const copy = executionState.copy || createStage("ambiguous", {
+    required: true,
+    attempted: true,
+    evidence: "write_dispatched",
+    errorCode: "write_workflow_interrupted",
+  });
+  return createOutcome({
+    ...base,
+    copy,
+    sourceTag: executionState.sourceTag || createStage(
+      tagPlan.source.length ? "not_attempted" : "not_required",
+      { required: tagPlan.source.length > 0 }
+    ),
+    targetTag: executionState.targetTag || createStage(
+      tagPlan.target.length ? "not_attempted" : "not_required",
+      { required: tagPlan.target.length > 0 }
+    ),
+    reconciliation: executionState.reconciliation
+      || createStage("ambiguous", { errorCode: "write_workflow_interrupted" }),
+    overall: "ambiguous",
+    errorCode: "write_workflow_interrupted",
+    remoteState: copy.status === "succeeded" ? "changed" : "possibly_changed",
+  });
+}
+
+function failureOutcome(code, options = {}) {
+  return createOutcome({
+    source: options.source || null,
+    target: options.target || null,
+    preflight: options.preflight || createStage("failed", { errorCode: code }),
+    confirmation: options.confirmation,
+    overall: "failed",
+    errorCode: code,
+    remoteState: "unchanged",
+  });
+}
+
+function errorCode(error, fallback) {
+  return error instanceof PromotionContractError && error.code ? error.code : fallback;
+}
+
+function readErrorCode(error, subject) {
+  if (error?.kind === "cancelled") return "cancelled";
+  if (error?.kind === "not_found" || error?.status === 404) return `${subject}_missing`;
+  if (error?.kind === "forbidden" || error?.status === 403) return `${subject}_access_denied`;
+  if (error?.kind === "invalid_response") return `${subject}_malformed`;
+  return `${subject}_unverified`;
+}
+
+function isDefiniteWriteFailure(error) {
+  if (!error || error.outcomeUnknown !== false) return false;
+  if (error.kind === "invalid_request" && error.status == null) return true;
+  return Number.isInteger(error.status) && error.status >= 400 && error.status < 500;
+}
+
+function sameSource(expected, actual) {
+  return Boolean(actual)
+    && expected.workspace === actual.workspace
+    && expected.repository === actual.repository
+    && expected.packageIdentifier === actual.packageIdentifier
+    && expected.name === actual.name
+    && expected.version === actual.version
+    && expected.format === actual.format
+    && expected.copyable === actual.copyable
+    && expected.fingerprint.checksum === actual.fingerprint.checksum
+    && expected.fingerprint.versionDigest === actual.fingerprint.versionDigest;
+}
+
+function reconcileTagStage(stage, missing) {
+  if (stage.status === "failed" && stage.attempted) return stage;
+  if (missing.length === 0) {
+    if (stage.status === "ambiguous" || stage.status === "failed") {
+      return createStage("succeeded", {
+        required: stage.required,
+        attempted: stage.attempted,
+        evidence: "fresh_read",
+      });
+    }
+    return stage;
+  }
+  if (stage.status === "ambiguous") return stage;
+  return createStage("failed", {
+    required: stage.required,
+    attempted: stage.attempted,
+    evidence: "fresh_read",
+    errorCode: "tag_not_present",
+  });
+}
+
+function stageSummary(outcome) {
+  return [
+    `Copy: ${outcome.copy.status}`,
+    `Source tags: ${outcome.sourceTag.status}`,
+    `Target tags: ${outcome.targetTag.status}`,
+    `Final verification: ${outcome.reconciliation.status}`,
+  ].join("\n");
+}
+
+function failureMessage(code) {
+  const messages = {
+    account_changed: "The active Cloudsmith account changed. No further promotion changes were attempted.",
+    authentication_unavailable: "Cloudsmith authentication is not ready. Connect an account and try again.",
+    cancelled: "Promotion was cancelled before any changes were made.",
+    conflicting_source_identifier: "Package identifiers disagree. Refresh the package list and try again.",
+    conflicting_source_repository: "Package repository details disagree. Refresh the package list and try again.",
+    conflicting_source_workspace: "Package workspace details disagree. Refresh the package list and try again.",
+    copy_failed: "Cloudsmith did not copy the package. No tags were attempted.",
+    malformed_copyability: "Cloudsmith returned incomplete copyability information. No changes were made.",
+    malformed_pipeline: "The promotion pipeline setting is invalid. Fix it before promoting a package.",
+    malformed_source_locator: "Package details are incomplete. Refresh the package list and try again.",
+    malformed_source_package: "Cloudsmith returned incomplete package details. No changes were made.",
+    malformed_tag_configuration: "The promotion tag setting is invalid. Fix it before promoting a package.",
+    missing_package_fingerprint: "The package cannot be verified strongly enough for a safe promotion. No changes were made.",
+    no_target_repositories: "No valid target repositories are available for this package.",
+    package_not_copyable: "This package is not copyable. No changes were made.",
+    pipeline_repository_missing: "A configured promotion repository is unavailable. Check the pipeline and repository access.",
+    preflight_changed: "Package or target state changed before promotion. No changes were made. Select the target again.",
+    repository_list_incomplete: "The complete repository list could not be verified. No changes were made.",
+    source_access_denied: "The source package could not be verified. Check repository access and try again.",
+    source_identity_changed: "Package details changed. Refresh the package list and try again. No changes were made.",
+    source_missing: "The source package is no longer available. Refresh the package list and try again.",
+    source_not_in_pipeline: "The source repository is not a valid stage in the configured promotion pipeline.",
+    target_access_denied: "The target repository could not be verified. Check repository access and try again.",
+    target_missing: "The target repository is unavailable. Check repository access and try again.",
+    target_package_exists: "This package already exists in the selected target repository. No changes were made.",
+    target_state_unknown: "Target package state could not be verified. No changes were made.",
+    unexpected_error: "Promotion stopped because of an unexpected error. No further changes were attempted.",
+  };
+  return messages[code] || "Promotion requirements could not be verified. No changes were made.";
 }
 
 function isRecord(value) {
@@ -348,44 +1414,22 @@ function isRecordArray(value) {
   return Array.isArray(value) && value.every(isRecord);
 }
 
-function packageIdentifier(value) {
-  if (typeof value === "string" && value.length > 0) {
-    return value;
-  }
-  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
-    ? value.value
-    : null;
-}
-
-function isPackageIdentityRecord(value) {
-  return isRecord(value)
-    && typeof value.name === "string" && value.name.length > 0
-    && (typeof value.version === "string" || typeof value.version === "number")
-    && String(value.version).length > 0
-    && typeof value.format === "string" && value.format.length > 0;
-}
-
-function isPackageWriteRecord(value) {
-  return isPackageIdentityRecord(value)
-    && Boolean(packageIdentifier(value.slug_perm || value.slug_perm_raw || value.slug));
-}
-
-function isPackageWriteArray(value) {
-  return Array.isArray(value) && value.every(isPackageWriteRecord);
+function isPackageLocationArray(value) {
+  return Array.isArray(value) && value.every(pkg => (
+    isRecord(pkg)
+    && typeof pkg.name === "string"
+    && (typeof pkg.version === "string" || typeof pkg.version === "number")
+    && typeof pkg.format === "string"
+    && typeof pkg.repository === "string"
+  ));
 }
 
 function isPromotionStatusArray(value) {
-  return Array.isArray(value) && value.every(pkg => (
-    isPackageIdentityRecord(pkg)
-    && typeof pkg.repository === "string"
-    && pkg.repository.length > 0
-  ));
+  return isPackageLocationArray(value);
 }
 
-function isRepositoryArray(value) {
-  return isRecordArray(value) && value.every(repo => (
-    typeof repo.slug === "string" && repo.slug.length > 0
-  ));
-}
-
-module.exports = { PromotionProvider };
+module.exports = {
+  MAX_EXACT_PACKAGE_ITEMS,
+  MAX_EXACT_PACKAGE_PAGES,
+  PromotionProvider,
+};

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -1089,6 +1089,11 @@ function canonicalizeSearchPackage(pkg) {
         repository,
         namespace,
         slug_perm: slugPerm,
+        is_copyable: pkg.is_copyable === true
+            ? true
+            : pkg.is_copyable === false
+                ? false
+                : null,
         status_str: optionalString(pkg.status_str),
         slug: optionalString(pkg.slug, MAX_PACKAGE_IDENTITY_LENGTH),
         downloads,


### PR DESCRIPTION
## Summary

- Adds canonical promotion identities, fresh preflight checks, and explicit confirmation before remote writes.
- Executes copy and source/target tagging as independently reported stages with bounded reconciliation and no blind write retries.
- Prevents duplicate and stale transactions while keeping history, refresh, and user messages aligned with verified outcomes.

## Validation

- `npm run lint` (0 errors; one pre-existing warning)
- `npm test` (775 passing; 7 pending)
- Focused promotion, package-model, pagination, and API tests (92 passing)
- `npm run build`
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`
- `vsce package --no-dependencies`
