### PR TITLE
fix: tighten promotion identity contracts

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -30,6 +30,10 @@ const { UpstreamChecker } = require("./util/upstreamChecker");
 const { UpstreamPreviewProvider } = require("./views/upstreamPreviewProvider");
 const { UpstreamDetailProvider } = require("./views/upstreamDetailProvider");
 const { PromotionProvider } = require("./views/promotionProvider");
+const {
+  isPackageLocationArray,
+  normalizePackageQueryIdentity,
+} = require("./util/promotionContracts");
 const { SearchQueryBuilder } = require("./util/searchQueryBuilder");
 const { formatApiError } = require("./util/errorFormatter");
 const { buildExactPackageQuery, packageMatchesExactIdentity } = require("./util/packageQuery");
@@ -108,19 +112,6 @@ function isRepositoryArray(value) {
     && repo.slug.length > 0
     && typeof repo.name === "string"
     && repo.name.length > 0
-  ));
-}
-
-function isPackageLocationArray(value) {
-  return isRecordArray(value) && value.every(pkg => (
-    typeof pkg.name === "string"
-    && pkg.name.length > 0
-    && (typeof pkg.version === "string" || typeof pkg.version === "number")
-    && String(pkg.version).length > 0
-    && typeof pkg.format === "string"
-    && pkg.format.length > 0
-    && typeof pkg.repository === "string"
-    && pkg.repository.length > 0
   ));
 }
 
@@ -2462,7 +2453,15 @@ async function activate(context) {
       recentPackages.add(item);
 
       const info = extractPackageInfo(item);
-      if (!info.workspace || !info.name || !info.version || !info.format) {
+      let promotionIdentity;
+      try {
+        promotionIdentity = normalizePackageQueryIdentity(
+          info.workspace,
+          info.name,
+          info.version,
+          info.format
+        );
+      } catch {
         vscode.window.showWarningMessage("Could not determine package details.");
         return;
       }
@@ -2471,7 +2470,10 @@ async function activate(context) {
       if (pipeline.length > 0) {
         // Pipeline mode: show status across configured repos
         const statusResult = await promotionProvider.getPromotionStatus(
-          info.workspace, info.name, info.version, info.format
+          promotionIdentity.workspace,
+          promotionIdentity.name,
+          promotionIdentity.version,
+          promotionIdentity.format
         );
 
         if (statusResult.error) {
@@ -2492,16 +2494,20 @@ async function activate(context) {
           return `${icon} ${s.repo}: ${s.status}`;
         });
         vscode.window.showInformationMessage(
-          `Pipeline for ${info.name} ${info.version}: ${lines.join(" \u2192 ")}`
+          `Pipeline for ${promotionIdentity.name} ${promotionIdentity.version}: ${lines.join(" \u2192 ")}`
         );
       } else {
         // No pipeline: search workspace-wide for this package name+version
         const cloudsmithAPI = new CloudsmithAPI(context);
         let endpoint;
         try {
-          endpoint = apiEndpoint(["packages", info.workspace], {
+          endpoint = apiEndpoint(["packages", promotionIdentity.workspace], {
             query: {
-              query: buildExactPackageQuery(info.name, info.version, info.format),
+              query: buildExactPackageQuery(
+                promotionIdentity.name,
+                promotionIdentity.version,
+                promotionIdentity.format
+              ),
               page_size: 100,
             },
           });
@@ -2521,9 +2527,13 @@ async function activate(context) {
           );
           return;
         }
-        const exactPackages = results.data.filter(pkg => packageMatchesExactIdentity(pkg, info));
+        const exactPackages = results.data.filter(pkg => (
+          packageMatchesExactIdentity(pkg, promotionIdentity)
+        ));
         if (exactPackages.length === 0) {
-          vscode.window.showInformationMessage(`${info.name} ${info.version} was not found in any other repository.`);
+          vscode.window.showInformationMessage(
+            `${promotionIdentity.name} ${promotionIdentity.version} was not found in any other repository.`
+          );
           return;
         }
 
@@ -2532,7 +2542,7 @@ async function activate(context) {
           return `${icon} ${pkg.repository}: ${pkg.status_str || "Unknown"}`;
         });
         vscode.window.showInformationMessage(
-          `${info.name} ${info.version} found in: ${lines.join(", ")}`
+          `${promotionIdentity.name} ${promotionIdentity.version} found in: ${lines.join(", ")}`
         );
       }
     }),

--- a/test/promotionContracts.test.js
+++ b/test/promotionContracts.test.js
@@ -5,7 +5,9 @@ const {
   createSourceLocator,
   createStage,
   createTagPlan,
+  isPackageLocationArray,
   normalizeFreshSource,
+  normalizePackageQueryIdentity,
   normalizePipeline,
   normalizeTargetPackage,
   preflightFingerprint,
@@ -29,6 +31,18 @@ suite("Promotion contracts", () => {
       is_copyable: true,
       checksum_sha256: "checksum-a",
       tags: { info: [] },
+      ...overrides,
+    };
+  }
+
+  function locationRecord(overrides = {}) {
+    return {
+      namespace: "workspace",
+      repository: "source",
+      slug_perm: "package-id",
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
       ...overrides,
     };
   }
@@ -85,6 +99,87 @@ suite("Promotion contracts", () => {
     }
   });
 
+  test("package-location arrays require complete canonical string identities", () => {
+    assert.strictEqual(isPackageLocationArray([locationRecord()]), true);
+    assert.strictEqual(
+      isPackageLocationArray([locationRecord({ slug_perm_raw: "package-id" })]),
+      true
+    );
+
+    const malformed = [
+      locationRecord({ name: "" }),
+      locationRecord({ name: "   " }),
+      locationRecord({ name: "artifact\u0000" }),
+      locationRecord({ version: "" }),
+      locationRecord({ version: "   " }),
+      locationRecord({ version: 1 }),
+      locationRecord({ version: Number.NaN }),
+      locationRecord({ version: Number.POSITIVE_INFINITY }),
+      locationRecord({ version: Number.NEGATIVE_INFINITY }),
+      locationRecord({ format: "" }),
+      locationRecord({ format: "   " }),
+      locationRecord({ format: "np\u202em" }),
+      locationRecord({ namespace: "" }),
+      locationRecord({ namespace: "   " }),
+      locationRecord({ namespace: "../workspace" }),
+      locationRecord({ namespace: "workspace%2fother" }),
+      locationRecord({ namespace: "workspace%252fother" }),
+      locationRecord({ repository: "" }),
+      locationRecord({ repository: "   " }),
+      locationRecord({ repository: "../source" }),
+      locationRecord({ repository: "source/other" }),
+      locationRecord({ slug_perm: "" }),
+      locationRecord({ slug_perm: "   " }),
+      locationRecord({ slug_perm: "../package-id" }),
+      locationRecord({ slug_perm: "package%5cid" }),
+      locationRecord({ slug_perm: "package%255cid" }),
+      locationRecord({ slug_perm_raw: "other-package-id" }),
+      locationRecord({ namespace: undefined }),
+      locationRecord({ repository: undefined }),
+      locationRecord({ slug_perm: undefined }),
+    ];
+    for (const record of malformed) {
+      assert.doesNotThrow(() => isPackageLocationArray([record]));
+      assert.strictEqual(isPackageLocationArray([record]), false);
+    }
+    assert.strictEqual(
+      isPackageLocationArray([locationRecord(), locationRecord({ repository: " " })]),
+      false
+    );
+    assert.strictEqual(isPackageLocationArray({}), false);
+  });
+
+  test("promotion query identity is normalized once and rejects ambiguous inputs", () => {
+    const identity = normalizePackageQueryIdentity("workspace", "artifact", "1.0.0", "npm");
+    assert.deepStrictEqual(identity, {
+      workspace: "workspace",
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+    });
+    assert(Object.isFrozen(identity));
+
+    const invalid = [
+      ["", "artifact", "1.0.0", "npm"],
+      ["   ", "artifact", "1.0.0", "npm"],
+      ["../workspace", "artifact", "1.0.0", "npm"],
+      ["workspace%252fother", "artifact", "1.0.0", "npm"],
+      ["workspace", "", "1.0.0", "npm"],
+      ["workspace", "   ", "1.0.0", "npm"],
+      ["workspace", "artifact", "", "npm"],
+      ["workspace", "artifact", "   ", "npm"],
+      ["workspace", "artifact", 1, "npm"],
+      ["workspace", "artifact", Number.NaN, "npm"],
+      ["workspace", "artifact", Number.POSITIVE_INFINITY, "npm"],
+      ["workspace", "artifact", Number.NEGATIVE_INFINITY, "npm"],
+      ["workspace", "artifact", "1.0.0", ""],
+      ["workspace", "artifact", "1.0.0", "   "],
+    ];
+    for (const args of invalid) {
+      assert.throws(() => normalizePackageQueryIdentity(...args), PromotionContractError);
+    }
+  });
+
   test("fresh source is the only authority for identity and strict copyability", () => {
     const source = normalizeFreshSource(sourceRecord(), locator);
     assert.strictEqual(source.copyable, true);
@@ -104,11 +199,25 @@ suite("Promotion contracts", () => {
   test("rejects fresh identity mismatch, malformed versions, and missing immutable evidence", () => {
     for (const record of [
       sourceRecord({ slug_perm: "different" }),
+      sourceRecord({ slug_perm: "" }),
+      sourceRecord({ slug_perm: "   " }),
       sourceRecord({ namespace: "other" }),
+      sourceRecord({ namespace: "" }),
+      sourceRecord({ namespace: "   " }),
       sourceRecord({ repository: "other" }),
+      sourceRecord({ repository: "" }),
+      sourceRecord({ repository: "   " }),
+      sourceRecord({ name: "" }),
+      sourceRecord({ name: "   " }),
+      sourceRecord({ version: "" }),
+      sourceRecord({ version: "   " }),
+      sourceRecord({ version: 1 }),
       sourceRecord({ version: Number.NaN }),
       sourceRecord({ version: Number.POSITIVE_INFINITY }),
+      sourceRecord({ version: Number.NEGATIVE_INFINITY }),
       sourceRecord({ version: {} }),
+      sourceRecord({ format: "" }),
+      sourceRecord({ format: "   " }),
       sourceRecord({ checksum_sha256: null, version_digest: null }),
     ]) {
       assert.throws(() => normalizeFreshSource(record, locator), PromotionContractError);
@@ -147,6 +256,30 @@ suite("Promotion contracts", () => {
       }, sourceWithBoth, target),
       PromotionContractError
     );
+
+    for (const record of [
+      { ...packageRecord, namespace: "" },
+      { ...packageRecord, namespace: "   " },
+      { ...packageRecord, repository: "" },
+      { ...packageRecord, repository: "   " },
+      { ...packageRecord, slug_perm: "" },
+      { ...packageRecord, slug_perm: "   " },
+      { ...packageRecord, name: "" },
+      { ...packageRecord, name: "   " },
+      { ...packageRecord, version: "" },
+      { ...packageRecord, version: "   " },
+      { ...packageRecord, version: 1 },
+      { ...packageRecord, version: Number.NaN },
+      { ...packageRecord, version: Number.POSITIVE_INFINITY },
+      { ...packageRecord, version: Number.NEGATIVE_INFINITY },
+      { ...packageRecord, format: "" },
+      { ...packageRecord, format: "   " },
+    ]) {
+      assert.throws(
+        () => normalizeTargetPackage(record, source, target),
+        PromotionContractError
+      );
+    }
   });
 
   test("pipeline and expanded tag plans are bounded, unique, and frozen", () => {

--- a/test/promotionProvider.test.js
+++ b/test/promotionProvider.test.js
@@ -66,6 +66,13 @@ suite("Safe package promotion workflow", () => {
       ...overrides,
     });
 
+    function validatedSuccess(data, requestOptions, pageOptions = null) {
+      if (requestOptions?.validate && !requestOptions.validate(data)) {
+        return apiFailure("invalid_response", { outcomeUnknown: false });
+      }
+      return pageOptions === null ? apiSuccess(data) : page(data, pageOptions);
+    }
+
     const api = {
       async get(endpoint, requestOptions) {
         calls.get.push({ endpoint, options: requestOptions });
@@ -83,13 +90,16 @@ suite("Safe package promotion workflow", () => {
           const overrides = typeof options.sourceOverrides === "function"
             ? options.sourceOverrides(sourceReadCount)
             : options.sourceOverrides || {};
-          return apiSuccess(sourceRecord(overrides));
+          return validatedSuccess(sourceRecord(overrides), requestOptions);
         }
         if (endpoint === "repos/workspace/target/") {
           if (options.targetRepositoryFailure) {
             return apiFailure("forbidden", { status: 403, outcomeUnknown: false });
           }
-          return apiSuccess({ name: "Target", slug: "target", namespace: "workspace" });
+          return validatedSuccess(
+            { name: "Target", slug: "target", namespace: "workspace" },
+            requestOptions
+          );
         }
         if (endpoint.startsWith("packages/workspace/target/?")) {
           targetQueryCount += 1;
@@ -104,7 +114,10 @@ suite("Safe package promotion workflow", () => {
           if (options.duplicateTargetAt === targetQueryCount && targetExists) {
             data.push(targetRecord({ slug_perm: "second-target-package-id" }));
           }
-          const result = page(data, {
+          if (options.targetLocationOverrides) {
+            data.push(targetRecord(options.targetLocationOverrides));
+          }
+          const result = validatedSuccess(data, requestOptions, {
             pageTotal: options.targetPageTotalAt === targetQueryCount ? 21 : 1,
             count: options.targetPageTotalAt === targetQueryCount ? 2100 : data.length,
           });
@@ -117,8 +130,12 @@ suite("Safe package promotion workflow", () => {
           if (options.presenceHintFailure) {
             return apiFailure("network_error", { outcomeUnknown: false });
           }
-          const data = options.hintExists || targetExists ? [targetRecord()] : [];
-          return page(data);
+          const data = options.presenceLocationOverrides
+            ? [targetRecord(options.presenceLocationOverrides)]
+            : options.hintExists || targetExists
+              ? [targetRecord()]
+              : [];
+          return validatedSuccess(data, requestOptions, {});
         }
         throw new Error(`Unexpected GET ${endpoint}`);
       },
@@ -138,8 +155,8 @@ suite("Safe package promotion workflow", () => {
             });
           }
           targetExists = true;
-          if (options.copyMalformedResponse) return apiSuccess({});
-          return apiSuccess(targetRecord(options.copyResponseOverrides));
+          if (options.copyMalformedResponse) return validatedSuccess({}, requestOptions);
+          return validatedSuccess(targetRecord(options.copyResponseOverrides), requestOptions);
         }
         if (endpoint === "packages/workspace/source/source-package-id/tag/") {
           if (options.sourceTagFailure) {
@@ -151,10 +168,12 @@ suite("Safe package promotion workflow", () => {
               outcomeUnknown: options.sourceTagAmbiguous === true,
             });
           }
-          if (options.sourceTagMalformedResponse) return apiSuccess({});
-          if (options.sourceTagPretendSuccess) return apiSuccess(sourceRecord());
+          if (options.sourceTagMalformedResponse) return validatedSuccess({}, requestOptions);
+          if (options.sourceTagPretendSuccess) {
+            return validatedSuccess(sourceRecord(), requestOptions);
+          }
           for (const tag of json.tags) sourceTags.add(tag);
-          return apiSuccess(sourceRecord());
+          return validatedSuccess(sourceRecord(), requestOptions);
         }
         if (endpoint === "packages/workspace/target/target-package-id/tag/") {
           if (options.targetTagFailure) {
@@ -167,7 +186,7 @@ suite("Safe package promotion workflow", () => {
             });
           }
           for (const tag of json.tags) targetTags.add(tag);
-          return apiSuccess(targetRecord(options.targetTagResponseOverrides));
+          return validatedSuccess(targetRecord(options.targetTagResponseOverrides), requestOptions);
         }
         throw new Error(`Unexpected POST ${endpoint}`);
       },
@@ -360,6 +379,9 @@ suite("Safe package promotion workflow", () => {
       { sourceFailureAt: 1, expected: "source_missing" },
       { sourceOverrides: { is_copyable: "false" }, expected: "malformed_copyability" },
       { sourceOverrides: { slug_perm: "different" }, expected: "source_identity_changed" },
+      { sourceOverrides: { name: "   " }, expected: "malformed_source_package" },
+      { sourceOverrides: { version: 1 }, expected: "malformed_source_package" },
+      { sourceOverrides: { format: "" }, expected: "malformed_source_package" },
       { sourceOverrides: { checksum_sha256: null, version_digest: null }, expected: "missing_package_fingerprint" },
     ];
     for (const testCase of cases) {
@@ -397,6 +419,54 @@ suite("Safe package promotion workflow", () => {
       assert.strictEqual(outcome.overall, "failed");
       assert.strictEqual(harness.calls.post.length, 0);
     }
+  });
+
+  test("malformed package-location arrays cannot map status, publish hints, or pass preflight", async () => {
+    const statusHarness = createHarness({ pipeline: ["source", "target"] });
+    statusHarness.provider.api = {
+      async get(_endpoint, requestOptions) {
+        const data = [
+          statusHarness.sourceRecord(),
+          statusHarness.sourceRecord({ name: "" }),
+        ];
+        return requestOptions.validate(data)
+          ? apiSuccess(data)
+          : apiFailure("invalid_response", { outcomeUnknown: false });
+      },
+    };
+    const status = await statusHarness.provider.getPromotionStatus(
+      "workspace",
+      "artifact",
+      "1.0.0",
+      "npm"
+    );
+    assert.deepStrictEqual(status.items, []);
+    assert.strictEqual(status.error.kind, "invalid_response");
+
+    const hints = createHarness({
+      cancelTargetSelection: true,
+      presenceLocationOverrides: { slug_perm_raw: "conflicting-package-id" },
+    });
+    const cancelled = await hints.provider.runPromotionWorkflow(hints.item);
+    assert.strictEqual(cancelled.overall, "cancelled");
+    assert.strictEqual(hints.calls.post.length, 0);
+    assert(hints.calls.quickPick[0].every(item => !item.detail.includes("Already contains")));
+
+    const preflight = createHarness({
+      presenceHintFailure: true,
+      targetLocationOverrides: { repository: "   " },
+    });
+    const failed = await preflight.provider.runPromotionWorkflow(preflight.item);
+    assert.strictEqual(failed.overall, "failed");
+    assert.strictEqual(failed.errorCode, "target_state_malformed");
+    assert.strictEqual(preflight.calls.post.length, 0);
+    assert.strictEqual(
+      preflight.calls.warning.some(call => call.action === "Promote package"),
+      false
+    );
+    assert.deepStrictEqual(preflight.calls.error, [
+      "Cloudsmith returned malformed target package data. No changes were made.",
+    ]);
   });
 
   test("post-confirmation target drift invalidates approval before every write", async () => {
@@ -755,11 +825,13 @@ suite("Safe package promotion workflow", () => {
 
     const filtered = createHarness({ pipeline: ["source", "target"] });
     filtered.provider.api = {
-      async get() {
-        return apiSuccess([
-          { name: "artifact", version: "1.0.0", format: "python", repository: "source" },
-          { name: "artifact", version: "1.0.0", format: "npm", repository: "source", status_str: "Completed" },
-        ]);
+      async get(_endpoint, requestOptions) {
+        const data = [
+          filtered.sourceRecord({ format: "python" }),
+          filtered.sourceRecord({ status_str: "Completed" }),
+        ];
+        assert.strictEqual(requestOptions.validate(data), true);
+        return apiSuccess(data);
       },
     };
     const status = await filtered.provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");

--- a/test/recentPackages.test.js
+++ b/test/recentPackages.test.js
@@ -3,6 +3,21 @@ const assert = require("assert");
 suite("RecentPackages Test Suite", () => {
   let recentPackages;
 
+  function identityPackage(overrides = {}) {
+    return {
+      name: "artifact",
+      format: "npm",
+      version: "1.0.0",
+      namespace: "workspace",
+      cloudsmithWorkspace: "workspace",
+      repository: "source",
+      cloudsmithRepo: "source",
+      slug_perm: "package-id",
+      slug_perm_raw: "package-id",
+      ...overrides,
+    };
+  }
+
   setup(() => {
     delete require.cache[require.resolve("../util/recentPackages")];
     recentPackages = require("../util/recentPackages");
@@ -108,5 +123,158 @@ suite("RecentPackages Test Suite", () => {
     assert.strictEqual(stored.slug_perm, null);
     assert.strictEqual(stored.slug_perm_raw, null);
     assert.strictEqual(stored.is_copyable, null);
+  });
+
+  test("repository and workspace alias inversions share one recent-package identity", () => {
+    const cases = [
+      {
+        mutateExisting(stored) { delete stored.repository; },
+        mutateIncoming(incoming) { delete incoming.cloudsmithRepo; },
+      },
+      {
+        mutateExisting(stored) { delete stored.cloudsmithRepo; },
+        mutateIncoming(incoming) { delete incoming.repository; },
+      },
+      {
+        mutateExisting(stored) { delete stored.namespace; },
+        mutateIncoming(incoming) { delete incoming.cloudsmithWorkspace; },
+      },
+      {
+        mutateExisting(stored) { delete stored.cloudsmithWorkspace; },
+        mutateIncoming(incoming) { delete incoming.namespace; },
+      },
+    ];
+
+    for (const testCase of cases) {
+      recentPackages.clear();
+      recentPackages.add(identityPackage());
+      testCase.mutateExisting(recentPackages.getAll()[0]);
+      const incoming = identityPackage();
+      testCase.mutateIncoming(incoming);
+
+      recentPackages.add(incoming);
+
+      const [stored] = recentPackages.getAll();
+      assert.strictEqual(recentPackages.getAll().length, 1);
+      assert.strictEqual(stored.namespace, "workspace");
+      assert.strictEqual(stored.cloudsmithWorkspace, "workspace");
+      assert.strictEqual(stored.repository, "source");
+      assert.strictEqual(stored.cloudsmithRepo, "source");
+    }
+  });
+
+  test("wrapped legacy versions and absent optional aliases canonicalize before comparison", () => {
+    recentPackages.add(identityPackage());
+    const existing = recentPackages.getAll()[0];
+    existing.version = { value: { value: "1.0.0" } };
+    existing.cloudsmithWorkspace = null;
+    existing.cloudsmithRepo = undefined;
+
+    recentPackages.add(identityPackage({
+      namespace: null,
+      repository: null,
+    }));
+
+    const [stored] = recentPackages.getAll();
+    assert.strictEqual(recentPackages.getAll().length, 1);
+    assert.strictEqual(stored.version, "1.0.0");
+    assert.strictEqual(stored.namespace, "workspace");
+    assert.strictEqual(stored.repository, "source");
+  });
+
+  test("empty current versions fall back to the canonical declared version", () => {
+    for (const emptyVersion of ["", { value: "" }, { value: { value: "" } }]) {
+      recentPackages.clear();
+      recentPackages.add(identityPackage({
+        version: emptyVersion,
+        declaredVersion: { value: "1.0.0" },
+      }));
+      recentPackages.add(identityPackage());
+
+      const [stored] = recentPackages.getAll();
+      assert.strictEqual(recentPackages.getAll().length, 1);
+      assert.strictEqual(stored.version, "1.0.0");
+    }
+  });
+
+  test("empty compatibility aliases fail closed without removing a valid identity", () => {
+    const cases = [
+      { cloudsmithRepo: "" },
+      { cloudsmithWorkspace: "" },
+    ];
+
+    for (const overrides of cases) {
+      recentPackages.clear();
+      recentPackages.add(identityPackage());
+      recentPackages.add(identityPackage(overrides));
+
+      const all = recentPackages.getAll();
+      assert.strictEqual(all.length, 2);
+      assert.strictEqual(all.filter(pkg => (
+        pkg.namespace === "workspace" && pkg.repository === "source"
+      )).length, 1);
+      assert.strictEqual(all.filter(pkg => (
+        pkg.namespace === null || pkg.repository === null
+      )).length, 1);
+    }
+  });
+
+  test("structured recent identities cannot collide through delimiters", () => {
+    recentPackages.add(identityPackage({ name: "artifact:1", version: "2" }));
+    recentPackages.add(identityPackage({ name: "artifact", version: "1:2" }));
+
+    assert.strictEqual(recentPackages.getAll().length, 2);
+  });
+
+  test("distinct workspace, repository, package, and version coordinates remain distinct", () => {
+    for (const record of [
+      identityPackage(),
+      identityPackage({ cloudsmithWorkspace: "other-workspace", namespace: "other-workspace" }),
+      identityPackage({ cloudsmithRepo: "other-source", repository: "other-source" }),
+      identityPackage({ name: "other-artifact" }),
+      identityPackage({ version: "2.0.0" }),
+    ]) {
+      recentPackages.add(record);
+    }
+
+    assert.strictEqual(recentPackages.getAll().length, 5);
+  });
+
+  test("malformed identities cannot remove valid entries or collapse into false equality", () => {
+    recentPackages.add(identityPackage());
+    recentPackages.add(identityPackage({ version: { value: { value: {} } } }));
+    recentPackages.add(identityPackage({ version: Number.NaN }));
+    assert.strictEqual(recentPackages.getAll().length, 1);
+
+    recentPackages.add(identityPackage({ cloudsmithRepo: "conflicting-source" }));
+    recentPackages.add(identityPackage({
+      repository: "another-source",
+      cloudsmithRepo: "another-conflict",
+    }));
+
+    const all = recentPackages.getAll();
+    assert.strictEqual(all.length, 3);
+    assert.strictEqual(all.filter(pkg => pkg.repository === "source").length, 1);
+    assert.strictEqual(all.filter(pkg => pkg.repository === null).length, 2);
+  });
+
+  test("re-adding a valid identity collapses every historical duplicate and moves it first", () => {
+    recentPackages.add(identityPackage({
+      name: "first",
+      repository: "first",
+      cloudsmithRepo: "first",
+    }));
+    recentPackages.add(identityPackage({ repository: "source-a", cloudsmithRepo: "source-a" }));
+    recentPackages.add(identityPackage({ repository: "source-b", cloudsmithRepo: "source-b" }));
+
+    for (const entry of recentPackages.getAll().filter(pkg => pkg.name === "artifact")) {
+      entry.repository = "source";
+      entry.cloudsmithRepo = "source";
+    }
+    recentPackages.add(identityPackage());
+
+    const all = recentPackages.getAll();
+    assert.deepStrictEqual(all.map(pkg => pkg.name), ["artifact", "first"]);
+    assert.strictEqual(all[0].repository, "source");
   });
 });

--- a/util/promotionContracts.js
+++ b/util/promotionContracts.js
@@ -71,12 +71,8 @@ function unwrapLegacyValue(value) {
   return current;
 }
 
-function scalarString(value, maximumLength, code, options = {}) {
-  let normalized = value;
-  if (options.allowFiniteNumber && typeof normalized === "number") {
-    if (!Number.isFinite(normalized)) throw new PromotionContractError(code);
-    normalized = String(normalized);
-  }
+function scalarString(value, maximumLength, code) {
+  const normalized = value;
   if (
     typeof normalized !== "string"
     || normalized.length === 0
@@ -211,8 +207,7 @@ function normalizeFreshSource(record, locator) {
     version: scalarString(
       record.version,
       MAX_PACKAGE_VERSION_LENGTH,
-      "malformed_source_package",
-      { allowFiniteNumber: true }
+      "malformed_source_package"
     ),
     format: scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_source_package"),
     copyable: record.is_copyable,
@@ -257,8 +252,7 @@ function normalizeTargetPackage(record, source, target) {
   const version = scalarString(
     record.version,
     MAX_PACKAGE_VERSION_LENGTH,
-    "malformed_target_package",
-    { allowFiniteNumber: true }
+    "malformed_target_package"
   );
   const format = scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_target_package");
   const fingerprint = immutableFingerprint(record);
@@ -299,6 +293,47 @@ function normalizePipeline(value) {
     throw new PromotionContractError("malformed_pipeline");
   }
   return Object.freeze(pipeline);
+}
+
+function normalizePackageQueryIdentity(workspace, name, version, format) {
+  return deepFreeze({
+    workspace: pathIdentity(workspace, MAX_WORKSPACE_LENGTH, "malformed_package_query"),
+    name: scalarString(name, MAX_PACKAGE_NAME_LENGTH, "malformed_package_query"),
+    version: scalarString(version, MAX_PACKAGE_VERSION_LENGTH, "malformed_package_query"),
+    format: scalarString(format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_package_query"),
+  });
+}
+
+function isPackageLocationArray(value) {
+  if (!Array.isArray(value)) return false;
+  try {
+    return value.every(record => {
+      if (!isRecord(record)) return false;
+      pathIdentity(record.namespace, MAX_WORKSPACE_LENGTH, "malformed_package_location");
+      pathIdentity(record.repository, MAX_REPOSITORY_LENGTH, "malformed_package_location");
+      scalarString(record.name, MAX_PACKAGE_NAME_LENGTH, "malformed_package_location");
+      scalarString(record.version, MAX_PACKAGE_VERSION_LENGTH, "malformed_package_location");
+      scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_package_location");
+      const packageIdentifier = pathIdentity(
+        record.slug_perm,
+        MAX_PACKAGE_IDENTIFIER_LENGTH,
+        "malformed_package_location"
+      );
+      if (
+        record.slug_perm_raw != null
+        && pathIdentity(
+          record.slug_perm_raw,
+          MAX_PACKAGE_IDENTIFIER_LENGTH,
+          "malformed_package_location"
+        ) !== packageIdentifier
+      ) {
+        return false;
+      }
+      return true;
+    });
+  } catch {
+    return false;
+  }
 }
 
 function normalizeTagTemplates(value) {
@@ -574,8 +609,10 @@ module.exports = {
   createTagPlan,
   deepFreeze,
   fingerprintsMatch,
+  isPackageLocationArray,
   missingTags,
   normalizeFreshSource,
+  normalizePackageQueryIdentity,
   normalizePipeline,
   normalizeTargetPackage,
   normalizeTargetRepository,

--- a/util/recentPackages.js
+++ b/util/recentPackages.js
@@ -53,35 +53,101 @@ function getRawTags(pkg) {
   return null;
 }
 
+function canonicalVersionScalar(value) {
+  if (value === undefined || value === null) {
+    return { state: "absent", value: "" };
+  }
+  let current = value;
+  for (let depth = 0; depth < 2; depth += 1) {
+    if (
+      !current
+      || typeof current !== "object"
+      || Array.isArray(current)
+      || !Object.prototype.hasOwnProperty.call(current, "value")
+    ) {
+      break;
+    }
+    current = current.value;
+  }
+  if (typeof current === "string") {
+    return { state: "valid", value: current };
+  }
+  if (typeof current === "number" && Number.isFinite(current)) {
+    return { state: "valid", value: String(current) };
+  }
+  return { state: "invalid", value: "" };
+}
+
+function canonicalRecentVersion(pkg) {
+  const version = canonicalVersionScalar(pkg.version);
+  if (version.state === "invalid" || (version.state === "valid" && version.value.length > 0)) {
+    return version;
+  }
+  const declaredVersion = canonicalVersionScalar(pkg.declaredVersion);
+  return declaredVersion.state === "absent"
+    ? { state: "valid", value: "" }
+    : declaredVersion;
+}
+
+function normalizeRecentPackage(pkg) {
+  const version = canonicalRecentVersion(pkg);
+  return {
+    name: pkg.name,
+    workspace: canonicalAlias([pkg.cloudsmithWorkspace, pkg.namespace]),
+    repository: canonicalAlias([pkg.cloudsmithRepo, pkg.repository]),
+    packageIdentifier: canonicalAlias([pkg.slug_perm, pkg.slug_perm_raw]),
+    version: version.value,
+    versionValid: version.state === "valid",
+  };
+}
+
+function recentPackageIdentity(normalized) {
+  if (
+    typeof normalized.name !== "string"
+    || normalized.name.length === 0
+    || typeof normalized.workspace !== "string"
+    || typeof normalized.repository !== "string"
+    || !normalized.versionValid
+  ) {
+    return null;
+  }
+  return JSON.stringify([
+    normalized.workspace,
+    normalized.name,
+    normalized.version,
+    normalized.repository,
+  ]);
+}
+
 /**
  * Add a package to the recent list.
- * @param {Object} pkg  Must have at least { name, format, namespace, repository }.
+ * Workspace and repository may use their current or compatibility aliases. Only
+ * records with a canonical workspace/repository/name/version tuple are deduplicated.
+ * @param {Object} pkg Must have a non-empty name and a supported version shape.
  */
 function add(pkg) {
-  if (!pkg || !pkg.name) {
+  if (!pkg || typeof pkg.name !== "string" || pkg.name.length === 0) {
     return;
   }
-  const workspace = canonicalAlias([pkg.cloudsmithWorkspace, pkg.namespace]);
-  const repository = canonicalAlias([pkg.cloudsmithRepo, pkg.repository]);
-  const packageIdentifier = canonicalAlias([pkg.slug_perm, pkg.slug_perm_raw]);
-  const version = unwrapValue(pkg.version) || pkg.declaredVersion || "";
-  // Deduplicate by workspace + name + version + repository
-  const key = `${workspace || ""}:${pkg.name}:${version}:${repository || ""}`;
-  const idx = _recent.findIndex(p =>
-    `${p.cloudsmithWorkspace || p.namespace || ""}:${p.name}:${p.version || ""}:${p.repository || ""}` === key
-  );
-  if (idx >= 0) {
-    _recent.splice(idx, 1);
+  const normalized = normalizeRecentPackage(pkg);
+  if (!normalized.versionValid) return;
+  const key = recentPackageIdentity(normalized);
+  if (key !== null) {
+    for (let index = _recent.length - 1; index >= 0; index -= 1) {
+      if (recentPackageIdentity(normalizeRecentPackage(_recent[index])) === key) {
+        _recent.splice(index, 1);
+      }
+    }
   }
   const rawTags = getRawTags(pkg);
   _recent.unshift({
-    name: pkg.name,
+    name: normalized.name,
     format: pkg.format,
-    version: version || null,
-    namespace: workspace,
-    repository,
-    slug_perm: packageIdentifier,
-    slug_perm_raw: packageIdentifier,
+    version: normalized.version || null,
+    namespace: normalized.workspace,
+    repository: normalized.repository,
+    slug_perm: normalized.packageIdentifier,
+    slug_perm_raw: normalized.packageIdentifier,
     slug: unwrapValue(pkg.slug) || null,
     is_copyable: pkg.is_copyable === true
       ? true
@@ -98,8 +164,8 @@ function add(pkg) {
     cdn_url: getNestedField(pkg, "cdn_url") || null,
     filename: getNestedField(pkg, "filename") || null,
     status_str: unwrapValue(pkg.status_str) || pkg.status_str_raw || getNestedField(pkg, "status_str") || null,
-    cloudsmithWorkspace: workspace,
-    cloudsmithRepo: repository,
+    cloudsmithWorkspace: normalized.workspace,
+    cloudsmithRepo: normalized.repository,
   });
   if (_recent.length > MAX_RECENT) {
     _recent.length = MAX_RECENT;

--- a/views/promotionProvider.js
+++ b/views/promotionProvider.js
@@ -15,8 +15,10 @@ const {
   createStage,
   createTagPlan,
   deepFreeze,
+  isPackageLocationArray,
   missingTags,
   normalizeFreshSource,
+  normalizePackageQueryIdentity,
   normalizePipeline,
   normalizeTargetPackage,
   normalizeTargetRepository,
@@ -75,27 +77,26 @@ class PromotionProvider {
       return { items: [], error };
     }
     if (pipeline.length === 0) return { items: [], error: null };
-    if (!name || !version || !format) {
-      return { items: [], error: new Error("Package identity is incomplete.") };
-    }
 
     let endpoint;
+    let identity;
     try {
-      const query = buildExactPackageQuery(name, version, format);
-      endpoint = apiEndpoint(["packages", workspace], { query: { query, page_size: 100 } });
+      identity = normalizePackageQueryIdentity(workspace, name, version, format);
+      const query = buildExactPackageQuery(identity.name, identity.version, identity.format);
+      endpoint = apiEndpoint(["packages", identity.workspace], { query: { query, page_size: 100 } });
     } catch (error) {
       return { items: [], error };
     }
     const results = await this.api.get(endpoint, {
       responseType: "array",
-      validate: isPromotionStatusArray,
+      validate: isPackageLocationArray,
       retry: "never",
     });
     if (!results.ok) return { items: [], error: results.error };
 
     const repoMap = new Map();
     for (const pkg of results.data.filter(candidate => (
-      packageMatchesExactIdentity(candidate, { name, version, format })
+      packageMatchesExactIdentity(candidate, identity)
     ))) {
       repoMap.set(pkg.repository, pkg);
     }
@@ -862,7 +863,7 @@ class PromotionProvider {
           query,
           {
             apiKey,
-            validate: isRecordArray,
+            validate: isPackageLocationArray,
             retry: "never",
             cancellationToken,
           }
@@ -1400,6 +1401,7 @@ function failureMessage(code) {
     target_access_denied: "The target repository could not be verified. Check repository access and try again.",
     target_missing: "The target repository is unavailable. Check repository access and try again.",
     target_package_exists: "This package already exists in the selected target repository. No changes were made.",
+    target_state_malformed: "Cloudsmith returned malformed target package data. No changes were made.",
     target_state_unknown: "Target package state could not be verified. No changes were made.",
     unexpected_error: "Promotion stopped because of an unexpected error. No further changes were attempted.",
   };
@@ -1408,24 +1410,6 @@ function failureMessage(code) {
 
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function isRecordArray(value) {
-  return Array.isArray(value) && value.every(isRecord);
-}
-
-function isPackageLocationArray(value) {
-  return Array.isArray(value) && value.every(pkg => (
-    isRecord(pkg)
-    && typeof pkg.name === "string"
-    && (typeof pkg.version === "string" || typeof pkg.version === "number")
-    && typeof pkg.format === "string"
-    && typeof pkg.repository === "string"
-  ));
-}
-
-function isPromotionStatusArray(value) {
-  return isPackageLocationArray(value);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Canonicalized recent-package workspace, repository, and version aliases before deduplication.
- Rejected malformed, empty, or whitespace-only promotion package-location identities.
- Added regression coverage for legacy aliases and fail-closed promotion validation.

## Validation

- `npm run lint` - passed
- `npm test` - passed
- `npm run build` - passed
- `npm audit --omit=dev` - passed
- `git diff --check` - passed
- VSIX package and integrity validation - passed
