### PR TITLE
perf: improve enterprise pagination and collection loading

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -30,13 +30,9 @@ const { UpstreamChecker } = require("./util/upstreamChecker");
 const { UpstreamPreviewProvider } = require("./views/upstreamPreviewProvider");
 const { UpstreamDetailProvider } = require("./views/upstreamDetailProvider");
 const { PromotionProvider } = require("./views/promotionProvider");
-const {
-  isPackageLocationArray,
-  normalizePackageQueryIdentity,
-} = require("./util/promotionContracts");
+const { normalizePackageQueryIdentity } = require("./util/promotionContracts");
 const { SearchQueryBuilder } = require("./util/searchQueryBuilder");
 const { formatApiError } = require("./util/errorFormatter");
-const { buildExactPackageQuery, packageMatchesExactIdentity } = require("./util/packageQuery");
 const { LicenseClassifier } = require("./util/licenseClassifier");
 const { fetchRepositoryUpstreams, generateTerraformConfig } = require("./util/terraformExporter");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("./util/upstreamFormats");
@@ -47,6 +43,10 @@ const { clearVulnerabilityCache } = require("./util/dependencyVulnEnricher");
 const { WorkspaceCache } = require("./util/workspaceCache");
 const { getWorkspaceContextProjector } = require("./util/workspaceContextProjector");
 const { captureAccount, isAccountCurrent } = require("./util/accountOperation");
+const { fetchWorkspaces, normalizedWorkspaceName } = require("./util/workspaceFetcher");
+const { fetchWorkspaceRepositories } = require("./util/workspaceRepositoryFetcher");
+const { PaginatedFetch, replaceCollectionItems } = require("./util/paginatedFetch");
+const { packageCollectionIdentity } = require("./util/collectionIdentity");
 
 let exportTerraformAbortController = null;
 
@@ -96,25 +96,6 @@ function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function isRecordArray(value) {
-  return Array.isArray(value) && value.every(isRecord);
-}
-
-function isWorkspaceArray(value) {
-  return isRecordArray(value) && value.every(workspace => (
-    typeof workspace.slug === "string" && workspace.slug.length > 0
-  ));
-}
-
-function isRepositoryArray(value) {
-  return isRecordArray(value) && value.every(repo => (
-    typeof repo.slug === "string"
-    && repo.slug.length > 0
-    && typeof repo.name === "string"
-    && repo.name.length > 0
-  ));
-}
-
 function getNestedInstallField(item, fieldName) {
   if (!item || typeof item !== "object") {
     return null;
@@ -126,6 +107,20 @@ function getNestedInstallField(item, fieldName) {
     return item.cloudsmithMatch[fieldName];
   }
   return null;
+}
+
+function isInspectedPackageArray(value, workspace, repository, name) {
+  return Array.isArray(value) && value.every(pkg => (
+    pkg
+    && typeof pkg === "object"
+    && !Array.isArray(pkg)
+    && pkg.namespace === workspace
+    && pkg.repository === repository
+    && pkg.name === name
+    && typeof pkg.slug_perm === "string"
+    && pkg.slug_perm.length > 0
+    && pkg.slug_perm.length <= 512
+  ));
 }
 
 function isQuarantinedPackage(item) {
@@ -344,6 +339,10 @@ async function resetAccountScopedState(context, options = {}) {
     () => (options.filterState || filterState).clear(),
     () => (options.recentPackages || recentPackages).clear(),
     () => (options.clearVulnerabilityCache || clearVulnerabilityCache)(),
+    () => options.vulnerabilityProvider?.resetForAccountChange?.(),
+    () => options.quarantineExplainProvider?.resetForAccountChange?.(),
+    () => options.upstreamPreviewProvider?.resetForAccountChange?.(),
+    () => options.upstreamDetailProvider?.resetForAccountChange?.(),
   ];
   const syncFailures = [];
   for (const invalidate of synchronousInvalidators) {
@@ -402,38 +401,77 @@ async function getWorkspaces(context, options = {}) {
     const cloudsmithAPI = options.createCloudsmithAPI
       ? options.createCloudsmithAPI()
       : new CloudsmithAPI(context);
-    const result = await cloudsmithAPI.get("namespaces/?sort=slug", {
-        responseType: "array",
-        validate: isWorkspaceArray,
+    const workspaceFetcher = options.fetchWorkspaces || fetchWorkspaces;
+    const result = await workspaceFetcher(context, {
+        account,
+        cloudsmithAPI,
+        connectionManager,
         retry: "safe-read",
     });
     if (!isAccountCurrent(connectionManager, account)) {
         await workspaceContextProjector.project(true, { operation: projection });
         return null;
     }
-    if (!result.ok) {
-        await workspaceContextProjector.project(false, { operation: projection });
-        if (!isAccountCurrent(connectionManager, account)) return null;
-        vscode.window.showErrorMessage(`Failed to load workspaces: ${formatApiError(result.error)}`);
-        return null;
-    }
-    if (result.data.length === 0) {
-        await workspaceContextProjector.project(false, { operation: projection });
-        if (!isAccountCurrent(connectionManager, account)) return null;
-        return [];
-    }
-    const workspaces = result.data.map(workspace => ({
+    const workspaces = result.items.map(workspace => ({
         ...workspace,
-        name: typeof workspace.name === "string" && workspace.name.length > 0
-            ? workspace.name
-            : workspace.slug,
+        name: normalizedWorkspaceName(workspace),
     }));
-    await workspaceContextProjector.project(workspaces.length > 1, { operation: projection });
+    const normalizedResult = replaceCollectionItems(result, workspaces);
+    await workspaceContextProjector.project(
+      !normalizedResult.complete || workspaces.length > 1,
+      { operation: projection }
+    );
     if (!isAccountCurrent(connectionManager, account)) {
         await workspaceContextProjector.project(true, { operation: projection });
         return null;
     }
-    return workspaces;
+    if (!normalizedResult.complete) {
+      const detail = firstCollectionFailureMessage(normalizedResult);
+      if (workspaces.length === 0) {
+        vscode.window.showErrorMessage(`Failed to load workspaces completely.${detail}`);
+      } else {
+        vscode.window.showWarningMessage(
+          `Workspace choices are incomplete; later workspaces may be unavailable.${detail}`
+        );
+      }
+    }
+    return normalizedResult;
+}
+
+async function getWorkspaceRepositories(context, workspace, options = {}) {
+  const connectionManager = options.connectionManager || getConnectionManager(context);
+  const result = await fetchWorkspaceRepositories(context, workspace, {
+    connectionManager,
+    retry: "safe-read",
+    ...options,
+  });
+  if (!result.complete) {
+    const detail = firstCollectionFailureMessage(result);
+    if (result.items.length === 0) {
+      vscode.window.showErrorMessage(`Could not load repositories completely.${detail}`);
+    } else {
+      vscode.window.showWarningMessage(
+        `Repository choices are incomplete; later repositories may be unavailable.${detail}`
+      );
+    }
+  }
+  return result;
+}
+
+function firstCollectionFailureMessage(result) {
+  const error = result && result.failures && result.failures[0] && result.failures[0].error;
+  return error ? ` ${formatApiError(error)}` : "";
+}
+
+function collectionQuickPickItems(result, mapper, incompleteLabel) {
+  const items = result.items.map(mapper);
+  if (!result.complete) {
+    items.unshift({
+      label: incompleteLabel,
+      kind: vscode.QuickPickItemKind.Separator,
+    });
+  }
+  return items;
 }
 
 async function getPreferredTextDocumentLanguage() {
@@ -546,20 +584,23 @@ async function resolveDependencyScanTarget(context, options = {}) {
     };
   }
 
-  const workspaces = await getWorkspaces(context);
-  if (!workspaces) {
+  const workspaceResult = await getWorkspaces(context);
+  if (!workspaceResult) {
     return null;
   }
-  if (workspaces.length === 0) {
-    vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+  if (workspaceResult.items.length === 0) {
+    if (workspaceResult.complete) {
+      vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+    }
     return null;
   }
 
   const selectedWorkspace = await vscode.window.showQuickPick(
-    workspaces.map((workspace) => ({
-      label: workspace.name,
-      description: workspace.slug,
-    })),
+    collectionQuickPickItems(
+      workspaceResult,
+      workspace => ({ label: workspace.name, description: workspace.slug }),
+      "Workspace list incomplete"
+    ),
     {
       placeHolder: "Select a Cloudsmith workspace for the scan",
     }
@@ -594,28 +635,14 @@ async function resolveDependencyScanTarget(context, options = {}) {
   }
 
   if (!selectedScope._all) {
-    const cloudsmithAPI = new CloudsmithAPI(context);
-    let endpoint;
-    try {
-      endpoint = apiEndpoint(["repos", scanWorkspace], { query: { sort: "name" } });
-    } catch {
-      return null;
-    }
-    const repos = await cloudsmithAPI.get(endpoint, {
-      responseType: "array",
-      validate: isRepositoryArray,
-      retry: "safe-read",
-    });
-    if (!repos.ok) {
-      vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
-      return null;
-    }
-    if (repos.ok && repos.data.length > 0) {
+    const repositories = await getWorkspaceRepositories(context, scanWorkspace);
+    if (repositories.items.length > 0) {
       const selectedRepo = await vscode.window.showQuickPick(
-        repos.data.map((repository) => ({
-          label: repository.name,
-          description: repository.slug,
-        })),
+        collectionQuickPickItems(
+          repositories,
+          repository => ({ label: repository.name, description: repository.slug }),
+          "Repository list incomplete"
+        ),
         {
           placeHolder: "Select a repository",
         }
@@ -624,8 +651,10 @@ async function resolveDependencyScanTarget(context, options = {}) {
       if (selectedRepo) {
         scanRepo = selectedRepo.description;
       }
-    } else {
+    } else if (repositories.complete) {
       vscode.window.showInformationMessage("No repositories were found in this workspace.");
+      return null;
+    } else {
       return null;
     }
   }
@@ -789,6 +818,8 @@ async function activate(context) {
   const connectionManager = new ConnectionManager(context);
   const connectionBinding = bindConnectionManager(context, connectionManager);
   context.subscriptions.push(connectionBinding, connectionManager);
+  const inspectOutputChannel = vscode.window.createOutputChannel("Cloudsmith");
+  context.subscriptions.push(inspectOutputChannel);
 
   // Persisted upstream summaries are account-bound. Purge them before the
   // initial SecretStorage read so an indeterminate startup cannot retain data
@@ -816,7 +847,7 @@ async function activate(context) {
     treeView.title = "Workspaces";
     treeView.description = "";
     vscode.window.showWarningMessage(
-      `Could not access workspace "${slug}". Showing all workspaces.`
+      `Could not verify the repository list for workspace "${slug}". Showing all workspaces.`
     );
   });
 
@@ -868,6 +899,10 @@ async function activate(context) {
 
   let projectedAccountEpoch = connectionManager.getState().accountEpoch;
   let promotionProvider = null;
+  let vulnerabilityProvider = null;
+  let quarantineExplainProvider = null;
+  let upstreamPreviewProvider = null;
+  let upstreamDetailProvider = null;
   const handleConnectionStateChange = async (state) => {
     if (state.accountEpoch !== projectedAccountEpoch) {
       projectedAccountEpoch = state.accountEpoch;
@@ -877,6 +912,10 @@ async function activate(context) {
         searchProvider,
         dependencyHealthProvider,
         workspaceContextProjector,
+        vulnerabilityProvider,
+        quarantineExplainProvider,
+        upstreamPreviewProvider,
+        upstreamDetailProvider,
       });
     }
 
@@ -892,7 +931,7 @@ async function activate(context) {
   context.subscriptions.push(connectionSubscription);
 
   // Create vulnerability WebView provider
-  const vulnerabilityProvider = new VulnerabilityProvider(context);
+  vulnerabilityProvider = new VulnerabilityProvider(context, { connectionManager });
   context.subscriptions.push({ dispose: () => vulnerabilityProvider.dispose() });
 
   // Create compliance report WebView provider
@@ -900,15 +939,15 @@ async function activate(context) {
   context.subscriptions.push({ dispose: () => complianceReportProvider.dispose() });
 
   // Create quarantine explanation WebView provider
-  const quarantineExplainProvider = new QuarantineExplainProvider(context);
+  quarantineExplainProvider = new QuarantineExplainProvider(context, { connectionManager });
   context.subscriptions.push({ dispose: () => quarantineExplainProvider.dispose() });
 
   // Create upstream preview WebView provider
-  const upstreamPreviewProvider = new UpstreamPreviewProvider(context);
+  upstreamPreviewProvider = new UpstreamPreviewProvider(context);
   context.subscriptions.push({ dispose: () => upstreamPreviewProvider.dispose() });
 
   // Create upstream detail WebView provider
-  const upstreamDetailProvider = new UpstreamDetailProvider(context);
+  upstreamDetailProvider = new UpstreamDetailProvider(context);
   context.subscriptions.push({ dispose: () => upstreamDetailProvider.dispose() });
 
   const credentialManager = new CredentialManager(context, { connectionManager });
@@ -955,8 +994,8 @@ async function activate(context) {
     // If connected and no default workspace, offer to set the single workspace as default.
     if (options.offerDefault !== false && !getDefaultWorkspace()) {
       const workspaces = await getWorkspaces(context);
-      if (Array.isArray(workspaces) && workspaces.length === 1) {
-        const ws = workspaces[0];
+      if (workspaces && workspaces.complete && workspaces.items.length === 1) {
+        const ws = workspaces.items[0];
         const choice = await vscode.window.showInformationMessage(
           `One workspace available: ${ws.name}. Set as default?`,
           "Set as default", "Dismiss"
@@ -1044,15 +1083,20 @@ async function activate(context) {
       if (!workspaces) {
         return;
       }
-      if (workspaces.length === 0) {
-        vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+      if (workspaces.items.length === 0) {
+        if (workspaces.complete) {
+          vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+        }
         return;
       }
 
       const items = [
         { label: "$(close) Clear default workspace", description: "Show all workspaces", _clear: true },
       ];
-      for (const ws of workspaces) {
+      if (!workspaces.complete) {
+        items.push({ label: "Workspace list incomplete", kind: vscode.QuickPickItemKind.Separator });
+      }
+      for (const ws of workspaces.items) {
         items.push({ label: ws.name, description: ws.slug });
       }
 
@@ -1154,11 +1198,9 @@ async function activate(context) {
             });
             await vscode.window.showTextDocument(doc, { preview: true });
           } else {
-            const outputChannel =
-              vscode.window.createOutputChannel("Cloudsmith");
-            outputChannel.clear();
-            outputChannel.show(true);
-            outputChannel.append(jsonContent);
+            inspectOutputChannel.clear();
+            inspectOutputChannel.show(true);
+            inspectOutputChannel.append(jsonContent);
           }
 
           vscode.window.showInformationMessage(
@@ -1185,23 +1227,39 @@ async function activate(context) {
 
         if (name) {
           let endpoint;
+          let query;
           try {
-            const query = new SearchQueryBuilder().name(name).build();
-            endpoint = apiEndpoint(["packages", workspace, repo], { query: { query } });
+            query = new SearchQueryBuilder().name(name).build();
+            endpoint = apiEndpoint(["packages", workspace, repo], { query: { sort: "-version" } });
           } catch {
             vscode.window.showErrorMessage("Could not inspect the package group because its identity was invalid.");
             return;
           }
-          const result = await cloudsmithAPI.get(endpoint, {
-            responseType: "array",
-            validate: isRecordArray,
+          const result = await new PaginatedFetch(cloudsmithAPI).fetchCollection(endpoint, {
+            pageSize: 100,
+            maxPages: 20,
+            maxRequests: 20,
+            maxItems: 2000,
+            query,
+            descriptor: `inspect-package-group:${workspace}:${repo}:${name}`,
+            canonicalIdentity: packageCollectionIdentity,
+            validate: value => isInspectedPackageArray(value, workspace, repo, name),
             retry: "safe-read",
           });
-          if (!result.ok) {
-            vscode.window.showErrorMessage(formatApiError(result.error));
+          if (!result.complete && result.items.length === 0) {
+            vscode.window.showErrorMessage(
+              firstCollectionFailureMessage(result) || "Could not inspect the package group completely."
+            );
             return;
           }
-          const jsonContent = JSON.stringify(result.data, null, 2);
+          const jsonContent = JSON.stringify({
+            items: result.items,
+            complete: result.complete,
+            loadedCount: result.items.length,
+            totalCount: result.pagination?.countAuthoritative ? result.pagination.count : null,
+            termination: result.termination,
+            failureCount: result.failureCount,
+          }, null, 2);
 
           const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
           const inspectOutput = await config.get("inspectOutput");
@@ -1213,16 +1271,18 @@ async function activate(context) {
             });
             await vscode.window.showTextDocument(doc, { preview: true });
           } else {
-            const outputChannel =
-              vscode.window.createOutputChannel("Cloudsmith");
-            outputChannel.clear();
-            outputChannel.show(true);
-            outputChannel.append(jsonContent);
+            inspectOutputChannel.clear();
+            inspectOutputChannel.show(true);
+            inspectOutputChannel.append(jsonContent);
           }
 
-          vscode.window.showInformationMessage(
-            `Inspecting package group ${name}.`
-          );
+          if (result.complete) {
+            vscode.window.showInformationMessage(`Inspecting package group ${name}.`);
+          } else {
+            vscode.window.showWarningMessage(
+              `Inspecting an incomplete package-group result (${result.items.length} packages loaded).`
+            );
+          }
         } else {
           vscode.window.showWarningMessage("Run this command from a package context menu.");
         }
@@ -1296,15 +1356,18 @@ async function activate(context) {
         if (!workspaces) {
           return;
         }
-        if (workspaces.length === 0) {
-          vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+        if (workspaces.items.length === 0) {
+          if (workspaces.complete) {
+            vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+          }
           return;
         }
 
-        const items = [];
-        for (const ws of workspaces) {
-          items.push({ label: ws.name, description: ws.slug });
-        }
+        const items = collectionQuickPickItems(
+          workspaces,
+          ws => ({ label: ws.name, description: ws.slug }),
+          "Workspace list incomplete"
+        );
 
         const selected = await vscode.window.showQuickPick(items, {
           placeHolder: "Select a workspace",
@@ -1374,6 +1437,12 @@ async function activate(context) {
       await searchProvider.loadNextPage();
     }),
 
+    vscode.commands.registerCommand("cloudsmith-vsc.loadMoreRepositoryPackages", async (item) => {
+      if (item && typeof item.loadMorePackages === "function") {
+        await item.loadMorePackages();
+      }
+    }),
+
     // Register search in workspace (from workspace context menu or view title)
     vscode.commands.registerCommand("cloudsmith-vsc.searchInWorkspace", async (item) => {
       let workspace;
@@ -1417,16 +1486,19 @@ async function activate(context) {
         if (!workspaces) {
           return;
         }
-        if (workspaces.length === 0) {
-          vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+        if (workspaces.items.length === 0) {
+          if (workspaces.complete) {
+            vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+          }
           return;
         }
 
         // Step 1: Select workspace
-        const wsItems = [];
-        for (const ws of workspaces) {
-          wsItems.push({ label: ws.name, description: ws.slug });
-        }
+        const wsItems = collectionQuickPickItems(
+          workspaces,
+          ws => ({ label: ws.name, description: ws.slug }),
+          "Workspace list incomplete"
+        );
 
         const selectedWs = await vscode.window.showQuickPick(wsItems, {
           placeHolder: "Step 1: Select a workspace",
@@ -1482,28 +1554,18 @@ async function activate(context) {
 
       let selectedRepos = null;
       if (selectedScope.label === "Select specific repositories") {
-        const cloudsmithAPI = new CloudsmithAPI(context);
-        let endpoint;
-        try {
-          endpoint = apiEndpoint(["repos", workspaceSlug], { query: { sort: "name" } });
-        } catch {
-          vscode.window.showErrorMessage("The selected workspace identifier was invalid.");
+        const repositories = await getWorkspaceRepositories(context, workspaceSlug);
+        if (repositories.items.length === 0) {
+          if (repositories.complete) {
+            vscode.window.showErrorMessage("No repositories found in this workspace.");
+          }
           return;
         }
-        const repos = await cloudsmithAPI.get(endpoint, {
-          responseType: "array",
-          validate: isRepositoryArray,
-          retry: "safe-read",
-        });
-        if (!repos.ok) {
-          vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
-          return;
-        }
-        if (repos.data.length === 0) {
-          vscode.window.showErrorMessage("No repositories found in this workspace.");
-          return;
-        }
-        const repoItems = repos.data.map(r => ({ label: r.name, description: r.slug }));
+        const repoItems = collectionQuickPickItems(
+          repositories,
+          repository => ({ label: repository.name, description: repository.slug }),
+          "Repository list incomplete"
+        );
         const picked = await vscode.window.showQuickPick(repoItems, {
           placeHolder: "Select repositories to search",
           canPickMany: true,
@@ -1706,7 +1768,15 @@ async function activate(context) {
       }
 
       if (result.versions.length === 0) {
-        vscode.window.showInformationMessage(`No safe versions found for "${name}" in ${crossRepo ? "the workspace" : repo}.`);
+        if (result.absenceProven) {
+          vscode.window.showInformationMessage(
+            `No safe versions found for "${name}" in ${crossRepo ? "the workspace" : repo}.`
+          );
+        } else {
+          vscode.window.showWarningMessage(
+            `Safe-version results were incomplete; no absence claim can be made for "${name}".`
+          );
+        }
         return;
       }
 
@@ -1729,9 +1799,19 @@ async function activate(context) {
         };
       });
 
+      if (!result.complete) {
+        const countDetail = result.totalCount === null
+          ? `${result.versions.length} loaded`
+          : `showing newest ${result.versions.length} of ${result.totalCount}`;
+        quickPickItems.unshift({
+          label: `Safe-version preview incomplete (${countDetail})`,
+          kind: vscode.QuickPickItemKind.Separator,
+        });
+      }
+
       const title = crossRepo
-        ? `Safe versions of "${name}" (${format}) in the workspace`
-        : `Safe versions of "${name}" (${format}) in ${repo}`;
+        ? `Newest safe versions of "${name}" (${format}) in the workspace`
+        : `Newest safe versions of "${name}" (${format}) in ${repo}`;
 
       const selected = await vscode.window.showQuickPick(quickPickItems, {
         placeHolder: title,
@@ -2095,12 +2175,18 @@ async function activate(context) {
         if (!workspaces) {
           return;
         }
-        if (workspaces.length === 0) {
-          vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+        if (workspaces.items.length === 0) {
+          if (workspaces.complete) {
+            vscode.window.showErrorMessage("No workspaces found. Connect to Cloudsmith first.");
+          }
           return;
         }
 
-        const wsItems = workspaces.map(ws => ({ label: ws.name, description: ws.slug }));
+        const wsItems = collectionQuickPickItems(
+          workspaces,
+          ws => ({ label: ws.name, description: ws.slug }),
+          "Workspace list incomplete"
+        );
         const selectedWs = await vscode.window.showQuickPick(wsItems, {
           placeHolder: "Select a workspace to search",
         });
@@ -2322,16 +2408,26 @@ async function activate(context) {
               return;
             }
 
-            const upstreamLoadFailed = Boolean(upstreamResult && upstreamResult.error);
+            const upstreamLoadFailed = Boolean(
+              upstreamResult
+              && upstreamResult.error
+              && (!Array.isArray(upstreamResult.data) || upstreamResult.data.length === 0)
+            );
+            const upstreamUnavailableFormats = [...new Set([
+              ...(upstreamResult.failedFormats || []),
+              ...(upstreamResult.uninspectedFormats || []),
+            ])];
             const retentionRules = retentionResult.ok ? retentionResult.data : null;
 
             const hclContent = generateTerraformConfig({
               repo: repoResult.data,
               workspace,
-              upstreams: upstreamLoadFailed ? [] : upstreamResult.data,
+              upstreams: Array.isArray(upstreamResult.data) ? upstreamResult.data : [],
               retention: retentionRules,
               exportedAt: new Date().toISOString(),
               upstreamLoadFailed,
+              upstreamLoadPartial: upstreamResult.complete !== true,
+              upstreamFailedFormats: upstreamUnavailableFormats,
             });
 
             const doc = await vscode.workspace.openTextDocument({
@@ -2395,12 +2491,18 @@ async function activate(context) {
         if (!workspaces) {
           return;
         }
-        if (workspaces.length === 0) {
-          vscode.window.showErrorMessage("No workspaces found.");
+        if (workspaces.items.length === 0) {
+          if (workspaces.complete) {
+            vscode.window.showErrorMessage("No workspaces found.");
+          }
           return;
         }
         const wsPick = await vscode.window.showQuickPick(
-          workspaces.map(ws => ({ label: ws.name, description: ws.slug })),
+          collectionQuickPickItems(
+            workspaces,
+            ws => ({ label: ws.name, description: ws.slug }),
+            "Workspace list incomplete"
+          ),
           { placeHolder: "Select a workspace" }
         );
         if (!wsPick) return;
@@ -2408,29 +2510,17 @@ async function activate(context) {
       }
 
       // Select repo
-      const cloudsmithAPI = new CloudsmithAPI(context);
-      let reposEndpoint;
-      try {
-        reposEndpoint = apiEndpoint(["repos", wsSlug], { query: { sort: "name" } });
-      } catch {
-        vscode.window.showErrorMessage("The workspace identifier was invalid.");
-        return;
-      }
-      const repos = await cloudsmithAPI.get(reposEndpoint, {
-        responseType: "array",
-        validate: isRepositoryArray,
-        retry: "safe-read",
-      });
-      if (!repos.ok) {
-        vscode.window.showErrorMessage(`Could not load repositories. ${formatApiError(repos.error)}`);
-        return;
-      }
-      if (repos.data.length === 0) {
-        vscode.window.showErrorMessage("No repositories found.");
+      const repositories = await getWorkspaceRepositories(context, wsSlug);
+      if (repositories.items.length === 0) {
+        if (repositories.complete) vscode.window.showErrorMessage("No repositories found.");
         return;
       }
       const repoPick = await vscode.window.showQuickPick(
-        repos.data.map(r => ({ label: r.name, description: r.slug })),
+        collectionQuickPickItems(
+          repositories,
+          repository => ({ label: repository.name, description: repository.slug }),
+          "Repository list incomplete"
+        ),
         { placeHolder: "Select target repository" }
       );
       if (!repoPick) return;
@@ -2441,7 +2531,9 @@ async function activate(context) {
         { location: vscode.ProgressLocation.Notification, title: "Checking upstream resolution..." },
         () => checker.previewResolution(wsSlug, targetRepo, pkgName, pkgFormat)
       );
-      upstreamPreviewProvider.show(result);
+      if (result) {
+        upstreamPreviewProvider.show(result);
+      }
     }),
 
     // Phase 10: Show promotion status
@@ -2490,50 +2582,41 @@ async function activate(context) {
         }
 
         const lines = status.map(s => {
-          const icon = !s.found ? "\u2014" : (s.quarantined ? "\u274C" : (s.policyViolated ? "\u26A0\uFE0F" : "\u2705"));
+          const icon = s.found === null
+            ? "?"
+            : !s.found
+              ? "\u2014"
+              : (s.quarantined ? "\u274C" : (s.policyViolated ? "\u26A0\uFE0F" : "\u2705"));
           return `${icon} ${s.repo}: ${s.status}`;
         });
+        const completeness = statusResult.complete ? "" : " (package-location search incomplete)";
         vscode.window.showInformationMessage(
-          `Pipeline for ${promotionIdentity.name} ${promotionIdentity.version}: ${lines.join(" \u2192 ")}`
+          `Pipeline for ${promotionIdentity.name} ${promotionIdentity.version}: ${lines.join(" \u2192 ")}${completeness}`
         );
       } else {
-        // No pipeline: search workspace-wide for this package name+version
-        const cloudsmithAPI = new CloudsmithAPI(context);
-        let endpoint;
-        try {
-          endpoint = apiEndpoint(["packages", promotionIdentity.workspace], {
-            query: {
-              query: buildExactPackageQuery(
-                promotionIdentity.name,
-                promotionIdentity.version,
-                promotionIdentity.format
-              ),
-              page_size: 100,
-            },
-          });
-        } catch {
-          vscode.window.showErrorMessage("The package search parameters were invalid.");
-          return;
-        }
-        const results = await cloudsmithAPI.get(endpoint, {
-          responseType: "array",
-          validate: isPackageLocationArray,
-          retry: "never",
-        });
-
-        if (!results.ok) {
+        const results = await promotionProvider.getPackageLocations(
+          promotionIdentity.workspace,
+          promotionIdentity.name,
+          promotionIdentity.version,
+          promotionIdentity.format
+        );
+        if (results.items.length === 0 && results.failureCount > 0 && results.pageCount === 0) {
           vscode.window.showErrorMessage(
-            `Could not load package locations. ${formatApiError(results.error)}`
+            `Could not load package locations.${firstCollectionFailureMessage(results)}`
           );
           return;
         }
-        const exactPackages = results.data.filter(pkg => (
-          packageMatchesExactIdentity(pkg, promotionIdentity)
-        ));
+        const exactPackages = results.items;
         if (exactPackages.length === 0) {
-          vscode.window.showInformationMessage(
-            `${promotionIdentity.name} ${promotionIdentity.version} was not found in any other repository.`
-          );
+          if (results.complete) {
+            vscode.window.showInformationMessage(
+              `${promotionIdentity.name} ${promotionIdentity.version} was not found in any other repository.`
+            );
+          } else {
+            vscode.window.showWarningMessage(
+              `Package locations are incomplete; ${promotionIdentity.name} ${promotionIdentity.version} may exist in another repository.`
+            );
+          }
           return;
         }
 
@@ -2541,8 +2624,9 @@ async function activate(context) {
           const icon = pkg.status_str === "Quarantined" ? "\u274C" : (pkg.policy_violated ? "\u26A0\uFE0F" : "\u2705");
           return `${icon} ${pkg.repository}: ${pkg.status_str || "Unknown"}`;
         });
+        const completeness = results.complete ? "" : " (additional locations may be unavailable)";
         vscode.window.showInformationMessage(
-          `${promotionIdentity.name} ${promotionIdentity.version} found in: ${lines.join(", ")}`
+          `${promotionIdentity.name} ${promotionIdentity.version} found in: ${lines.join(", ")}${completeness}`
         );
       }
     }),

--- a/extension.js
+++ b/extension.js
@@ -924,8 +924,8 @@ async function activate(context) {
     dependencyHealthProvider.refresh();
   };
   const connectionSubscription = connectionManager.onDidChange(state => {
-    void handleConnectionStateChange(state).catch(error => {
-      console.warn("[Cloudsmith] Could not refresh all account-scoped state:", error);
+    void handleConnectionStateChange(state).catch(() => {
+      console.warn("[Cloudsmith] Could not refresh all account-scoped state.");
     });
   });
   context.subscriptions.push(connectionSubscription);
@@ -2440,14 +2440,13 @@ async function activate(context) {
             }
 
             await vscode.window.showTextDocument(doc);
-          } catch (error) {
+          } catch {
             if (abortController.signal.aborted) {
               return;
             }
 
-            const message = error && error.message ? error.message : String(error);
             vscode.window.showErrorMessage(
-              `Could not export repository. ${formatApiError(message)}`
+              "Could not export repository because an unexpected error occurred."
             );
           } finally {
             cancellationSubscription.dispose();

--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -3,6 +3,7 @@ const vscode = require("vscode");
 const { LicenseClassifier } = require("../util/licenseClassifier");
 const { getFormatIconPath } = require("../util/formatIcons");
 const { canonicalFormat } = require("../util/packageNameNormalizer");
+const { getPackageVulnerabilityState } = require("../util/packageVulnerabilities");
 
 class DependencyHealthNode {
   constructor(dep, cloudsmithMatchOrContext, maybeContext, maybeOptions) {
@@ -83,7 +84,10 @@ class DependencyHealthNode {
       this.tags_raw = this.cloudsmithMatch.tags || {};
       this.cdn_url = this.cloudsmithMatch.cdn_url || null;
       this.filename = this.cloudsmithMatch.filename || null;
-      this.num_vulnerabilities = this.cloudsmithMatch.num_vulnerabilities || 0;
+      const vulnerabilityState = getPackageVulnerabilityState(this.cloudsmithMatch);
+      this.num_vulnerabilities = vulnerabilityState.count !== null
+        ? vulnerabilityState.count
+        : vulnerabilityState.detected ? -1 : null;
       this.max_severity = this.cloudsmithMatch.max_severity || null;
       this.status_reason = this.cloudsmithMatch.status_reason || null;
     }
@@ -140,6 +144,7 @@ class DependencyHealthNode {
 
     if (
       this._hasVulnerabilities()
+      || this._hasVulnerabilityUncertainty()
       || this._hasPolicyViolation()
       || this._hasRestrictiveLicense()
       || this._hasWeakCopyleftLicense()
@@ -151,17 +156,25 @@ class DependencyHealthNode {
   }
 
   _hasVulnerabilities() {
-    return Boolean(this._getVulnerabilityData() && this._getVulnerabilityData().count > 0);
+    const vulnerabilities = this._getVulnerabilityData();
+    return Boolean(vulnerabilities && (
+      vulnerabilities.detected === true
+      || (vulnerabilities.countKnown !== false && vulnerabilities.count > 0)
+    ));
+  }
+
+  _hasVulnerabilityUncertainty() {
+    return this._getVulnerabilityData()?.unknown === true;
   }
 
   _hasCriticalVulnerability() {
     const vulnerabilities = this._getVulnerabilityData();
-    return Boolean(vulnerabilities && vulnerabilities.count > 0 && vulnerabilities.maxSeverity === "Critical");
+    return Boolean(this._hasVulnerabilities() && vulnerabilities.maxSeverity === "Critical");
   }
 
   _hasHighVulnerability() {
     const vulnerabilities = this._getVulnerabilityData();
-    return Boolean(vulnerabilities && vulnerabilities.count > 0 && vulnerabilities.maxSeverity === "High");
+    return Boolean(this._hasVulnerabilities() && vulnerabilities.maxSeverity === "High");
   }
 
   _hasMediumOrLowVulnerability() {
@@ -265,7 +278,12 @@ class DependencyHealthNode {
       return new vscode.ThemeIcon("warning", new vscode.ThemeColor("charts.orange"));
     }
 
-    if (this._hasMediumOrLowVulnerability() || this._hasWeakCopyleftLicense() || this._hasPolicyViolation()) {
+    if (
+      this._hasMediumOrLowVulnerability()
+      || this._hasVulnerabilityUncertainty()
+      || this._hasWeakCopyleftLicense()
+      || this._hasPolicyViolation()
+    ) {
       return new vscode.ThemeIcon("warning", new vscode.ThemeColor("charts.yellow"));
     }
 
@@ -278,9 +296,13 @@ class DependencyHealthNode {
 
   _buildVulnerabilityDescription() {
     const vulnerabilities = this._getVulnerabilityData();
-    if (!vulnerabilities || vulnerabilities.count === 0) {
+    if (!vulnerabilities) {
       return null;
     }
+    if (vulnerabilities.unknown && !this._hasVulnerabilities()) {
+      return "Vulnerability status unknown";
+    }
+    if (!this._hasVulnerabilities()) return null;
 
     if (
       vulnerabilities.detailsLoaded
@@ -292,9 +314,16 @@ class DependencyHealthNode {
       return `Vulnerabilities found (${maxCount} ${vulnerabilities.maxSeverity})`;
     }
 
-    const summary = vulnerabilities.maxSeverity
-      ? `${vulnerabilities.count} ${vulnerabilities.maxSeverity}`
-      : String(vulnerabilities.count);
+    if (vulnerabilities.countKnown === false) {
+      const severity = vulnerabilities.maxSeverity && vulnerabilities.maxSeverity !== "Unknown"
+        ? ` (${vulnerabilities.maxSeverity})`
+        : "";
+      return `Vulnerabilities detected${severity}`;
+    }
+    const countLabel = String(vulnerabilities.count);
+    const summary = vulnerabilities.maxSeverity && vulnerabilities.maxSeverity !== "Unknown"
+      ? `${countLabel} ${vulnerabilities.maxSeverity}`
+      : countLabel;
     return `Vulnerabilities found (${summary})`;
   }
 
@@ -386,16 +415,19 @@ class DependencyHealthNode {
 
       const vulnerabilities = this._getVulnerabilityData();
       if (vulnerabilities) {
-        if (vulnerabilities && vulnerabilities.count > 0) {
+        if (this._hasVulnerabilities()) {
           const severitySummary = Object.entries(vulnerabilities.severityCounts || {})
             .map(([severity, count]) => `${count} ${severity}`)
             .join(", ");
           const suffix = severitySummary
             ? ` (${severitySummary})`
-            : vulnerabilities.maxSeverity
+            : vulnerabilities.maxSeverity && vulnerabilities.maxSeverity !== "Unknown"
               ? ` (${vulnerabilities.maxSeverity})`
               : "";
-          lines.push(`Vulnerabilities: ${vulnerabilities.count}${suffix}`);
+          const countLabel = vulnerabilities.countKnown === false
+            ? "Detected"
+            : String(vulnerabilities.count);
+          lines.push(`Vulnerabilities: ${countLabel}${suffix}`);
 
           if (Array.isArray(vulnerabilities.entries)) {
             for (const entry of vulnerabilities.entries) {
@@ -403,6 +435,8 @@ class DependencyHealthNode {
               lines.push(`  ${entry.cveId} (${entry.severity}) — ${fixText}`);
             }
           }
+        } else if (vulnerabilities.unknown) {
+          lines.push("Vulnerabilities: Unknown");
         } else {
           lines.push("Vulnerabilities: none known");
         }
@@ -462,13 +496,13 @@ class DependencyHealthNode {
     }
 
     const vulnerabilities = this._getVulnerabilityData();
-    if (vulnerabilities && vulnerabilities.count > 0) {
+    if (vulnerabilities && this._hasVulnerabilities()) {
       const VulnerabilitySummaryNode = require("./vulnerabilitySummaryNode");
       children.push(new VulnerabilitySummaryNode({
         namespace: this.cloudsmithMatch.namespace,
         repository: this.cloudsmithMatch.repository,
         slug_perm: this.cloudsmithMatch.slug_perm,
-        num_vulnerabilities: vulnerabilities.count,
+        num_vulnerabilities: vulnerabilities.countKnown === false ? -1 : vulnerabilities.count,
         max_severity: vulnerabilities.maxSeverity,
       }, this.context, { connectionManager: this.options.connectionManager }));
     }
@@ -500,12 +534,8 @@ class DependencyHealthNode {
       return null;
     }
 
-    const count = Number(
-      this.cloudsmithMatch.vulnerability_scan_results_count
-      || this.cloudsmithMatch.num_vulnerabilities
-      || 0
-    );
-    if (!Number.isFinite(count) || count <= 0) {
+    const state = getPackageVulnerabilityState(this.cloudsmithMatch);
+    if (state.count === 0 && !state.detected && !state.unknown) {
       return {
         count: 0,
         maxSeverity: null,
@@ -517,10 +547,14 @@ class DependencyHealthNode {
       };
     }
 
+    const count = state.count !== null ? state.count : (state.candidateCount || 0);
     const maxSeverity = this.cloudsmithMatch.max_severity || null;
     const severityCounts = maxSeverity ? { [maxSeverity]: 1 } : {};
     return {
       count,
+      countKnown: state.count !== null,
+      detected: state.detected,
+      unknown: state.unknown,
       maxSeverity,
       cveIds: [],
       hasFixAvailable: false,

--- a/models/entitlementNode.js
+++ b/models/entitlementNode.js
@@ -2,21 +2,39 @@
 // Shows entitlement token info under a repository for debugging access issues.
 
 const vscode = require("vscode");
+const InfoNode = require("./infoNode");
 
 /**
- * Summary header node: "Entitlements: {active} active of {total}"
+ * Summary header node with an authoritative total only for complete collections.
  */
 class EntitlementSummaryNode {
-  constructor(entitlements, context) {
+  constructor(entitlements, context, options = {}) {
     this.context = context;
     this.entitlements = entitlements || [];
     this.activeCount = this.entitlements.filter(e => e.is_active !== false).length;
+    this.complete = options.complete === true;
+    this.totalCount = Number.isSafeInteger(options.totalCount) && options.totalCount >= 0
+      ? options.totalCount
+      : null;
+    this.failureCount = Number.isSafeInteger(options.failureCount) && options.failureCount >= 0
+      ? options.failureCount
+      : 0;
+    this.termination = typeof options.termination === "string" ? options.termination : null;
   }
 
   getTreeItem() {
+    const loadedCount = this.entitlements.length;
+    const label = this.complete
+      ? `Entitlement tokens: ${this.activeCount} active of ${loadedCount}`
+      : `Entitlement tokens: ${this.activeCount} active among ${loadedCount} loaded (partial)`;
+    const tooltip = this.complete
+      ? `${loadedCount} entitlement token${loadedCount === 1 ? "" : "s"} configured`
+      : this.totalCount !== null
+        ? `${loadedCount} of ${this.totalCount} entitlement tokens loaded; the collection is incomplete`
+        : `${loadedCount} entitlement tokens loaded; the configured total could not be verified`;
     return {
-      label: `Entitlement tokens: ${this.activeCount} active of ${this.entitlements.length}`,
-      tooltip: `${this.entitlements.length} entitlement token${this.entitlements.length === 1 ? "" : "s"} configured`,
+      label,
+      tooltip,
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
       contextValue: "entitlementSummary",
       iconPath: new vscode.ThemeIcon("key"),
@@ -24,7 +42,18 @@ class EntitlementSummaryNode {
   }
 
   getChildren() {
-    return this.entitlements.map(e => new EntitlementNode(e, this.context));
+    const children = this.entitlements.map(e => new EntitlementNode(e, this.context));
+    if (!this.complete) {
+      children.unshift(new InfoNode(
+        "Entitlement list is incomplete",
+        this.failureCount > 0
+          ? `${this.failureCount} page request${this.failureCount === 1 ? "" : "s"} failed`
+          : "A safe collection limit was reached",
+        "Loaded entitlement tokens remain available, but the configured total is not being claimed.",
+        "warning"
+      ));
+    }
+    return children;
   }
 }
 

--- a/models/loadMoreNode.js
+++ b/models/loadMoreNode.js
@@ -3,15 +3,19 @@
 const vscode = require("vscode");
 
 class LoadMoreNode {
-    constructor(currentPage, totalPages, totalCount) {
+    constructor(currentPage, totalPages, totalCount, loadedCount = null) {
         this.currentPage = currentPage;
         this.totalPages = totalPages;
         this.totalCount = totalCount;
+        this.loadedCount = loadedCount;
     }
 
     getTreeItem() {
+        const progress = Number.isSafeInteger(this.totalCount) && this.totalCount >= 0
+            ? `page ${this.currentPage} of ${this.totalPages}, ${this.totalCount} total`
+            : `${Number.isSafeInteger(this.loadedCount) ? this.loadedCount : 0} loaded; page ${this.currentPage} of ${this.totalPages}`;
         return {
-            label: `Load more results (page ${this.currentPage} of ${this.totalPages}, ${this.totalCount} total)`,
+            label: `Load more results (${progress})`,
             tooltip: "Load the next page of search results.",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "loadMore",

--- a/models/repositoryLoadMoreNode.js
+++ b/models/repositoryLoadMoreNode.js
@@ -1,0 +1,46 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const vscode = require("vscode");
+
+class RepositoryLoadMoreNode {
+  constructor(repositoryNode, options = {}) {
+    this.repositoryNode = repositoryNode;
+    this.kind = options.kind === "package groups" ? "package groups" : "packages";
+    this.loadedCount = Number.isSafeInteger(options.loadedCount) && options.loadedCount >= 0
+      ? options.loadedCount
+      : 0;
+    this.pagination = options.pagination || null;
+    this.retry = options.retry === true;
+  }
+
+  getTreeItem() {
+    const loaded = this.loadedCount.toLocaleString();
+    const progress = this.pagination?.countAuthoritative
+      ? `showing ${loaded} of ${this.pagination.count.toLocaleString()}`
+      : this.pagination
+        ? `${loaded} loaded; page ${this.pagination.page} of ${this.pagination.pageTotal}`
+        : `${loaded} loaded`;
+    return {
+      label: this.retry
+        ? `Retry loading ${this.kind} (${progress})`
+        : `Load more ${this.kind} (${progress})`,
+      tooltip: this.retry
+        ? `Retry the failed bounded page of repository ${this.kind}.`
+        : `Load the next bounded page of repository ${this.kind}.`,
+      collapsibleState: vscode.TreeItemCollapsibleState.None,
+      contextValue: "repositoryLoadMore",
+      iconPath: new vscode.ThemeIcon("ellipsis"),
+      command: {
+        command: "cloudsmith-vsc.loadMoreRepositoryPackages",
+        title: `Load more ${this.kind}`,
+        arguments: [this.repositoryNode],
+      },
+    };
+  }
+
+  getChildren() {
+    return [];
+  }
+}
+
+module.exports = RepositoryLoadMoreNode;

--- a/models/repositoryNode.js
+++ b/models/repositoryNode.js
@@ -3,20 +3,55 @@
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiEndpoint } = require("../util/apiEndpoint");
-const upstreamChecker = require("../util/upstreamChecker");
+const { PaginatedFetch, replaceCollectionItems } = require("../util/paginatedFetch");
+const { formatApiError } = require("../util/errorFormatter");
 const {
-  normalizeUpstreamFormat,
-  SUPPORTED_UPSTREAM_FORMATS,
-} = require("../util/upstreamFormats");
+  getPackagePolicyFlags,
+  getPackageVulnerabilityState,
+} = require("../util/packageVulnerabilities");
+const {
+  entitlementCollectionIdentity,
+  packageCollectionIdentity,
+  packageGroupCollectionIdentity,
+} = require("../util/collectionIdentity");
+const upstreamChecker = require("../util/upstreamChecker");
 const UpstreamIndicatorNode = require("./upstreamIndicatorNode");
 const { activeFilters } = require("../util/filterState");
 const InfoNode = require("./infoNode");
 const { EntitlementSummaryNode } = require("./entitlementNode");
+const RepositoryLoadMoreNode = require("./repositoryLoadMoreNode");
 const {
   captureAccount,
   isAccountCurrent,
   resolveConnectionManager,
 } = require("../util/accountOperation");
+
+const MAX_COLLECTION_PAGES = 20;
+const MAX_COLLECTION_REQUESTS = 24;
+const MAX_COLLECTION_ITEMS = 600;
+const ENTITLEMENT_PAGE_SIZE = 50;
+const MAX_NAME_LENGTH = 2048;
+const MAX_FORMAT_LENGTH = 100;
+const MAX_VERSION_LENGTH = 2048;
+const MAX_IDENTITY_LENGTH = 512;
+const MAX_SCOPE_LENGTH = 256;
+const MAX_OPTIONAL_STRING_LENGTH = 4096;
+const MAX_URL_LENGTH = 8192;
+const MAX_TAGS = 100;
+const MAX_TAG_LENGTH = 500;
+const COLLECTION_TERMINATIONS = new Set([
+  "cancelled",
+  "duplicate_or_invalid_identity",
+  "exhausted",
+  "invalid_continuation",
+  "invalid_pagination",
+  "invalid_request",
+  "item_limit",
+  "page_batch",
+  "page_limit",
+  "request_failed",
+  "request_limit",
+]);
 
 class RepositoryNode {
   constructor(repo, workspace, context, options = {}) {
@@ -24,12 +59,44 @@ class RepositoryNode {
     this._connectionManager = resolveConnectionManager(context, options.connectionManager);
     this._createCloudsmithAPI = options.createCloudsmithAPI
       || (() => new CloudsmithAPI(this.context));
+    this._createPaginatedFetch = options.createPaginatedFetch
+      || (api => new PaginatedFetch(api));
     this._upstreamChecker = options.upstreamChecker || upstreamChecker;
+    this._requestRefresh = typeof options.requestRefresh === "function"
+      ? options.requestRefresh
+      : () => {};
+    this._withProgress = options.withProgress || ((progressOptions, task) => (
+      vscode.window.withProgress(progressOptions, task)
+    ));
     this.slug = repo.slug;
     this.slug_perm = repo.slug_perm;
     this.name = repo.name;
     this.workspace = workspace;
     this.storageRegion = repo.storage_region || repo.region || null;
+    this._disposed = false;
+    this._generation = 0;
+    this._lifecycleController = new AbortController();
+    this._packageDescriptor = null;
+    this._packageState = createEmptyPackageState();
+    this._activePackageLoad = null;
+    this._metadataPromise = null;
+    this._metadataChildren = [];
+    this._metadataLoaded = false;
+  }
+
+  invalidate() {
+    if (this._disposed) return;
+    this._disposed = true;
+    this._generation += 1;
+    this._lifecycleController.abort();
+    this._activePackageLoad = null;
+    this._metadataPromise = null;
+    this._metadataChildren = [];
+    this._metadataLoaded = false;
+  }
+
+  dispose() {
+    this.invalidate();
   }
 
   /** Get the active filter from the module-level singleton Map. */
@@ -114,268 +181,408 @@ class RepositoryNode {
   }
 
   async getPackages() {
-    const account = captureAccount(this._connectionManager);
-    if (!account) return [];
-    const cloudsmithAPI = this._createCloudsmithAPI();
-    let packages = '';
-    
-
-    let workspace = this.workspace;
-    let repo = this.slug;
-    let groupContext = { "repo": repo, "workspace": workspace  };
-
-    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-    const maxPackages = await config.get("showMaxPackages"); // get legacy app setting from configuration settings
-    const groupByPackageGroup = await config.get("groupByPackageGroups");
-    if (!isAccountCurrent(this._connectionManager, account)) return [];
-
-    const activeFilter = this._getActiveFilter();
-    const filterQuery = activeFilter ? (activeFilter.query || activeFilter) : null;
-    let apiFailed = false;
-    try {
-      const query = {
-        sort: groupByPackageGroup ? "-last_push" : "-date",
-        page_size: maxPackages,
-        ...(filterQuery ? { query: filterQuery } : {}),
-      };
-      if (!groupByPackageGroup) {
-        const result = await cloudsmithAPI.get(
-          apiEndpoint(["packages", workspace, repo], { query }),
-          { responseType: "array", validate: isPackageArray, retry: "safe-read" }
-        );
-        if (result.ok) {
-          packages = result.data;
-        } else {
-          apiFailed = true;
-          packages = [];
-        }
-      } else {
-        const result = await cloudsmithAPI.get(
-          apiEndpoint(["packages", workspace, repo, "groups"], { query }),
-          {
-            responseType: "object",
-            validate: value => isPackageGroupArray(value.results),
-            retry: "safe-read",
-          }
-        );
-        if (result.ok) {
-          packages = result.data.results;
-        } else {
-          apiFailed = true;
-          packages = [];
-        }
-      }
-    } catch {
-      if (!isAccountCurrent(this._connectionManager, account)) return [];
-      apiFailed = true;
-      packages = [];
+    if (this._disposed) return [];
+    const descriptor = this._readPackageDescriptor();
+    this._ensurePackageDescriptor(descriptor);
+    if (!this._packageState.initialized && !this._activePackageLoad) {
+      await this._startPackageLoad(descriptor, null, false);
+    } else if (!this._packageState.initialized && this._activePackageLoad) {
+      await this._activePackageLoad.promise;
     }
-    if (!isAccountCurrent(this._connectionManager, account)) return [];
-    this._lastApiFailed = apiFailed;
-
-    const PackageNodes = [];
-    if (packages && packages.length > 0) {
-      for (const pkg of packages) {
-        if (!groupByPackageGroup) {
-          const packageNode = require("./packageNode");
-          let packageNodeInst = new packageNode(pkg, this.context, {
-            connectionManager: this._connectionManager,
-          });
-          PackageNodes.push(packageNodeInst);
-        } else {
-          const packageGroupsNode = require("./packageGroupsNode");
-          const groupPkg = { ...pkg, ...groupContext };
-          const packageGroupNodeInst = new packageGroupsNode(groupPkg, this.context);
-          PackageNodes.push(packageGroupNodeInst);
-        }
-      }
-    }
-    return PackageNodes;
+    return this._disposed ? [] : this._packageState.nodes;
   }
 
-  /**
-   * Infer relevant formats from the loaded package list and fetch upstream configs
-   * only for those formats as a hint. Repository-level configured upstream
-   * counts must reconcile against the full all-format path unless the inferred
-   * set is known to cover every supported upstream format.
-   *
-   * @returns {Array} Array of upstream config objects (may be empty).
-   */
-  async getUpstreams(packageNodes = []) {
-    const account = captureAccount(this._connectionManager);
-    if (!account) return [];
-    const inferredFormats = this._inferUpstreamFormats(packageNodes);
-    if (inferredFormats.length === 0) {
-      const result = await this._upstreamChecker.getAllUpstreamData(
-        this.context,
-        this.workspace,
-        this.slug,
-        { account, connectionManager: this._connectionManager }
-      );
-      return isAccountCurrent(this._connectionManager, account)
-        ? this._getUpstreamList(result)
-        : [];
+  loadMorePackages() {
+    if (this._disposed || !this._packageState.initialized || !this._packageState.continuation) {
+      return Promise.resolve();
     }
+    if (this._activePackageLoad) {
+      return this._activePackageLoad.promise;
+    }
+    const descriptor = this._packageDescriptor;
+    if (!descriptor) return Promise.resolve();
+    return this._startPackageLoad(descriptor, this._packageState.continuation, true);
+  }
 
-    const hintedResult = await this._upstreamChecker.getUpstreamDataForFormats(
-      this.context,
+  _readPackageDescriptor() {
+    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
+    const account = captureAccount(this._connectionManager);
+    const pageSize = normalizePageSize(config.get("showMaxPackages"));
+    const groupByPackageGroup = config.get("groupByPackageGroups") === true;
+    const showEntitlements = config.get("showEntitlements") === true;
+    const activeFilter = this._getActiveFilter();
+    const filterQuery = activeFilter ? String(activeFilter.query || activeFilter) : null;
+    const mode = groupByPackageGroup ? "groups" : "packages";
+    const sort = groupByPackageGroup ? "-last_push" : "-date";
+    const key = JSON.stringify([
+      account ? account.activationId : null,
+      account ? account.accountEpoch : null,
       this.workspace,
       this.slug,
-      inferredFormats,
-      { account, connectionManager: this._connectionManager }
-    );
-    if (!isAccountCurrent(this._connectionManager, account)) return [];
+      mode,
+      sort,
+      pageSize,
+      filterQuery,
+      showEntitlements,
+    ]);
+    return Object.freeze({ key, mode, sort, pageSize, filterQuery, showEntitlements });
+  }
 
-    if (this._hasCompleteUpstreamCoverage(inferredFormats)) {
-      return this._getUpstreamList(hintedResult);
+  _ensurePackageDescriptor(descriptor) {
+    if (this._packageDescriptor?.key === descriptor.key) return;
+    this._generation += 1;
+    this._lifecycleController.abort();
+    this._lifecycleController = new AbortController();
+    this._packageDescriptor = descriptor;
+    this._packageState = createEmptyPackageState();
+    this._activePackageLoad = null;
+    this._metadataPromise = null;
+    this._metadataChildren = [];
+    this._metadataLoaded = false;
+  }
+
+  _startPackageLoad(descriptor, resume, showProgress) {
+    if (this._activePackageLoad) return this._activePackageLoad.promise;
+    const account = captureAccount(this._connectionManager);
+    if (!account || this._disposed || this._packageDescriptor?.key !== descriptor.key) {
+      return Promise.resolve();
+    }
+    const operation = Object.freeze({
+      generation: this._generation,
+      account,
+      descriptor,
+      resume,
+    });
+    const task = (_progress, cancellationToken) => this._fetchPackageBatch(
+      operation,
+      cancellationToken
+    );
+    const promise = Promise.resolve().then(() => (
+      showProgress
+        ? this._withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: descriptor.mode === "groups"
+            ? "Loading more package groups..."
+            : "Loading more packages...",
+          cancellable: true,
+        }, task)
+        : task({ report() {} }, null)
+    )).finally(() => {
+      if (this._activePackageLoad?.operation === operation) {
+        this._activePackageLoad = null;
+        if (showProgress && this._isOperationCurrent(operation)) {
+          this._requestRefresh(this);
+        }
+      }
+    });
+    this._activePackageLoad = Object.freeze({ operation, promise });
+    if (showProgress) this._requestRefresh(this);
+    return promise;
+  }
+
+  async _fetchPackageBatch(operation, cancellationToken) {
+    const { descriptor, resume } = operation;
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(
+        descriptor.mode === "groups"
+          ? ["packages", this.workspace, this.slug, "groups"]
+          : ["packages", this.workspace, this.slug],
+        { query: { sort: descriptor.sort } }
+      );
+    } catch {
+      this._commitPackageFailure(operation, localCollectionFailure(
+        "invalid_request",
+        "The repository package endpoint was invalid."
+      ));
+      return;
     }
 
+    let result;
+    try {
+      const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
+      const collectionOptions = {
+        pageSize: descriptor.pageSize,
+        query: descriptor.filterQuery,
+        maxPages: MAX_COLLECTION_PAGES,
+        maxRequests: MAX_COLLECTION_REQUESTS,
+        maxItems: MAX_COLLECTION_ITEMS,
+        pageBatchLimit: 1,
+        descriptor: descriptor.key,
+        resume,
+        ...(resume ? { knownIdentities: new Set(this._packageState.resultKeys) } : {}),
+        retry: "never",
+        signal: this._lifecycleController.signal,
+        cancellationToken,
+      };
+      if (descriptor.mode === "groups") {
+        Object.assign(collectionOptions, {
+          responseType: "object",
+          validate: isPackageGroupArray,
+          validateResponse: isPackageGroupResponse,
+          extractItems: response => response.results,
+          canonicalIdentity: group => packageGroupCollectionIdentity(
+            this.workspace,
+            this.slug,
+            canonicalizePackageGroup(group)
+          ),
+        });
+      } else {
+        Object.assign(collectionOptions, {
+          validate: value => isPackageArray(value, this.workspace, this.slug),
+          canonicalIdentity: packageCollectionIdentity,
+        });
+      }
+      result = await paginatedFetch.fetchCollection(endpoint, collectionOptions);
+    } catch {
+      this._commitPackageFailure(operation, localCollectionFailure(
+        "unexpected",
+        "The package collection could not be loaded."
+      ), { preserveContinuation: Boolean(resume) });
+      return;
+    }
+
+    if (!this._isOperationCurrent(operation)) return;
+    if (!isCollectionResult(result)) {
+      this._commitPackageFailure(operation, localCollectionFailure(
+        "invalid_response",
+        "Cloudsmith returned an invalid package collection."
+      ));
+      return;
+    }
+    if (result.cancelled) {
+      // Cancellation still consumes a dispatched request. Commit the returned
+      // continuation so repeated retries cannot reset the cumulative budget.
+      this._commitPackageResult(operation, result);
+      return;
+    }
+    this._commitPackageResult(operation, result);
+  }
+
+  _commitPackageResult(operation, result) {
+    if (!this._isOperationCurrent(operation)) return;
+    const descriptor = operation.descriptor;
+    const previous = this._packageState;
+    const keys = new Set(previous.resultKeys);
+    const appendedNodes = [];
+    let duplicateCount = result.duplicateCount || 0;
+    try {
+      for (const item of result.items) {
+        const canonical = descriptor.mode === "groups"
+          ? canonicalizePackageGroup(item)
+          : canonicalizeRepositoryPackage(item, this.workspace, this.slug);
+        if (!canonical) throw new Error("invalid collection item");
+        const key = descriptor.mode === "groups"
+          ? packageGroupCollectionIdentity(this.workspace, this.slug, canonical)
+          : packageCollectionIdentity(canonical);
+        if (keys.has(key)) {
+          duplicateCount += 1;
+          continue;
+        }
+        keys.add(key);
+        appendedNodes.push(this._createPackageNode(canonical, descriptor.mode));
+      }
+    } catch {
+      this._commitPackageFailure(operation, localCollectionFailure(
+        "invalid_response",
+        "Cloudsmith returned an invalid package record."
+      ));
+      return;
+    }
+
+    const nodes = [...previous.nodes, ...appendedNodes];
+    const crossPageDuplicate = duplicateCount > (result.duplicateCount || 0);
+    const complete = result.complete === true && !crossPageDuplicate;
+    const continuation = complete || crossPageDuplicate
+      ? null
+      : validContinuation(result.continuation, descriptor.key, nodes.length, result);
+    // A continuation failure is retryable. Once that exact page succeeds, the
+    // prior failure no longer describes the collection and must not keep a
+    // subsequently complete result labelled as partial.
+    const failures = [...result.failures];
+    if (crossPageDuplicate) {
+      failures.push(localCollectionFailure(
+        "duplicate_identity",
+        "Cloudsmith returned a package identity that was already loaded."
+      ));
+    }
+    const invalidContinuation = !complete
+      && !crossPageDuplicate
+      && ((result.continuation && !continuation)
+        || (result.termination === "page_batch" && !continuation));
+    if (invalidContinuation) {
+      failures.push(localCollectionFailure(
+        "invalid_continuation",
+        "Cloudsmith returned contradictory package continuation metadata."
+      ));
+    }
+    const capReached = !complete && !continuation && isCollectionCapReached(result, nodes.length);
+    this._packageState = Object.freeze({
+      initialized: true,
+      nodes: Object.freeze(nodes),
+      resultKeys: Object.freeze([...keys]),
+      pagination: result.pagination,
+      complete,
+      partial: !complete && nodes.length > 0,
+      continuation,
+      failures: Object.freeze(failures),
+      pageCount: result.pageCount,
+      requestCount: result.requestCount,
+      duplicateCount,
+      termination: crossPageDuplicate
+        ? "duplicate_identity"
+        : invalidContinuation ? "invalid_continuation" : result.termination,
+      capReached,
+    });
+  }
+
+  _commitPackageFailure(operation, failure, options = {}) {
+    if (!this._isOperationCurrent(operation)) return;
+    const previous = this._packageState;
+    this._packageState = Object.freeze({
+      ...previous,
+      initialized: true,
+      complete: false,
+      partial: previous.nodes.length > 0,
+      continuation: options.preserveContinuation ? operation.resume : null,
+      failures: Object.freeze([...previous.failures, failure]),
+      termination: failure.kind,
+    });
+  }
+
+  _createPackageNode(item, mode) {
+    if (mode === "groups") {
+      const PackageGroupsNode = require("./packageGroupsNode");
+      return new PackageGroupsNode({
+        ...item,
+        repo: this.slug,
+        workspace: this.workspace,
+      }, this.context);
+    }
+    const PackageNode = require("./packageNode");
+    return new PackageNode(item, this.context, {
+      connectionManager: this._connectionManager,
+    });
+  }
+
+  _isOperationCurrent(operation) {
+    return Boolean(
+      !this._disposed
+      && operation
+      && operation.generation === this._generation
+      && this._packageDescriptor?.key === operation.descriptor.key
+      && !this._lifecycleController.signal.aborted
+      && isAccountCurrent(this._connectionManager, operation.account)
+    );
+  }
+
+  /** Fetch the single repository-wide upstream state used by the tree summary. */
+  async getUpstreamState() {
+    const account = captureAccount(this._connectionManager);
+    if (!account || this._disposed) return emptyUpstreamState();
+    const requestOptions = {
+      account,
+      connectionManager: this._connectionManager,
+      signal: this._lifecycleController.signal,
+    };
     const result = await this._upstreamChecker.getAllUpstreamData(
       this.context,
       this.workspace,
       this.slug,
-      { account, connectionManager: this._connectionManager }
+      requestOptions
     );
     return isAccountCurrent(this._connectionManager, account)
-      ? this._getUpstreamList(result)
-      : [];
+      ? normalizeUpstreamState(result)
+      : emptyUpstreamState();
   }
 
-  _getUpstreamList(result) {
-    if (!result || !Array.isArray(result.upstreams)) {
-      return [];
-    }
-
-    return result.upstreams;
-  }
-
-  _hasCompleteUpstreamCoverage(formats) {
-    return Array.isArray(formats) && formats.length === SUPPORTED_UPSTREAM_FORMATS.length;
-  }
-
-  _inferUpstreamFormats(packageNodes) {
-    if (!Array.isArray(packageNodes) || packageNodes.length === 0) {
-      return [];
-    }
-
-    const formats = new Set();
-    for (const node of packageNodes) {
-      this._addInferredFormat(formats, node && node.format);
-
-      if (Array.isArray(node && node.formats)) {
-        for (const format of node.formats) {
-          this._addInferredFormat(formats, format);
-        }
-      }
-    }
-
-    return SUPPORTED_UPSTREAM_FORMATS.filter((format) => formats.has(format));
-  }
-
-  _addInferredFormat(target, value) {
-    const normalized = normalizeUpstreamFormat(value);
-    if (normalized) {
-      target.add(normalized);
-    }
+  async getUpstreams(packageNodes = []) {
+    return (await this.getUpstreamState(packageNodes)).upstreams;
   }
 
   /**
    * Fetch entitlement tokens for this repository.
    * @returns {Array} Array of entitlement objects.
    */
-  async getEntitlements() {
+  async getEntitlementCollection() {
     const account = captureAccount(this._connectionManager);
-    if (!account) return [];
+    if (!account || this._disposed) return emptyCollectionResult();
     const cloudsmithAPI = this._createCloudsmithAPI();
     let endpoint;
     try {
       endpoint = apiEndpoint(["entitlements", this.workspace, this.slug], {
-        query: { page_size: 50 },
+        query: { sort: "name" },
       });
     } catch {
       throw new Error("The entitlement endpoint was invalid.");
     }
-    const result = await cloudsmithAPI.get(endpoint, {
-      responseType: "array",
+    const result = await this._createPaginatedFetch(cloudsmithAPI).fetchCollection(endpoint, {
+      pageSize: ENTITLEMENT_PAGE_SIZE,
+      maxPages: MAX_COLLECTION_PAGES,
+      maxRequests: MAX_COLLECTION_REQUESTS,
+      maxItems: MAX_COLLECTION_ITEMS,
+      descriptor: JSON.stringify(["entitlements", this.workspace, this.slug]),
+      canonicalIdentity: entitlement => entitlementCollectionIdentity(
+        this.workspace,
+        this.slug,
+        entitlement
+      ),
       validate: isEntitlementArray,
-      retry: "safe-read",
+      retry: "never",
+      signal: this._lifecycleController.signal,
     });
-    if (!isAccountCurrent(this._connectionManager, account)) return [];
-    if (!result.ok) {
-      throw result.error;
+    if (!isAccountCurrent(this._connectionManager, account) || this._disposed) {
+      return emptyCollectionResult(true);
     }
-    return result.data;
+    if (!isCollectionResult(result)) {
+      throw new Error("Cloudsmith returned an invalid entitlement collection.");
+    }
+    return replaceCollectionItems(
+      result,
+      result.items.map(entitlement => canonicalizeEntitlement(entitlement))
+    );
+  }
+
+  async getEntitlements() {
+    const result = await this.getEntitlementCollection();
+    if (!result.cancelled && result.items.length === 0 && result.failureCount > 0) {
+      throw result.failures[0]?.error || result.failures[0];
+    }
+    return result.items;
   }
 
   async getChildren() {
     const account = captureAccount(this._connectionManager);
-    if (!account) return [];
+    if (!account || this._disposed) return [];
     const packages = await this.getPackages();
-    if (!isAccountCurrent(this._connectionManager, account)) return [];
-    const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
-    const showEntitlements = config.get("showEntitlements");
+    if (!isAccountCurrent(this._connectionManager, account) || this._disposed) return [];
+    const generation = this._generation;
+    const descriptor = this._packageDescriptor;
+    const metadata = await this._getMetadataChildren(packages, account, generation, descriptor);
+    if (
+      !isAccountCurrent(this._connectionManager, account)
+      || this._disposed
+      || generation !== this._generation
+    ) return [];
 
-    const children = [];
-
-    // Fetch upstreams lazily (only when repo is expanded)
-    if (packages.length > 0) {
-      const upstreams = await this.getUpstreams(packages);
-      if (!isAccountCurrent(this._connectionManager, account)) return [];
-      if (upstreams.length > 0) {
-        children.push(new UpstreamIndicatorNode(
-          upstreams,
-          {
-            workspace: this.workspace,
-            slug: this.slug,
-            name: this.name,
-          },
-          this.context
-        ));
-      }
-    }
-
-    if (this.storageRegion) {
-      const regionLabel = this._getStorageRegionLabel(this.storageRegion);
-
-      children.push({
-        getTreeItem: () => ({
-          label: "Storage Region",
-          description: regionLabel,
-          collapsibleState: vscode.TreeItemCollapsibleState.None,
-          contextValue: "repoDetail",
-          iconPath: new vscode.ThemeIcon("globe"),
-        }),
-        getChildren: () => [],
-      });
-    }
-
-    // Entitlement tokens (Phase 12)
-    if (showEntitlements) {
-      try {
-        const entitlements = await this.getEntitlements();
-        if (!isAccountCurrent(this._connectionManager, account)) return [];
-        if (entitlements.length > 0) {
-          children.push(new EntitlementSummaryNode(entitlements, this.context));
-        }
-      } catch (e) {
-        if (!isAccountCurrent(this._connectionManager, account)) return [];
-        children.push(new InfoNode(
-          "Entitlements: failed to load",
-          "",
-          e.message || "An error occurred loading entitlement tokens.",
-          "warning"
-        ));
-      }
-    }
+    const children = [...metadata];
 
     if (packages.length === 0) {
       const activeFilter = this._getActiveFilter();
       let placeholderNode;
-      if (this._lastApiFailed) {
+      if (this._packageState.failures.length > 0) {
         placeholderNode = new InfoNode(
           "Failed to load packages",
           "Check your connection and try refreshing",
-          "The Cloudsmith API returned an error when loading packages for this repository.",
+          collectionFailureMessage(this._packageState.failures.at(-1)),
+          "warning"
+        );
+      } else if (!this._packageState.complete) {
+        const cancelled = this._packageState.termination === "cancelled";
+        placeholderNode = new InfoNode(
+          cancelled ? "Package loading cancelled" : "Package results are incomplete",
+          cancelled ? "Refresh to try again" : "Completeness could not be proven",
+          "No empty-repository claim is being made because package enumeration did not complete.",
           "warning"
         );
       } else if (activeFilter) {
@@ -399,13 +606,173 @@ class RepositoryNode {
       children.push(placeholderNode);
     }
 
-    // packages are already PackageNode or PackageGroupsNode instances from getPackages()
-    // Push them directly — do NOT re-wrap in new packageNode(item)
+    if (this._activePackageLoad && this._packageState.initialized) {
+      children.push(new InfoNode(
+        this._packageDescriptor?.mode === "groups"
+          ? "Loading more package groups..."
+          : "Loading more packages...",
+        "The next page is still loading.",
+        "Only one package page is loaded at a time.",
+        "loading~spin"
+      ));
+    }
+
+    if (packages.length > 0 && this._packageState.failures.length > 0) {
+      children.push(new InfoNode(
+        "Package results are incomplete",
+        collectionProgressDescription(this._packageState),
+        collectionFailureMessage(this._packageState.failures.at(-1)),
+        "warning"
+      ));
+    } else if (packages.length > 0 && this._packageState.capReached) {
+      children.push(new InfoNode(
+        this._packageDescriptor?.mode === "groups"
+          ? "Package group loading limit reached"
+          : "Package loading limit reached",
+        collectionProgressDescription(this._packageState),
+        "Refine the repository filter or refresh before loading more results.",
+        "info"
+      ));
+    }
+
     for (const node of packages) {
       children.push(node);
     }
 
+    if (this._packageState.continuation && !this._activePackageLoad) {
+      children.push(new RepositoryLoadMoreNode(this, {
+        kind: this._packageDescriptor?.mode === "groups" ? "package groups" : "packages",
+        loadedCount: packages.length,
+        pagination: this._packageState.pagination,
+        retry: packages.length === 0
+          && ["cancelled", "request_failed"].includes(this._packageState.termination),
+      }));
+    }
+
     return isAccountCurrent(this._connectionManager, account) ? children : [];
+  }
+
+  _getMetadataChildren(packages, account, generation, descriptor) {
+    if (this._metadataLoaded) return Promise.resolve(this._metadataChildren);
+    if (this._metadataPromise) return this._metadataPromise;
+    const promise = this._loadMetadataChildren(packages, account, generation, descriptor)
+      .finally(() => {
+        if (this._metadataPromise === promise) this._metadataPromise = null;
+      });
+    this._metadataPromise = promise;
+    return promise;
+  }
+
+  async _loadMetadataChildren(packages, account, generation, descriptor) {
+    const children = [];
+    const hasValidatedPackagePage = this._packageState.pageCount > 0;
+    if (hasValidatedPackagePage) {
+      let upstreamState;
+      try {
+        upstreamState = await this.getUpstreamState(packages);
+      } catch {
+        upstreamState = null;
+      }
+      if (!this._isMetadataCurrent(account, generation, descriptor)) return [];
+      if (upstreamState?.upstreams.length > 0) {
+        children.push(new UpstreamIndicatorNode(
+          upstreamState.upstreams,
+          {
+            workspace: this.workspace,
+            slug: this.slug,
+            name: this.name,
+          },
+          this.context,
+          {
+            complete: upstreamState.complete,
+            failedFormats: upstreamState.failedFormats,
+            uninspectedFormats: upstreamState.uninspectedFormats,
+          }
+        ));
+      } else if (upstreamState && !upstreamState.complete) {
+        const unavailableCount = upstreamState.failedFormats.length
+          + upstreamState.uninspectedFormats.length;
+        children.push(new InfoNode(
+          "Upstreams: incomplete",
+          unavailableCount > 0
+            ? `${unavailableCount} formats could not be loaded`
+            : "The collection could not be verified",
+          "The configured upstream total could not be determined.",
+          "warning"
+        ));
+      } else if (!upstreamState) {
+        children.push(new InfoNode(
+          "Upstreams: failed to load",
+          "The upstream collection could not be verified",
+          "Package results remain available.",
+          "warning"
+        ));
+      }
+    }
+
+    if (this.storageRegion) {
+      const regionLabel = this._getStorageRegionLabel(this.storageRegion);
+      children.push({
+        getTreeItem: () => ({
+          label: "Storage Region",
+          description: regionLabel,
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+          contextValue: "repoDetail",
+          iconPath: new vscode.ThemeIcon("globe"),
+        }),
+        getChildren: () => [],
+      });
+    }
+
+    if (descriptor?.showEntitlements) {
+      try {
+        const entitlements = await this.getEntitlementCollection();
+        if (!this._isMetadataCurrent(account, generation, descriptor)) return [];
+        if (entitlements.items.length > 0) {
+          children.push(new EntitlementSummaryNode(entitlements.items, this.context, {
+            complete: entitlements.complete,
+            totalCount: entitlements.pagination?.countAuthoritative
+              ? entitlements.pagination.count
+              : null,
+            failureCount: entitlements.failureCount,
+            termination: entitlements.termination,
+          }));
+        } else if (!entitlements.complete) {
+          children.push(new InfoNode(
+            entitlements.failureCount > 0
+              ? "Entitlements: failed to load"
+              : "Entitlements: incomplete",
+            "The entitlement collection could not be verified.",
+            entitlements.failureCount > 0
+              ? collectionFailureMessage(entitlements.failures[0])
+              : "A safe collection limit was reached or loading was cancelled.",
+            "warning"
+          ));
+        }
+      } catch {
+        if (!this._isMetadataCurrent(account, generation, descriptor)) return [];
+        children.push(new InfoNode(
+          "Entitlements: failed to load",
+          "The entitlement collection could not be verified.",
+          "An error occurred loading entitlement tokens.",
+          "warning"
+        ));
+      }
+    }
+
+    if (!this._isMetadataCurrent(account, generation, descriptor)) return [];
+    this._metadataChildren = Object.freeze(children);
+    this._metadataLoaded = true;
+    return this._metadataChildren;
+  }
+
+  _isMetadataCurrent(account, generation, descriptor) {
+    return Boolean(
+      !this._disposed
+      && generation === this._generation
+      && descriptor?.key === this._packageDescriptor?.key
+      && isAccountCurrent(this._connectionManager, account)
+    );
   }
 }
 
@@ -415,42 +782,451 @@ function isRecordArray(value) {
   ));
 }
 
-function unwrapIdentifier(value) {
-  if (typeof value === "string" && value.length > 0) {
-    return value;
-  }
-  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
-    ? value.value
+function createEmptyPackageState() {
+  return Object.freeze({
+    initialized: false,
+    nodes: Object.freeze([]),
+    resultKeys: Object.freeze([]),
+    pagination: null,
+    complete: false,
+    partial: false,
+    continuation: null,
+    failures: Object.freeze([]),
+    pageCount: 0,
+    requestCount: 0,
+    duplicateCount: 0,
+    termination: "not_started",
+    capReached: false,
+  });
+}
+
+function emptyCollectionResult(cancelled = false) {
+  return Object.freeze({
+    items: Object.freeze([]),
+    complete: false,
+    incomplete: true,
+    partial: false,
+    cancelled,
+    continuation: null,
+    failures: Object.freeze([]),
+    failureCount: 0,
+    termination: cancelled ? "cancelled" : "not_started",
+    pageCount: 0,
+    requestCount: 0,
+    duplicateCount: 0,
+    pagination: null,
+  });
+}
+
+function isCollectionResult(value) {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Array.isArray(value.items)
+    && typeof value.complete === "boolean"
+    && value.incomplete === !value.complete
+    && typeof value.partial === "boolean"
+    && typeof value.cancelled === "boolean"
+    && Array.isArray(value.failures)
+    && Number.isSafeInteger(value.failureCount)
+    && value.failureCount >= value.failures.length
+    && typeof value.termination === "string"
+    && value.termination.length > 0
+    && value.termination.length <= 80
+    && COLLECTION_TERMINATIONS.has(value.termination)
+    && Number.isSafeInteger(value.pageCount)
+    && value.pageCount >= 0
+    && value.pageCount <= MAX_COLLECTION_PAGES
+    && Number.isSafeInteger(value.requestCount)
+    && value.requestCount >= value.pageCount
+    && value.requestCount <= MAX_COLLECTION_REQUESTS
+    && Number.isSafeInteger(value.duplicateCount)
+    && value.duplicateCount >= 0
+    && (!value.complete || (
+      value.termination === "exhausted"
+      && value.continuation === null
+      && !value.cancelled
+      && value.failureCount === 0
+    ))
+    && (!value.cancelled || !value.complete)
+    && (value.pagination === null || isPagination(value.pagination))
+  );
+}
+
+function isPagination(value) {
+  return Boolean(
+    value
+    && Number.isSafeInteger(value.page)
+    && value.page >= 1
+    && Number.isSafeInteger(value.pageTotal)
+    && value.pageTotal >= value.page
+    && Number.isSafeInteger(value.pageSize)
+    && value.pageSize >= 1
+    && typeof value.countAuthoritative === "boolean"
+    && (value.countAuthoritative
+      ? Number.isSafeInteger(value.count) && value.count >= 0
+      : value.count === null)
+  );
+}
+
+function validContinuation(value, descriptor, itemCount, result) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const anchor = value.anchor;
+  const cumulative = value.cumulative;
+  const firstPageRetry = value.nextPage === 1 && anchor === null;
+  if (
+    value.descriptor !== descriptor
+    || typeof value.binding !== "string"
+    || !/^[a-f0-9]{64}$/.test(value.binding)
+    || !Number.isSafeInteger(value.nextPage)
+    || value.nextPage < 1
+    || (!firstPageRetry && !isPagination(anchor))
+    || (!firstPageRetry && anchor.page + 1 !== value.nextPage)
+    || (!firstPageRetry && anchor.page >= anchor.pageTotal)
+    || !cumulative
+    || !Number.isSafeInteger(cumulative.pageCount)
+    || cumulative.pageCount < (firstPageRetry ? 0 : 1)
+    || cumulative.pageCount >= MAX_COLLECTION_PAGES
+    || !Number.isSafeInteger(cumulative.requestCount)
+    || cumulative.requestCount < cumulative.pageCount
+    || cumulative.requestCount >= MAX_COLLECTION_REQUESTS
+    || !Number.isSafeInteger(cumulative.itemCount)
+    || cumulative.itemCount !== itemCount
+    || cumulative.itemCount >= MAX_COLLECTION_ITEMS
+    || !Number.isSafeInteger(cumulative.duplicateCount)
+    || cumulative.duplicateCount < 0
+    || !Number.isSafeInteger(cumulative.failureCount)
+    || cumulative.failureCount < 0
+    || cumulative.pageCount !== result.pageCount
+    || cumulative.requestCount !== result.requestCount
+    || cumulative.duplicateCount !== result.duplicateCount
+    || (firstPageRetry
+      ? result.pagination !== null
+        || cumulative.pageCount !== 0
+        || cumulative.itemCount !== 0
+        || value.nextPage !== 1
+      : cumulative.pageCount !== anchor.page
+        || value.nextPage !== cumulative.pageCount + 1
+        || cumulative.itemCount !== committedItemCount(anchor)
+        || !samePagination(anchor, result.pagination))
+  ) return null;
+  return value;
+}
+
+function committedItemCount(pagination) {
+  const fullPageCount = pagination.page * pagination.pageSize;
+  if (!Number.isSafeInteger(fullPageCount)) return -1;
+  return pagination.countAuthoritative
+    ? Math.min(pagination.count, fullPageCount)
+    : fullPageCount;
+}
+
+function samePagination(left, right) {
+  return Boolean(left && right)
+    && left.page === right.page
+    && left.pageTotal === right.pageTotal
+    && left.pageSize === right.pageSize
+    && left.count === right.count
+    && left.countAuthoritative === right.countAuthoritative;
+}
+
+function isCollectionCapReached(result, itemCount) {
+  return result.pageCount >= MAX_COLLECTION_PAGES
+    || result.requestCount >= MAX_COLLECTION_REQUESTS
+    || itemCount >= MAX_COLLECTION_ITEMS
+    || /(?:cap|limit)/i.test(result.termination);
+}
+
+function normalizePageSize(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 30;
+  return Math.min(30, Math.max(1, Math.floor(numeric)));
+}
+
+function boundedString(value, maxLength, options = {}) {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) return null;
+  if (options.trimmed !== false && value !== value.trim()) return null;
+  if (/[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/.test(value)) return null;
+  return value;
+}
+
+function optionalString(value, maxLength = MAX_OPTIONAL_STRING_LENGTH) {
+  if (value == null) return null;
+  return typeof value === "string" && value.length <= maxLength
+    && !/[\u0000-\u001f\u007f]/.test(value)
+    ? value
     : null;
 }
 
-function isPackageArray(value) {
-  return isRecordArray(value) && value.every(pkg => (
-    typeof pkg.name === "string" && pkg.name.length > 0
-    && typeof pkg.format === "string" && pkg.format.length > 0
-    && (typeof pkg.version === "string" || typeof pkg.version === "number")
-    && String(pkg.version).length > 0
-    && typeof pkg.repository === "string" && pkg.repository.length > 0
-    && typeof pkg.namespace === "string" && pkg.namespace.length > 0
-    && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+function canonicalTags(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const tags = {};
+  for (const field of ["info", "version"]) {
+    if (value[field] == null) continue;
+    const raw = Array.isArray(value[field]) ? value[field] : [value[field]];
+    if (
+      raw.length > MAX_TAGS
+      || !raw.every(tag => typeof tag === "string" && tag.length <= MAX_TAG_LENGTH)
+    ) return null;
+    tags[field] = [...raw];
+  }
+  return tags;
+}
+
+function canonicalizeRepositoryPackage(pkg, workspace, repository) {
+  if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) return null;
+  const name = boundedString(pkg.name, MAX_NAME_LENGTH, { trimmed: false });
+  const format = boundedString(pkg.format, MAX_FORMAT_LENGTH);
+  const version = typeof pkg.version === "string" || typeof pkg.version === "number"
+    ? boundedString(String(pkg.version), MAX_VERSION_LENGTH, { trimmed: false })
+    : null;
+  const namespace = boundedString(pkg.namespace, MAX_SCOPE_LENGTH);
+  const returnedRepository = boundedString(pkg.repository, MAX_SCOPE_LENGTH);
+  const slugPerm = boundedString(pkg.slug_perm, MAX_IDENTITY_LENGTH);
+  const tags = canonicalTags(pkg.tags);
+  const policyFlags = getPackagePolicyFlags(pkg);
+  if (
+    !name || !format || !version || !namespace || !returnedRepository || !slugPerm || !tags
+    || !policyFlags
+    || namespace !== workspace || returnedRepository !== repository
+  ) return null;
+  const vulnerability = canonicalVulnerabilityFields(pkg);
+  return {
+    name,
+    format,
+    version,
+    namespace,
+    repository: returnedRepository,
+    slug_perm: slugPerm,
+    slug: optionalString(pkg.slug, MAX_IDENTITY_LENGTH),
+    is_copyable: pkg.is_copyable === true ? true : pkg.is_copyable === false ? false : null,
+    status_str: optionalString(pkg.status_str),
+    downloads: Number.isSafeInteger(pkg.downloads) && pkg.downloads >= 0 ? pkg.downloads : 0,
+    uploaded_at: optionalString(pkg.uploaded_at),
+    status_reason: optionalString(pkg.status_reason),
+    checksum_sha256: optionalString(pkg.checksum_sha256),
+    version_digest: optionalString(pkg.version_digest),
+    cdn_url: optionalString(pkg.cdn_url, MAX_URL_LENGTH),
+    filename: optionalString(pkg.filename),
+    ...policyFlags,
+    num_vulnerabilities: vulnerability.numVulnerabilities,
+    has_vulnerabilities: vulnerability.hasVulnerabilities,
+    max_severity: optionalString(pkg.max_severity),
+    vulnerability_scan_results_url: optionalString(pkg.vulnerability_scan_results_url, MAX_URL_LENGTH),
+    security_scan_status: vulnerability.securityScanStatus,
+    spdx_license: optionalString(pkg.spdx_license),
+    license: optionalString(pkg.license),
+    raw_license: optionalString(pkg.raw_license),
+    license_url: optionalString(pkg.license_url, MAX_URL_LENGTH),
+    tags,
+  };
+}
+
+function canonicalVulnerabilityFields(pkg) {
+  const evidenceFields = [
+    "num_vulnerabilities",
+    "vulnerability_scan_results_count",
+    "vulnerabilityCount",
+    "has_vulnerabilities",
+    "security_scan_status",
+  ];
+  const hasEvidence = evidenceFields.some(field => (
+    Object.prototype.hasOwnProperty.call(pkg, field)
+    && pkg[field] !== undefined
+    && pkg[field] !== null
+    && pkg[field] !== ""
   ));
+  const state = getPackageVulnerabilityState(pkg);
+  if (!hasEvidence || state.unknown) {
+    return {
+      numVulnerabilities: undefined,
+      hasVulnerabilities: undefined,
+      securityScanStatus: null,
+    };
+  }
+  const securityScanStatus = optionalString(pkg.security_scan_status, 256);
+  if (state.count !== null) {
+    return {
+      numVulnerabilities: state.count,
+      hasVulnerabilities: state.count > 0,
+      securityScanStatus,
+    };
+  }
+  if (state.detected) {
+    return {
+      numVulnerabilities: undefined,
+      hasVulnerabilities: true,
+      securityScanStatus,
+    };
+  }
+  return {
+    numVulnerabilities: undefined,
+    hasVulnerabilities: undefined,
+    securityScanStatus: null,
+  };
+}
+
+function isPackageArray(value, workspace, repository) {
+  return isRecordArray(value)
+    && value.every(pkg => canonicalizeRepositoryPackage(pkg, workspace, repository) !== null);
+}
+
+function canonicalPackageGroupFormat(group) {
+  const formats = [group?.format, group?.package_format, group?.packageFormat]
+    .filter(value => value != null)
+    .map(value => boundedString(value, MAX_FORMAT_LENGTH));
+  if (formats.length === 0 || formats.some(value => !value || value !== formats[0])) return null;
+  return formats[0];
+}
+
+function canonicalizePackageGroup(group) {
+  if (!group || typeof group !== "object" || Array.isArray(group)) return null;
+  const name = boundedString(group.name, MAX_NAME_LENGTH, { trimmed: false });
+  const format = canonicalPackageGroupFormat(group);
+  if (!name || !format) return null;
+  const formats = Array.isArray(group.formats)
+    ? group.formats.map(value => boundedString(value, MAX_FORMAT_LENGTH))
+    : [];
+  if (formats.some(value => !value) || formats.length > 100) return null;
+  return {
+    name,
+    format,
+    formats,
+    count: Number.isSafeInteger(group.count) && group.count >= 0 ? group.count : 0,
+    size: Number.isSafeInteger(group.size) && group.size >= 0 ? group.size : 0,
+    num_downloads: Number.isSafeInteger(group.num_downloads) && group.num_downloads >= 0
+      ? group.num_downloads
+      : 0,
+    last_push: optionalString(group.last_push),
+  };
 }
 
 function isPackageGroupArray(value) {
-  return isRecordArray(value) && value.every(group => (
-    typeof group.name === "string"
-    && group.name.length > 0
-    && [group.format, group.package_format, group.packageFormat]
-      .some(format => typeof format === "string" && format.length > 0)
-  ));
+  return isRecordArray(value) && value.every(group => canonicalizePackageGroup(group) !== null);
+}
+
+function isPackageGroupResponse(value) {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && isPackageGroupArray(value.results)
+  );
 }
 
 function isEntitlementArray(value) {
-  return isRecordArray(value) && value.every(entitlement => (
-    typeof entitlement.name === "string"
-    && entitlement.name.trim().length > 0
-    && (entitlement.is_active === undefined || typeof entitlement.is_active === "boolean")
-  ));
+  return isRecordArray(value)
+    && value.every(entitlement => canonicalizeEntitlement(entitlement) !== null);
+}
+
+function canonicalizeEntitlement(entitlement) {
+  if (!entitlement || typeof entitlement !== "object" || Array.isArray(entitlement)) return null;
+  const name = boundedString(entitlement.name, MAX_NAME_LENGTH, { trimmed: false });
+  const slugPerm = boundedString(entitlement.slug_perm, MAX_IDENTITY_LENGTH);
+  if (!name || !slugPerm || typeof entitlement.is_active !== "boolean") return null;
+  const token = entitlement.token == null
+    ? null
+    : optionalString(entitlement.token, MAX_OPTIONAL_STRING_LENGTH);
+  const queryValues = [entitlement.limit_package_query, entitlement.package_query]
+    .filter(value => value != null);
+  const packageQuery = queryValues.length === 0
+    ? null
+    : optionalString(queryValues[0], MAX_OPTIONAL_STRING_LENGTH);
+  const limitBandwidthUnit = entitlement.limit_bandwidth_unit == null
+    ? null
+    : optionalString(entitlement.limit_bandwidth_unit, 100);
+  const limitDateRangeFrom = entitlement.limit_date_range_from == null
+    ? null
+    : optionalString(entitlement.limit_date_range_from, 100);
+  const limitDateRangeTo = entitlement.limit_date_range_to == null
+    ? null
+    : optionalString(entitlement.limit_date_range_to, 100);
+  if (
+    (entitlement.token != null && token === null)
+    || (queryValues.length > 0 && (
+      packageQuery === null || queryValues.some(value => value !== queryValues[0])
+    ))
+    || (entitlement.limit_bandwidth_unit != null && limitBandwidthUnit === null)
+    || (entitlement.limit_date_range_from != null && limitDateRangeFrom === null)
+    || (entitlement.limit_date_range_to != null && limitDateRangeTo === null)
+  ) return null;
+  const limitBandwidth = optionalNonNegativeNumber(entitlement.limit_bandwidth);
+  const limitDownloads = optionalNonNegativeNumber(entitlement.limit_num_downloads);
+  const limitClients = optionalNonNegativeNumber(entitlement.limit_num_clients);
+  if ([limitBandwidth, limitDownloads, limitClients].includes(false)) return null;
+  return {
+    name,
+    slug_perm: slugPerm,
+    is_active: entitlement.is_active,
+    token,
+    package_query: packageQuery,
+    limit_bandwidth: limitBandwidth,
+    limit_bandwidth_unit: limitBandwidthUnit,
+    limit_num_downloads: limitDownloads,
+    limit_num_clients: limitClients,
+    limit_date_range_from: limitDateRangeFrom,
+    limit_date_range_to: limitDateRangeTo,
+  };
+}
+
+function optionalNonNegativeNumber(value) {
+  if (value == null) return null;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : false;
+}
+
+function normalizeUpstreamState(result) {
+  if (!result || !Array.isArray(result.upstreams)) return emptyUpstreamState();
+  const failedFormats = Array.isArray(result.failedFormats) ? [...result.failedFormats] : [];
+  const uninspectedFormats = Array.isArray(result.uninspectedFormats)
+    ? [...result.uninspectedFormats]
+    : [];
+  return Object.freeze({
+    upstreams: Object.freeze([...result.upstreams]),
+    failedFormats: Object.freeze(failedFormats),
+    uninspectedFormats: Object.freeze(uninspectedFormats),
+    complete: result.complete === true
+      && failedFormats.length === 0
+      && uninspectedFormats.length === 0,
+  });
+}
+
+function emptyUpstreamState() {
+  return Object.freeze({
+    upstreams: Object.freeze([]),
+    failedFormats: Object.freeze([]),
+    uninspectedFormats: Object.freeze([]),
+    complete: false,
+  });
+}
+
+function localCollectionFailure(kind, message) {
+  return Object.freeze({
+    kind,
+    status: null,
+    retryable: false,
+    message,
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
+}
+
+function collectionFailureMessage(failure) {
+  if (!failure) return "The collection could not be verified.";
+  try {
+    return formatApiError(failure.error || failure);
+  } catch {
+    return "The collection could not be verified.";
+  }
+}
+
+function collectionProgressDescription(state) {
+  const loaded = state.nodes.length.toLocaleString();
+  return state.pagination?.countAuthoritative
+    ? `Showing ${loaded} of ${state.pagination.count.toLocaleString()}`
+    : `${loaded} loaded; completeness could not be verified`;
 }
 
 module.exports = RepositoryNode;

--- a/models/upstreamIndicatorNode.js
+++ b/models/upstreamIndicatorNode.js
@@ -4,9 +4,18 @@
 const vscode = require("vscode");
 
 class UpstreamIndicatorNode {
-    constructor(upstreams, repositoryContext = {}, context) {
+    constructor(upstreams, repositoryContext = {}, context, options = {}) {
         this.context = context;
         this.upstreams = upstreams;
+        this.failedFormats = Array.isArray(options.failedFormats)
+            ? options.failedFormats.filter(format => typeof format === "string")
+            : [];
+        this.uninspectedFormats = Array.isArray(options.uninspectedFormats)
+            ? options.uninspectedFormats.filter(format => typeof format === "string")
+            : [];
+        this.complete = options.complete === true
+            && this.failedFormats.length === 0
+            && this.uninspectedFormats.length === 0;
         this.workspace = repositoryContext.workspace || null;
         this.slug = repositoryContext.slug || null;
         this.name = repositoryContext.name || null;
@@ -15,10 +24,28 @@ class UpstreamIndicatorNode {
     getTreeItem() {
         const count = this.upstreams.length;
         const active = this.upstreams.filter(u => u.is_active !== false).length;
+        const partial = !this.complete;
+        const label = partial
+            ? `Upstreams: ${active} active among ${count} loaded (partial)`
+            : `Upstreams: ${active} active of ${count} configured`;
+        const unavailableFormats = [...new Set([
+            ...this.failedFormats,
+            ...this.uninspectedFormats,
+        ])];
+        const failureDetail = unavailableFormats.length > 0
+            ? `\nCould not load formats: ${unavailableFormats.join(", ")}`
+            : partial ? "\nThe configured total could not be verified." : "";
+
+        const loadedUpstreamDetail = this.upstreams.map((upstream) => {
+            const url = typeof upstream.upstream_url === "string" && upstream.upstream_url.length > 0
+                ? ` (${upstream.upstream_url})`
+                : "";
+            return `${upstream.name}${url}`;
+        }).join('\n');
 
         return {
-            label: `Upstreams: ${active} active of ${count} configured`,
-            tooltip: this.upstreams.map(u => `${u.name} (${u.upstream_url})`).join('\n'),
+            label,
+            tooltip: `${loadedUpstreamDetail}${failureDetail}`,
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "upstreamIndicator",
             iconPath: new vscode.ThemeIcon('cloud'),

--- a/models/upstreamIndicatorNode.js
+++ b/models/upstreamIndicatorNode.js
@@ -2,6 +2,12 @@
 // Appears at the top of a repository's package list when upstream sources are configured.
 
 const vscode = require("vscode");
+const {
+    formatUpstreamOrigin,
+    formatUpstreamText,
+} = require("../util/upstreamPresentation");
+
+const MAX_TOOLTIP_UPSTREAMS = 20;
 
 class UpstreamIndicatorNode {
     constructor(upstreams, repositoryContext = {}, context, options = {}) {
@@ -36,16 +42,17 @@ class UpstreamIndicatorNode {
             ? `\nCould not load formats: ${unavailableFormats.join(", ")}`
             : partial ? "\nThe configured total could not be verified." : "";
 
-        const loadedUpstreamDetail = this.upstreams.map((upstream) => {
-            const url = typeof upstream.upstream_url === "string" && upstream.upstream_url.length > 0
-                ? ` (${upstream.upstream_url})`
-                : "";
-            return `${upstream.name}${url}`;
-        }).join('\n');
+        const displayedUpstreams = this.upstreams.slice(0, MAX_TOOLTIP_UPSTREAMS);
+        const loadedUpstreamDetail = displayedUpstreams.map((upstream) => (
+            `${formatUpstreamText(upstream.name, "Unnamed")} (${formatUpstreamOrigin(upstream.upstream_url)})`
+        )).join("\n");
+        const omittedDetail = this.upstreams.length > displayedUpstreams.length
+            ? `\nShowing ${displayedUpstreams.length} of ${this.upstreams.length} loaded upstreams.`
+            : "";
 
         return {
             label,
-            tooltip: `${loadedUpstreamDetail}${failureDetail}`,
+            tooltip: `${loadedUpstreamDetail}${omittedDetail}${failureDetail}`,
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "upstreamIndicator",
             iconPath: new vscode.ThemeIcon('cloud'),

--- a/models/workspaceNode.js
+++ b/models/workspaceNode.js
@@ -23,6 +23,14 @@ class WorkspaceNode {
       || (() => new CloudsmithAPI(this.context));
     this._fetchWorkspaceRepositories = options.fetchWorkspaceRepositories
       || workspaceRepositoryFetcher.fetchWorkspaceRepositories;
+    this._signal = options.signal || null;
+    this._createRepositoryNode = options.createRepositoryNode
+      || ((repo, workspace) => new repositoryNode(
+        repo,
+        workspace,
+        this.context,
+        { connectionManager: this._connectionManager, createCloudsmithAPI: this._createCloudsmithAPI }
+      ));
     this.name = item.name;
     this.slug = item.slug;
     this.workspace = item.slug;
@@ -47,32 +55,32 @@ class WorkspaceNode {
     const account = captureAccount(this._connectionManager);
     if (!account) return [];
     const workspace = this.workspace;
-    const result = await this._fetchWorkspaceRepositories(this.context, workspace, {
-      account,
-      connectionManager: this._connectionManager,
-    });
+    let result;
+    try {
+      result = await this._fetchWorkspaceRepositories(this.context, workspace, {
+        account,
+        connectionManager: this._connectionManager,
+        signal: this._signal,
+      });
+    } catch {
+      return isAccountCurrent(this._connectionManager, account)
+        ? [repositoryCollectionWarning(workspace, null)]
+        : [];
+    }
+    if (!result || !Array.isArray(result.items)) {
+      return [repositoryCollectionWarning(workspace, result)];
+    }
     if (!isAccountCurrent(this._connectionManager, account) || result.stale) return [];
 
-    if (result.error) {
-      return [new InfoNode(
-        "Failed to load repositories",
-        "Check your connection and try refreshing",
-        `Failed to load repositories for ${workspace}: ${formatApiError(result.error)}`,
-        "warning"
-      )];
-    }
-
-    const repositories = result.repositories;
+    const repositories = result.items;
     const RepositoryNodes = [];
 
     for (const repo of repositories) {
-      const repositoryNodeInst = new repositoryNode(
-        repo,
-        this.slug,
-        this.context,
-        { connectionManager: this._connectionManager, createCloudsmithAPI: this._createCloudsmithAPI }
-      );
+      const repositoryNodeInst = this._createRepositoryNode(repo, this.slug);
       RepositoryNodes.push(repositoryNodeInst);
+    }
+    if (result.complete !== true) {
+      RepositoryNodes.push(repositoryCollectionWarning(workspace, result));
     }
     return RepositoryNodes;
   }
@@ -87,6 +95,7 @@ class WorkspaceNode {
       const result = await cloudsmithAPI.get(apiEndpoint(["quota", this.workspace]), {
         responseType: "object",
         retry: "safe-read",
+        signal: this._signal,
       });
 
       if (result.ok && result.data.usage && typeof result.data.usage === "object") {
@@ -106,6 +115,20 @@ class WorkspaceNode {
 
     return children;
   }
+}
+
+function repositoryCollectionWarning(workspace, result) {
+  const loaded = Array.isArray(result?.items) ? result.items.length : 0;
+  const error = result?.failures?.[0]?.error;
+  const detail = error
+    ? formatApiError(error)
+    : "A safe collection limit was reached before completeness was proven.";
+  return new InfoNode(
+    loaded > 0 ? "Repository list is incomplete" : "Failed to load repositories",
+    loaded > 0 ? `${loaded.toLocaleString()} repositories loaded` : "Check your connection and try refreshing",
+    `Repositories for ${workspace} are incomplete: ${detail}`,
+    "warning"
+  );
 }
 
 module.exports = WorkspaceNode;

--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
         "category": "Cloudsmith"
       },
       {
+        "command": "cloudsmith-vsc.loadMoreRepositoryPackages",
+        "title": "Load more repository packages",
+        "category": "Cloudsmith"
+      },
+      {
         "command": "cloudsmith-vsc.searchInWorkspace",
         "title": "Search packages in this workspace",
         "category": "Cloudsmith"
@@ -395,6 +400,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "cloudsmith-vsc.loadMoreRepositoryPackages",
+          "when": "false"
+        }
+      ],
       "view/item/context": [
         {
           "command": "cloudsmith-vsc.inspectPackage",
@@ -763,7 +774,7 @@
           "default": 30,
           "maximum": 30,
           "minimum": 1,
-          "description": "Maximum number of packages to return per repository. Limit: 30."
+          "description": "Packages loaded per page in the repository tree. Use Load More to continue, up to the 600-package safety bound per expansion."
         },
         "cloudsmith-vsc.groupByPackageGroups": {
           "type": "boolean",

--- a/test/cloudsmithProvider.test.js
+++ b/test/cloudsmithProvider.test.js
@@ -5,6 +5,38 @@ const { getWorkspaces } = require("../extension");
 const { getWorkspaceContextProjector } = require("../util/workspaceContextProjector");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
+function workspaceSuccess(items) {
+  return apiSuccess(items, {
+    headers: {
+      "x-pagination-page": "1",
+      "x-pagination-pagetotal": "1",
+      "x-pagination-pagesize": "500",
+      "x-pagination-count": String(items.length),
+    },
+  });
+}
+
+function collectionResult(items, options = {}) {
+  const complete = options.complete !== false;
+  const failures = options.failures || [];
+  return {
+    items,
+    complete,
+    incomplete: !complete,
+    partial: !complete && items.length > 0,
+    cancelled: options.cancelled === true,
+    continuation: null,
+    failures,
+    failureCount: failures.length,
+    termination: complete ? "exhausted" : (options.termination || "request_failed"),
+    pageCount: options.pageCount ?? (items.length > 0 ? 1 : 0),
+    requestCount: options.requestCount ?? (items.length > 0 ? 1 : failures.length),
+    duplicateCount: 0,
+    pagination: null,
+    stale: false,
+  };
+}
+
 function deferred() {
   let resolve;
   const promise = new Promise(res => { resolve = res; });
@@ -100,7 +132,7 @@ suite("CloudsmithProvider", () => {
   });
 
   test("always clears Loading when the workspace API factory throws", async () => {
-    const provider = createProvider(async () => apiSuccess([]), {
+    const provider = createProvider(async () => workspaceSuccess([]), {
       createCloudsmithAPI() {
         throw new Error("unexpected factory failure");
       },
@@ -119,7 +151,7 @@ suite("CloudsmithProvider", () => {
       begin() { return Object.freeze({}); },
       async project() { throw new Error("projection failed"); },
     };
-    const provider = createProvider(async () => apiSuccess([
+    const provider = createProvider(async () => workspaceSuccess([
       { slug: "workspace-a", name: "Workspace A" },
       { slug: "workspace-b", name: "Workspace B" },
     ]), { workspaceContextProjector });
@@ -147,13 +179,53 @@ suite("CloudsmithProvider", () => {
     assert.strictEqual(treeView.message, undefined);
   });
 
+  test("keeps workspace multiplicity conservative while enumeration is pending", async () => {
+    const pending = deferred();
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      fetchWorkspaces: async () => pending.promise,
+    });
+
+    const resultPromise = provider.getWorkspaces();
+    while (!commands.some(call => (
+      call[1] === "cloudsmith.hasMultipleWorkspaces" && call[2] === true
+    ))) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.strictEqual(commands.some(call => call[2] === false), false);
+
+    pending.resolve(collectionResult([{ slug: "workspace-a", name: "Workspace A" }]));
+    const nodes = await resultPromise;
+    assert.strictEqual(nodes.length, 1);
+    assert.strictEqual(commands.at(-1)[2], false);
+  });
+
+  test("keeps workspace multiplicity conservative after enumeration failure", async () => {
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      fetchWorkspaces: async () => { throw new Error("workspace fetch failed"); },
+    });
+
+    const nodes = await provider.getWorkspaces();
+
+    assert.strictEqual(nodes[0].getTreeItem().label, "Could not load workspaces");
+    assert.strictEqual(commands.at(-1)[2], true);
+  });
+
+  test("refresh projects conservative multiplicity while connected", async () => {
+    const provider = createProvider(async () => workspaceSuccess([]));
+
+    provider.refresh();
+    await provider._workspaceContextProjector.whenIdle();
+
+    assert.strictEqual(commands.at(-1)[2], true);
+  });
+
   test("publishes validated workspace nodes from an account-scoped memory cache", async () => {
     let requests = 0;
     const provider = createProvider(async (_endpoint, options) => {
       requests += 1;
       const payload = [{ slug: "workspace-a", name: "Workspace A", api_key: "not persisted" }];
       assert.strictEqual(options.validate(payload), true);
-      return apiSuccess(payload);
+      return workspaceSuccess(payload);
     });
 
     const first = await provider.getWorkspaces();
@@ -170,10 +242,10 @@ suite("CloudsmithProvider", () => {
     const resultPromise = provider.getWorkspaces();
     await new Promise(resolve => setImmediate(resolve));
     manager.setState({ accountEpoch: 2 });
-    pending.resolve(apiSuccess([{ slug: "old-account", name: "Old Account" }]));
+    pending.resolve(workspaceSuccess([{ slug: "old-account", name: "Old Account" }]));
 
     assert.deepStrictEqual(await resultPromise, []);
-    assert.strictEqual(commands.some(call => call[2] === true), false);
+    assert.strictEqual(commands.some(call => call[2] === true), true);
   });
 
   test("guards repository and quota publication with one captured account", async () => {
@@ -181,8 +253,7 @@ suite("CloudsmithProvider", () => {
     const quota = deferred();
     const provider = createProvider(async () => quota.promise, {
       fetchWorkspaceRepositories: async () => ({
-        repositories: [{ slug: "repo-a", name: "Repo A" }],
-        error: null,
+        ...collectionResult([{ slug: "repo-a", name: "Repo A" }]),
         stale: false,
       }),
     });
@@ -204,7 +275,7 @@ suite("CloudsmithProvider", () => {
       }
       applied.push(value);
     };
-    const provider = createProvider(async () => apiSuccess([
+    const provider = createProvider(async () => workspaceSuccess([
       { slug: "workspace-a", name: "Workspace A" },
       { slug: "workspace-b", name: "Workspace B" },
     ]));
@@ -221,7 +292,7 @@ suite("CloudsmithProvider", () => {
 
     assert.deepStrictEqual(await pending, []);
     await provider._workspaceContextProjector.whenIdle();
-    assert.strictEqual(applied.at(-1), false);
+    assert.strictEqual(applied.at(-1), true);
     assert.strictEqual(treeView.message, undefined);
   });
 
@@ -258,7 +329,195 @@ suite("CloudsmithProvider", () => {
 
     assert.strictEqual(await pending, null);
     await workspaceContextProjector.whenIdle();
-    assert.deepStrictEqual(applied, [true, false]);
-    assert.strictEqual(applied.at(-1), false);
+    assert.deepStrictEqual(applied, [true, true]);
+    assert.strictEqual(applied.at(-1), true);
+  });
+
+  test("publishes partial workspaces truthfully and does not cache them", async () => {
+    let fetches = 0;
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      fetchWorkspaces: async () => {
+        fetches += 1;
+        return collectionResult(
+          [{ slug: "workspace-a", name: "Workspace A" }],
+          {
+            complete: false,
+            failures: [{ error: { message: "Page 2 failed." } }],
+            requestCount: 2,
+          }
+        );
+      },
+    });
+
+    const first = await provider.getWorkspaces();
+    const second = await provider.getWorkspaces();
+
+    assert.strictEqual(fetches, 2);
+    assert.strictEqual(first[0].workspace, "workspace-a");
+    assert.strictEqual(first[1].getTreeItem().label, "Workspaces are incomplete");
+    assert.strictEqual(second[1].getTreeItem().description, "1 loaded");
+    assert.ok(commands.some(call => call[2] === true));
+  });
+
+  test("keeps partial default-workspace repositories and appends an incomplete marker", async () => {
+    defaultWorkspace = "workspace-a";
+    const provider = createProvider(async () => apiSuccess({ usage: {} }), {
+      fetchWorkspaceRepositories: async () => collectionResult(
+        [{ slug: "repo-a", name: "Repo A" }],
+        {
+          complete: false,
+          failures: [{ error: { message: "Page 2 failed." } }],
+          requestCount: 2,
+        }
+      ),
+    });
+
+    const children = await provider.getRepositories("workspace-a");
+
+    assert.strictEqual(children[0].getTreeItem().contextValue, "workspaceInfo");
+    assert.strictEqual(children[1].name, "Repo A");
+    assert.strictEqual(children[2].getTreeItem().label, "Repositories are incomplete");
+  });
+
+  test("falls back when a default workspace returns zero unproven repositories", async () => {
+    defaultWorkspace = "workspace-a";
+    let fallback;
+    const provider = createProvider(async () => workspaceSuccess([
+      { slug: "workspace-b", name: "Workspace B" },
+    ]), {
+      fetchWorkspaceRepositories: async () => collectionResult([], {
+        complete: false,
+        failures: [{ error: { message: "Page 1 failed." } }],
+        requestCount: 1,
+      }),
+    });
+    provider.setDefaultWorkspaceFallbackHandler(value => { fallback = value; });
+
+    const children = await provider.getRepositories("workspace-a");
+
+    assert.strictEqual(fallback, "workspace-a");
+    assert.strictEqual(children[0].workspace, "workspace-b");
+  });
+
+  test("targeted repository refresh does not invalidate the node", () => {
+    const provider = createProvider(async () => workspaceSuccess([]));
+    const node = provider._createRepositoryNode(
+      { slug: "repo-a", slug_perm: "repo-a", name: "Repo A" },
+      "workspace-a"
+    );
+    const events = [];
+    const subscription = provider.onDidChangeTreeData(element => events.push(element));
+
+    provider.refreshNode(node);
+    assert.strictEqual(events[0], node);
+    assert.strictEqual(node._disposed, false);
+
+    provider.refresh();
+    assert.strictEqual(node._disposed, true);
+    subscription.dispose();
+  });
+
+  test("cancelled default-workspace loading does not fall back or request quota", async () => {
+    let apiCalls = 0;
+    let workspaceFetches = 0;
+    let fallback;
+    const provider = createProvider(async () => {
+      apiCalls += 1;
+      return apiSuccess({ usage: {} });
+    }, {
+      fetchWorkspaces: async () => {
+        workspaceFetches += 1;
+        return collectionResult([], { complete: true });
+      },
+      fetchWorkspaceRepositories: async (_context, _workspace, options) => {
+        assert.strictEqual(options.signal.aborted, false);
+        return collectionResult([], {
+          complete: false,
+          cancelled: true,
+          termination: "cancelled",
+          requestCount: 1,
+        });
+      },
+    });
+    provider.setDefaultWorkspaceFallbackHandler(workspace => { fallback = workspace; });
+
+    const children = await provider.getRepositories("workspace-a");
+
+    assert.strictEqual(children.length, 1);
+    assert.strictEqual(children[0].getTreeItem().label, "Repository loading cancelled");
+    assert.strictEqual(fallback, undefined);
+    assert.strictEqual(workspaceFetches, 0);
+    assert.strictEqual(apiCalls, 0);
+  });
+
+  test("cancelled partial repositories survive without a quota request", async () => {
+    let apiCalls = 0;
+    const provider = createProvider(async () => {
+      apiCalls += 1;
+      return apiSuccess({ usage: {} });
+    }, {
+      fetchWorkspaceRepositories: async () => collectionResult(
+        [{ slug: "repo-a", name: "Repo A" }],
+        { complete: false, cancelled: true, termination: "cancelled", requestCount: 2 }
+      ),
+    });
+
+    const children = await provider.getRepositories("workspace-a");
+
+    assert.strictEqual(children[1].name, "Repo A");
+    assert.strictEqual(children[2].getTreeItem().label, "Repositories are incomplete");
+    assert.strictEqual(apiCalls, 0);
+  });
+
+  test("refresh aborts an in-flight default-workspace collection", async () => {
+    const pending = deferred();
+    let capturedSignal;
+    let apiCalls = 0;
+    const provider = createProvider(async () => {
+      apiCalls += 1;
+      return apiSuccess({ usage: {} });
+    }, {
+      fetchWorkspaceRepositories: async (_context, _workspace, options) => {
+        capturedSignal = options.signal;
+        return pending.promise;
+      },
+    });
+    const resultPromise = provider.getRepositories("workspace-a");
+    await new Promise(resolve => setImmediate(resolve));
+
+    provider.refresh();
+    assert.strictEqual(capturedSignal.aborted, true);
+    pending.resolve(collectionResult([], {
+      complete: false,
+      cancelled: true,
+      termination: "cancelled",
+      requestCount: 1,
+    }));
+
+    assert.deepStrictEqual(await resultPromise, []);
+    assert.strictEqual(apiCalls, 0);
+  });
+
+  test("refresh aborts an in-flight default-workspace quota request", async () => {
+    const quota = deferred();
+    let quotaSignal;
+    const provider = createProvider(async (_endpoint, options) => {
+      quotaSignal = options.signal;
+      return quota.promise;
+    }, {
+      fetchWorkspaceRepositories: async () => collectionResult([
+        { slug: "repo-a", name: "Repo A" },
+      ]),
+    });
+    const resultPromise = provider.getRepositories("workspace-a");
+    while (!quotaSignal) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    provider.refresh();
+    assert.strictEqual(quotaSignal.aborted, true);
+    quota.resolve(apiFailure("cancelled"));
+
+    assert.deepStrictEqual(await resultPromise, []);
   });
 });

--- a/test/collectionIdentity.test.js
+++ b/test/collectionIdentity.test.js
@@ -1,0 +1,52 @@
+const assert = require("assert");
+const {
+  canonicalCollectionIdentity,
+  packageCollectionIdentity,
+  repositoryCollectionIdentity,
+  unwrapIdentityValue,
+} = require("../util/collectionIdentity");
+
+suite("Collection identity", () => {
+  test("uses exact scoped package identity without case folding", () => {
+    const upper = packageCollectionIdentity({
+      namespace: "Workspace",
+      repository: "Repository",
+      slug_perm: "Package",
+    });
+    const lower = packageCollectionIdentity({
+      namespace: "workspace",
+      repository: "repository",
+      slug_perm: "package",
+    });
+
+    assert.notStrictEqual(upper, lower);
+    assert.strictEqual(upper, JSON.stringify(["Workspace", "Repository", "Package"]));
+  });
+
+  test("unwraps bounded tree-node values through one shared path", () => {
+    assert.strictEqual(unwrapIdentityValue({ value: { value: "package-id" } }), "package-id");
+    assert.strictEqual(packageCollectionIdentity({
+      namespace: "workspace",
+      repository: "repository",
+      slug_perm: { value: { value: "package-id" } },
+    }), JSON.stringify(["workspace", "repository", "package-id"]));
+  });
+
+  test("rejects missing, padded, oversized, and over-nested identities", () => {
+    assert.throws(() => canonicalCollectionIdentity([""]));
+    assert.throws(() => canonicalCollectionIdentity([" padded"]));
+    assert.throws(() => canonicalCollectionIdentity(["x".repeat(513)]));
+    assert.throws(() => packageCollectionIdentity({
+      namespace: "workspace",
+      repository: "repository",
+      slug_perm: { value: { value: { value: { value: { value: "too-deep" } } } } },
+    }));
+  });
+
+  test("repository identities include their workspace scope", () => {
+    assert.notStrictEqual(
+      repositoryCollectionIdentity("workspace-a", { slug: "repo" }),
+      repositoryCollectionIdentity("workspace-b", { slug: "repo" })
+    );
+  });
+});

--- a/test/complianceReportProvider.test.js
+++ b/test/complianceReportProvider.test.js
@@ -107,7 +107,7 @@ suite("ComplianceReportProvider", () => {
     assert.match(html, /proxy &lt;prod&gt;/);
     assert.match(html, /Blocked by policy &lt;rule&gt;/);
     assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
-    assert.match(html, /Vulnerable Dependencies/);
+    assert.match(html, /Vulnerability Findings/);
     assert.match(html, /License Summary/);
     assert.match(html, /Policy Compliance/);
     assert.match(html, /Uncovered Dependencies/);
@@ -146,5 +146,52 @@ suite("ComplianceReportProvider", () => {
     } finally {
       vscode.window.createWebviewPanel = originalCreateWebviewPanel;
     }
+  });
+
+  test("renders unknown vulnerability totals without manufacturing zero CVEs", () => {
+    const reportData = buildComplianceReportData("fixture", [{
+      name: "unknown-package",
+      version: "1.0.0",
+      format: "npm",
+      isDirect: true,
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: { num_vulnerabilities: "0x10" },
+    }]);
+    assert.strictEqual(reportData.summary.vulnCount, 0);
+    assert.strictEqual(reportData.summary.vulnUnknownCount, 1);
+    assert.strictEqual(reportData.vulnerableDeps[0].cveCount, null);
+    assert.strictEqual(reportData.vulnerableDeps[0].vulnerabilityStatus, "Unknown");
+
+    const provider = new ComplianceReportProvider({});
+    const html = provider._getHtml(reportData);
+
+    assert.match(html, /CVE Count \/ Status/);
+    assert.match(html, />Unknown<\/td>/);
+    assert.match(html, /1 Unknown/);
+    assert.doesNotMatch(html, /unknown-package[\s\S]*?<td>0<\/td>/);
+  });
+
+  test("does not render an incomplete lookup set as clean or unreachable", () => {
+    const provider = new ComplianceReportProvider({});
+    const incompleteHtml = provider._getHtml({
+      projectName: "fixture",
+      summary: { lookupIncomplete: 2 },
+    });
+    assert.match(incompleteHtml, /Compliance status incomplete/);
+    assert.doesNotMatch(incompleteHtml, /No compliance issues detected/);
+
+    const upstreamHtml = provider._getHtml({
+      projectName: "fixture",
+      summary: { notFound: 1 },
+      uncoveredDeps: [{
+        name: "unknown-package",
+        version: "1.0.0",
+        ecosystem: "npm",
+        upstreamStatus: "unknown",
+        upstreamDetail: "Inspection incomplete",
+      }],
+    });
+    assert.match(upstreamHtml, /Reachability unknown/);
+    assert.doesNotMatch(upstreamHtml, /<h3>Not reachable<\/h3>/);
   });
 });

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -7,6 +7,7 @@ const {
   SCAN_STATES,
   buildComplianceReportData,
   getConcreteDependencyVersion,
+  getLookupPaginationDirective,
   lookupExactDependency,
   matchCoverageCandidates,
 } = require("../views/dependencyHealthProvider");
@@ -216,6 +217,7 @@ suite("DependencyHealthProvider Test Suite", () => {
           return response;
         }
         if (response && typeof response === "object" && Array.isArray(response.data)) {
+          addDefaultTestPackageIdentities(response.data);
           return apiSuccess(response.data, { headers: normalizeTestLookupHeaders(response.headers) });
         }
         return apiSuccess(response);
@@ -233,6 +235,7 @@ suite("DependencyHealthProvider Test Suite", () => {
   }
 
   function lookupPage(data, page = 1, pageTotal = 1, count = data.length, pageSize = 100) {
+    addDefaultTestPackageIdentities(data);
     return {
       data,
       headers: {
@@ -242,6 +245,20 @@ suite("DependencyHealthProvider Test Suite", () => {
         pageSize: String(pageSize),
       },
     };
+  }
+
+  function addDefaultTestPackageIdentities(data) {
+    for (const candidate of data) {
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+      if (candidate.namespace === undefined) candidate.namespace = "workspace";
+      if (candidate.repository === undefined) candidate.repository = "repo";
+      if (candidate.slug_perm === undefined) {
+        const groupId = candidate.identifiers && candidate.identifiers.group_id
+          ? `${candidate.identifiers.group_id}:`
+          : "";
+        candidate.slug_perm = `${candidate.format || "package"}:${groupId}${candidate.name}:${candidate.version}`;
+      }
+    }
   }
 
   async function runFixtureThroughLookupAndNode(ecosystem, fixtureName, dependencyName, candidate) {
@@ -275,7 +292,7 @@ suite("DependencyHealthProvider Test Suite", () => {
       cloudsmithPackage: lookup.package,
       cloudsmithLookupDetail: lookup.detail,
     }, {});
-    assert.strictEqual(node.state, "available");
+    assert.strictEqual(node.state, "violated");
     assert.strictEqual(node.version.value, candidate.version);
     return { adapterResult, dependency, lookup, node };
   }
@@ -1380,6 +1397,53 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(maxInFlight, 8);
   });
 
+  test("exact lookup workers settle delayed siblings before publishing a thrown request failure", async () => {
+    const gate = deferred();
+    const dependencies = Array.from(
+      { length: 5 },
+      (_value, index) => createDependency(`package-${index}`, "1.0.0")
+    );
+    let calls = 0;
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      createCloudsmithAPI: () => ({
+        async get() {
+          calls += 1;
+          if (calls === 1) throw new Error("unexpected transport throw");
+          await gate.promise;
+          return apiSuccess([], {
+            headers: normalizeTestLookupHeaders(lookupPage([], 1, 1, 0).headers),
+          });
+        },
+      }),
+    });
+    let flushed = null;
+    provider._flushCoverageMatchBatch = async (matches, completed) => {
+      flushed = matches;
+      return completed + matches.length;
+    };
+
+    let settled = false;
+    const pending = provider._resolveCoverageWithExactQueries(
+      "workspace",
+      "repo",
+      "npm",
+      dependencies,
+      0,
+      dependencies.length,
+      { report() {} },
+      { isCancellationRequested: false }
+    ).then(value => { settled = true; return value; });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(settled, false);
+    gate.resolve();
+    assert.strictEqual(await pending, dependencies.length);
+    assert.strictEqual(flushed.length, dependencies.length);
+    assert.strictEqual(
+      flushed.filter(entry => entry.result.status === CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED).length,
+      1
+    );
+  });
+
   test("scan-wide lookup budget counts pages across formats and marks remaining work incomplete", async () => {
     const npmDependency = createDependency("first-package", "1.0.0", "npm");
     const pythonDependency = createDependency("second-package", "2.0.0", "python");
@@ -1509,7 +1573,7 @@ suite("DependencyHealthProvider Test Suite", () => {
     });
     const partialApi = createLookupApi((_endpoint, callCount) => (
       callCount === 1
-        ? lookupPage([{ name: "other", version: "1.0.0" }], 1, 2, 2, 1)
+        ? lookupPage([{ name: "other", version: "1.0.0", format: "npm" }], 1, 2, 2, 1)
         : apiFailure("server_error", { status: 503 })
     ));
     const incomplete = await lookupExactDependency({
@@ -1561,6 +1625,162 @@ suite("DependencyHealthProvider Test Suite", () => {
     });
 
     assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
+  });
+
+  test("exact lookup rejects pagination anchor drift across otherwise valid pages", async () => {
+    for (const secondPageHeaders of [
+      { page: "2", pageTotal: "3", count: "3", pageSize: "1" },
+      { page: "2", pageTotal: "2", pageSize: "1" },
+      { page: "2", pageTotal: "1", count: "2", pageSize: "2" },
+    ]) {
+      const api = createLookupApi((endpoint) => {
+        const page = Number(new URL(endpoint, "https://api.cloudsmith.io/v1/").searchParams.get("page"));
+        return page === 1
+          ? lookupPage([{ name: "other-a", version: "1.0.0", format: "npm" }], 1, 2, 2, 1)
+          : {
+            data: [{ name: "other-b", version: "1.0.0", format: "npm" }],
+            headers: secondPageHeaders,
+          };
+      });
+      const result = await lookupExactDependency({
+        api,
+        cloudsmithWorkspace: "workspace",
+        cloudsmithRepo: "repo",
+        dependency: createDependency("left-pad", "1.0.0"),
+        token: { isCancellationRequested: false },
+      });
+      assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
+      assert.strictEqual(api.calls.length, 2);
+    }
+  });
+
+  test("exact lookup stops when a later page repeats an earlier package identity", async () => {
+    const repeated = {
+      name: "other",
+      version: "1.0.0",
+      format: "npm",
+      namespace: "workspace",
+      repository: "repo",
+      slug_perm: "repeated-package",
+    };
+    const api = createLookupApi((endpoint) => {
+      const page = Number(new URL(endpoint, "https://api.cloudsmith.io/v1/").searchParams.get("page"));
+      return lookupPage([{ ...repeated }], page, 2, 2, 1);
+    });
+
+    const result = await lookupExactDependency({
+      api,
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency("left-pad", "1.0.0"),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
+    assert.strictEqual(result.pagesFetched, 1);
+    assert.strictEqual(api.calls.length, 2);
+  });
+
+  test("page-total-only nonfinal pages must be full before lookup can continue", async () => {
+    for (const data of [
+      [],
+      [{ name: "other", version: "1.0.0", format: "npm" }],
+    ]) {
+      const api = createLookupApi(() => ({
+        data,
+        headers: { page: "1", pageTotal: "2", pageSize: "100" },
+      }));
+      const result = await lookupExactDependency({
+        api,
+        cloudsmithWorkspace: "workspace",
+        cloudsmithRepo: "repo",
+        dependency: createDependency("left-pad", "1.0.0"),
+        token: { isCancellationRequested: false },
+      });
+
+      assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
+      assert.strictEqual(api.calls.length, 1);
+    }
+  });
+
+  test("out-of-scope or identity-less matching packages cannot become found", async () => {
+    for (const candidate of [
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "other-workspace",
+        repository: "repo",
+        slug_perm: "left-pad",
+      },
+      {
+        name: "left-pad",
+        version: 100,
+        format: "npm",
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: "left-pad-numeric-version",
+      },
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "workspace",
+        repository: "other-repo",
+        slug_perm: "left-pad",
+      },
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: null,
+      },
+    ]) {
+      const result = await lookupExactDependency({
+        api: createLookupApi(() => lookupPage([candidate])),
+        cloudsmithWorkspace: "workspace",
+        cloudsmithRepo: "repo",
+        dependency: createDependency("left-pad", "1.0.0"),
+        token: { isCancellationRequested: false },
+      });
+      assert.notStrictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
+      assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED);
+    }
+  });
+
+  test("malformed package policy booleans cannot become exact lookup evidence", async () => {
+    const candidate = {
+      name: "left-pad",
+      version: "1.0.0",
+      format: "npm",
+      namespace: "workspace",
+      repository: "repo",
+      slug_perm: "left-pad",
+      policy_violated: "false",
+    };
+    const result = await lookupExactDependency({
+      api: createLookupApi(() => lookupPage([candidate])),
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency("left-pad", "1.0.0"),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED);
+    assert.strictEqual(result.package, null);
+  });
+
+  test("pagination metadata accepts only strict safe decimal integers", () => {
+    for (const malformed of ["1e0", "+1", " 1 ", "01", "0x1"]) {
+      assert.strictEqual(getLookupPaginationDirective({
+        page: malformed,
+        pageTotal: "1",
+        count: "0",
+        pageSize: "100",
+      }, 1, 0, 100), "incomplete");
+    }
   });
 
   test("contradictory page totals and counts cannot prove package absence", async () => {
@@ -1928,7 +2148,7 @@ suite("DependencyHealthProvider Test Suite", () => {
   test("pagination terminates at the safety limit and remains incomplete", async () => {
     const api = createLookupApi((endpoint) => {
       const page = Number(new URL(endpoint, "https://api.cloudsmith.io/v1/").searchParams.get("page"));
-      return lookupPage([{ name: "other", version: "1.0.0" }], page, 101, 101, 1);
+      return lookupPage([{ name: `other-${page}`, version: "1.0.0", format: "npm" }], page, 101, 101, 1);
     });
 
     const result = await lookupExactDependency({
@@ -2100,10 +2320,10 @@ suite("DependencyHealthProvider Test Suite", () => {
     const provider = new DependencyHealthProvider(createContext(), null, {
       enrichLicenses: async (_dependencies, options = {}) => {
         options.onProgress(new Map([
-          ["workspace:repo:left-pad/1.0.0", { spdx: "MIT" }],
+          [JSON.stringify(["workspace", "repo", "left-pad/1.0.0"]), { spdx: "MIT" }],
         ]));
         options.onProgress(new Map([
-          ["workspace:repo:left-pad/1.0.0", { spdx: "Apache-2.0" }],
+          [JSON.stringify(["workspace", "repo", "left-pad/1.0.0"]), { spdx: "Apache-2.0" }],
         ]));
       },
     });
@@ -2139,6 +2359,7 @@ suite("DependencyHealthProvider Test Suite", () => {
     const originalShowErrorMessage = vscode.window.showErrorMessage;
     const notifications = [];
     let refreshArgs = null;
+    let preparationToken = null;
 
     vscode.window.withProgress = async (_options, task) => task(
       { report() {} },
@@ -2158,7 +2379,8 @@ suite("DependencyHealthProvider Test Suite", () => {
     try {
       const provider = new DependencyHealthProvider(createContext(), null, {
         upstreamPullService: {
-          async prepareSingle({ dependency }) {
+          async prepareSingle({ dependency, cancellationToken }) {
+            preparationToken = cancellationToken;
             return {
               workspace: "workspace-a",
               repository: { slug: "repo-b" },
@@ -2166,7 +2388,8 @@ suite("DependencyHealthProvider Test Suite", () => {
               plan: { skippedDependencies: [] },
             };
           },
-          async execute() {
+          async execute(_prepared, options) {
+            assert.strictEqual(options.token, preparationToken);
             return {
               canceled: false,
               pullResult: {
@@ -2218,12 +2441,66 @@ suite("DependencyHealthProvider Test Suite", () => {
           ecosystem: "python",
         },
       });
+      assert.ok(preparationToken);
       assert.deepStrictEqual(notifications, ["requests@2.31.0 cached in repo-b"]);
     } finally {
       vscode.window.withProgress = originalWithProgress;
       vscode.window.showInformationMessage = originalShowInformationMessage;
       vscode.window.showErrorMessage = originalShowErrorMessage;
     }
+  });
+
+  test("coverage refresh waits for every enrichment sibling after one rejects", async () => {
+    const dependency = createDependency("left-pad", "1.0.0");
+    dependency.cloudsmithStatus = "ABSENT";
+    const provider = new DependencyHealthProvider(createContext());
+    provider._fullTrees = [{ ecosystem: "npm", sourceFile: "package.json", dependencies: [dependency] }];
+    provider._displayTrees = cloneTrees(provider._fullTrees);
+    provider._runCoverageResolution = async () => {
+      dependency.cloudsmithStatus = "FOUND";
+      dependency.cloudsmithPackage = {
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: "left-pad-1",
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+      };
+    };
+    const gate = deferred();
+    let siblingCompletions = 0;
+    provider._runVulnerabilityEnrichment = async () => {
+      throw new Error("vulnerability enrichment failed");
+    };
+    provider._runLicenseEnrichment = async () => {
+      await gate.promise;
+      siblingCompletions += 1;
+    };
+    provider._runPolicyEnrichment = async () => {
+      await gate.promise;
+      siblingCompletions += 1;
+    };
+    provider._publishDiagnostics = async () => {
+      assert.strictEqual(siblingCompletions, 2);
+    };
+    provider._rebuildSummary = () => {};
+    provider._storeReportData = async () => {};
+    provider.refresh = () => {};
+
+    let settled = false;
+    const pending = provider._refreshCoverageForDependencies(
+      "workspace",
+      "repo",
+      [dependency],
+      { report() {} },
+      { isCancellationRequested: false }
+    ).then(value => { settled = true; return value; });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(settled, false);
+    gate.resolve();
+    await pending;
+    assert.strictEqual(siblingCompletions, 2);
+    assert.ok(provider._warnings.some(warning => /vulnerability enrichment failed/.test(warning)));
   });
 
   test("pullSingleDependency reserves the operation before asynchronous preparation", async () => {

--- a/test/dependencyVulnEnricher.test.js
+++ b/test/dependencyVulnEnricher.test.js
@@ -3,6 +3,7 @@ const {
   clearVulnerabilityCache,
   enrichVulnerabilities: enrichVulnerabilitiesImpl,
   getVulnerabilityCacheSize,
+  MAX_VULNERABILITY_DETAIL_REQUESTS,
 } = require("../util/dependencyVulnEnricher");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
@@ -130,6 +131,185 @@ suite("dependencyVulnEnricher", () => {
     assert.strictEqual(getVulnerabilityCacheSize(), 0);
   });
 
+  test("preserves an authoritative indicator count when detail records are incomplete", async () => {
+    const enriched = await enrichVulnerabilities([createFoundDependency("pkg-partial", 5)], "workspace-a", {
+      cloudsmithAPI: {
+        async getV2() {
+          return apiSuccess({
+            results: [
+              { vulnerability_id: "CVE-1", severity: "High" },
+              { vulnerability_id: "CVE-2", severity: "Medium" },
+            ],
+          });
+        },
+      },
+    });
+
+    assert.strictEqual(enriched[0].vulnerabilities.count, 5);
+    assert.strictEqual(enriched[0].vulnerabilities.detailsLoaded, false);
+    assert.strictEqual(getVulnerabilityCacheSize(), 0);
+  });
+
+  test("keeps duplicate, conflicting, and excess detail records indicator-only", async () => {
+    for (const results of [
+      [
+        { vulnerability_id: "CVE-1", severity: "High" },
+        { vulnerability_id: "cve-1", severity: "Low" },
+      ],
+      [{ vulnerability_id: "CVE-1", identifier: "CVE-2", severity: "High" }],
+      [
+        { vulnerability_id: "CVE-1", severity: "High" },
+        { vulnerability_id: "CVE-2", severity: "Low" },
+      ],
+    ]) {
+      const count = results.length === 1 ? 1 : 1;
+      const enriched = await enrichVulnerabilities(
+        [createFoundDependency(`identity-${results.length}-${results[0].identifier || "duplicate"}`, count)],
+        "workspace-a",
+        { cloudsmithAPI: { async getV2() { return apiSuccess({ results }); } } }
+      );
+      assert.strictEqual(enriched[0].vulnerabilities.count, count);
+      assert.strictEqual(enriched[0].vulnerabilities.detailsLoaded, false);
+      assert.deepStrictEqual(enriched[0].vulnerabilities.entries, []);
+    }
+    assert.strictEqual(getVulnerabilityCacheSize(), 0);
+  });
+
+  test("does not let zero or conflicting indicator aliases silently select another count", async () => {
+    let calls = 0;
+    const dependency = createFoundDependency("alias-conflict", 0);
+    dependency.cloudsmithPackage.num_vulnerabilities = 3;
+    const [enriched] = await enrichVulnerabilities([dependency], "workspace-a", {
+      cloudsmithAPI: { async getV2() { calls += 1; return apiSuccess({ results: [] }); } },
+    });
+
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(enriched.vulnerabilities.count, 3);
+    assert.strictEqual(enriched.vulnerabilities.countAuthoritative, false);
+    assert.strictEqual(enriched.vulnerabilities.detailsLoaded, false);
+  });
+
+  test("positive presence and detected status remain visible when counts are zero or missing", async () => {
+    for (const indicator of [
+      { vulnerability_scan_results_count: 0, has_vulnerabilities: true },
+      { vulnerability_scan_results_count: undefined, security_scan_status: "scan detected vulnerabilities" },
+    ]) {
+      let calls = 0;
+      const dependency = createFoundDependency(`presence-${calls}`, 0);
+      Object.assign(dependency.cloudsmithPackage, indicator);
+      const [enriched] = await enrichVulnerabilities([dependency], "workspace-a", {
+        cloudsmithAPI: { async getV2() { calls += 1; return apiSuccess({ results: [] }); } },
+      });
+      assert.strictEqual(calls, 0);
+      assert.strictEqual(enriched.vulnerabilities.count, 0);
+      assert.strictEqual(enriched.vulnerabilities.countKnown, false);
+      assert.strictEqual(enriched.vulnerabilities.detected, true);
+      assert.strictEqual(enriched.vulnerabilities.detailsLoaded, false);
+    }
+  });
+
+  test("keeps malformed-only vulnerability evidence unknown without inventing a detection", async () => {
+    let calls = 0;
+    const dependency = createFoundDependency("malformed-only", 0);
+    dependency.cloudsmithPackage.vulnerability_scan_results_count = undefined;
+    dependency.cloudsmithPackage.num_vulnerabilities = "0x10";
+    const [enriched] = await enrichVulnerabilities([dependency], "workspace-a", {
+      cloudsmithAPI: { async getV2() { calls += 1; return apiSuccess({ results: [] }); } },
+    });
+
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(enriched.vulnerabilities.count, 0);
+    assert.strictEqual(enriched.vulnerabilities.countKnown, false);
+    assert.strictEqual(enriched.vulnerabilities.detected, false);
+    assert.strictEqual(enriched.vulnerabilities.unknown, true);
+    assert.strictEqual(Object.getPrototypeOf(enriched.vulnerabilities.severityCounts), null);
+    assert.strictEqual(Object.keys(enriched.vulnerabilities.severityCounts).length, 0);
+  });
+
+  test("contains throwing progress observers and waits for all bounded detail work", async () => {
+    let calls = 0;
+    const enriched = await enrichVulnerabilities(
+      Array.from({ length: 8 }, (_value, index) => createFoundDependency(`progress-${index}`)),
+      "workspace-a",
+      {
+        cloudsmithAPI: {
+          async getV2() {
+            calls += 1;
+            return apiSuccess({
+              results: [{ vulnerability_id: `CVE-${calls}`, severity: "High" }],
+            });
+          },
+        },
+        onProgress() { throw new Error("observer failure"); },
+      }
+    );
+
+    assert.strictEqual(calls, 8);
+    assert.strictEqual(enriched.every(item => item.vulnerabilities.detailsLoaded), true);
+  });
+
+  test("bounds vulnerability detail fan-out and leaves uninspected indicators incomplete", async () => {
+    const dependencies = Array.from(
+      { length: MAX_VULNERABILITY_DETAIL_REQUESTS + 100 },
+      (_value, index) => createFoundDependency(`bounded-${index}`)
+    );
+    let calls = 0;
+    const enriched = await enrichVulnerabilities(dependencies, "workspace-a", {
+      cloudsmithAPI: {
+        async getV2() {
+          calls += 1;
+          return apiSuccess({
+            results: [{ vulnerability_id: `CVE-${calls}`, severity: "High" }],
+          });
+        },
+      },
+    });
+
+    assert.strictEqual(calls, MAX_VULNERABILITY_DETAIL_REQUESTS);
+    assert.strictEqual(
+      enriched.filter(dependency => dependency.vulnerabilities.detailsLoaded).length,
+      MAX_VULNERABILITY_DETAIL_REQUESTS
+    );
+    assert.strictEqual(
+      enriched.filter(dependency => !dependency.vulnerabilities.detailsLoaded).length,
+      100
+    );
+  });
+
+  test("limits vulnerability detail concurrency to four fixed workers", async () => {
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    let releaseFirstWave;
+    const firstWave = new Promise(resolve => { releaseFirstWave = resolve; });
+    const pending = enrichVulnerabilities(
+      Array.from({ length: 100 }, (_value, index) => createFoundDependency(`concurrent-${index}`)),
+      "workspace-a",
+      {
+        cloudsmithAPI: {
+          async getV2() {
+            calls += 1;
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            if (calls <= 4) await firstWave;
+            active -= 1;
+            return apiSuccess({
+              results: [{ vulnerability_id: `CVE-${calls}`, severity: "High" }],
+            });
+          },
+        },
+      }
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(calls, 4);
+    releaseFirstWave();
+    await pending;
+
+    assert.strictEqual(maxActive, 4);
+    assert.strictEqual(active, 0);
+    assert.strictEqual(calls, 100);
+  });
+
   test("deletes expired cache entries on read when the refresh does not replace them", async () => {
     const originalNow = Date.now;
     let now = 1_000;
@@ -180,19 +360,24 @@ suite("dependencyVulnEnricher", () => {
     try {
       Date.now = () => now;
 
-      const dependencies = Array.from({ length: 5000 }, (_, index) => createFoundDependency(`pkg-${index}`));
-      await enrichVulnerabilities(dependencies, "workspace-a", {
-        cloudsmithAPI: {
-          async getV2() {
-            return apiSuccess({
-              results: [{
-                vulnerability_id: "CVE-2024-1234",
-                severity: "High",
-              }],
-            });
+      for (let batch = 0; batch < 5; batch += 1) {
+        const dependencies = Array.from(
+          { length: MAX_VULNERABILITY_DETAIL_REQUESTS },
+          (_, index) => createFoundDependency(`pkg-${batch}-${index}`)
+        );
+        await enrichVulnerabilities(dependencies, "workspace-a", {
+          cloudsmithAPI: {
+            async getV2() {
+              return apiSuccess({
+                results: [{
+                  vulnerability_id: "CVE-2024-1234",
+                  severity: "High",
+                }],
+              });
+            },
           },
-        },
-      });
+        });
+      }
 
       assert.strictEqual(getVulnerabilityCacheSize(), 5000);
 

--- a/test/foundDependencyKey.test.js
+++ b/test/foundDependencyKey.test.js
@@ -2,19 +2,19 @@ const assert = require("assert");
 const { getFoundDependencyKey } = require("../util/foundDependencyKey");
 
 suite("foundDependencyKey", () => {
-  test("builds a lowercase trimmed key for valid found dependencies", () => {
+  test("uses the exact shared scoped package identity", () => {
     const key = getFoundDependencyKey({
       cloudsmithPackage: {
-        namespace: " Workspace-A ",
-        repository: " Production-NPM ",
+        namespace: "Workspace-A",
+        repository: "Production-NPM",
         slug_perm: "Pkg-1",
       },
     });
 
-    assert.strictEqual(key, "workspace-a:production-npm:pkg-1");
+    assert.strictEqual(key, JSON.stringify(["Workspace-A", "Production-NPM", "Pkg-1"]));
   });
 
-  test("uses slug fallbacks in priority order", () => {
+  test("requires slug_perm and rejects legacy identity fallbacks", () => {
     assert.strictEqual(getFoundDependencyKey({
       cloudsmithPackage: {
         namespace: "workspace-a",
@@ -24,7 +24,7 @@ suite("foundDependencyKey", () => {
         slug: "slug-value",
         identifier: "identifier-value",
       },
-    }), "workspace-a:repo-a:slug-perm");
+    }), JSON.stringify(["workspace-a", "repo-a", "slug-perm"]));
 
     assert.strictEqual(getFoundDependencyKey({
       cloudsmithPackage: {
@@ -34,7 +34,7 @@ suite("foundDependencyKey", () => {
         slug: "slug-value",
         identifier: "identifier-value",
       },
-    }), "workspace-a:repo-a:slug-perm-camel");
+    }), null);
 
     assert.strictEqual(getFoundDependencyKey({
       cloudsmithPackage: {
@@ -43,7 +43,7 @@ suite("foundDependencyKey", () => {
         slug: "slug-value",
         identifier: "identifier-value",
       },
-    }), "workspace-a:repo-a:slug-value");
+    }), null);
 
     assert.strictEqual(getFoundDependencyKey({
       cloudsmithPackage: {
@@ -51,7 +51,7 @@ suite("foundDependencyKey", () => {
         repository: "repo-a",
         identifier: "identifier-value",
       },
-    }), "workspace-a:repo-a:identifier-value");
+    }), null);
   });
 
   test("returns null for null or undefined dependency inputs", () => {
@@ -90,15 +90,22 @@ suite("foundDependencyKey", () => {
     }), null);
   });
 
-  test("keeps the key format workspace repo slug with lowercase trimmed values", () => {
-    const key = getFoundDependencyKey({
+  test("does not merge case-distinct permanent package identities", () => {
+    const upper = getFoundDependencyKey({
       cloudsmithPackage: {
-        namespace: " Workspace-A ",
-        repository: " Repo-A ",
-        slugPerm: " slug-value ",
+        namespace: "Workspace-A",
+        repository: "Repo-A",
+        slug_perm: "Package-A",
+      },
+    });
+    const lower = getFoundDependencyKey({
+      cloudsmithPackage: {
+        namespace: "workspace-a",
+        repository: "repo-a",
+        slug_perm: "package-a",
       },
     });
 
-    assert.strictEqual(key, "workspace-a:repo-a:slug-value");
+    assert.notStrictEqual(upper, lower);
   });
 });

--- a/test/packageMetadataFlow.test.js
+++ b/test/packageMetadataFlow.test.js
@@ -329,6 +329,26 @@ suite("Package Metadata Flow Test Suite", () => {
     assert.strictEqual(quarantinedNode.getTreeItem().description, "4.18.2 — Quarantined");
   });
 
+  test("dependency vulnerability indicators never turn conflicting positive evidence into clean state", () => {
+    const cloudsmithPackage = {
+      ...pkg,
+      vulnerability_scan_results_count: 0,
+      has_vulnerabilities: true,
+      max_severity: undefined,
+    };
+    const node = new DependencyHealthNode({
+      name: "artifact",
+      version: "4.18.2",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage,
+    }, cloudsmithPackage, {});
+
+    assert.match(node.getTreeItem().description, /Vulnerabilities detected/);
+    assert.doesNotMatch(node.getTreeItem().description, /undefined/);
+    assert.strictEqual(node.num_vulnerabilities, -1);
+  });
+
   test("dependency health tooltips show no-license text only in the tooltip", () => {
     const node = new DependencyHealthNode({
       name: "artifact",

--- a/test/packageVulnerabilities.test.js
+++ b/test/packageVulnerabilities.test.js
@@ -1,0 +1,270 @@
+const assert = require("assert");
+const {
+  fetchPackageVulnerabilities,
+  getPackageVulnerabilityCount,
+} = require("../util/packageVulnerabilities");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+suite("Package vulnerability scan collection", () => {
+  function page(data, pageNumber, pageTotal, count) {
+    return apiSuccess(data, {
+      headers: {
+        "x-pagination-page": String(pageNumber),
+        "x-pagination-pagetotal": String(pageTotal),
+        "x-pagination-pagesize": "100",
+        "x-pagination-count": String(count),
+      },
+    });
+  }
+
+  function scan(index, createdAt) {
+    return {
+      identifier: `scan-${index}`,
+      created_at: createdAt,
+      has_vulnerabilities: true,
+      num_vulnerabilities: 1,
+      max_severity: "High",
+    };
+  }
+
+  test("selects the latest scan only after later pages prove collection completeness", async () => {
+    const firstPage = Array.from(
+      { length: 100 },
+      (_, index) => scan(index, "2026-01-01T00:00:00Z")
+    );
+    const calls = [];
+    const api = {
+      async get(endpoint) {
+        calls.push(endpoint);
+        if (endpoint.includes("?page=1")) return page(firstPage, 1, 2, 101);
+        if (endpoint.includes("?page=2")) {
+          return page([scan(100, "2026-02-01T00:00:00Z")], 2, 2, 101);
+        }
+        assert.ok(endpoint.endsWith("scan-100/"));
+        return apiSuccess({
+          scan: { results: [{ vulnerability_id: "CVE-2026-1000", severity: "High" }] },
+        });
+      },
+    };
+
+    const result = await fetchPackageVulnerabilities(
+      api,
+      "workspace-a",
+      "repo-a",
+      "package-a",
+      1
+    );
+
+    assert.strictEqual(result.complete, true);
+    assert.deepStrictEqual(result.results.map(item => item.vulnerability_id), ["CVE-2026-1000"]);
+    assert.strictEqual(calls.length, 3);
+  });
+
+  test("does not publish an older scan as current when a later page fails", async () => {
+    const firstPage = Array.from(
+      { length: 100 },
+      (_, index) => scan(index, "2026-01-01T00:00:00Z")
+    );
+    const api = {
+      async get(endpoint) {
+        if (endpoint.includes("?page=1")) return page(firstPage, 1, 2, 101);
+        if (endpoint.includes("?page=2")) {
+          return apiFailure("rate_limited", { status: 429, retryable: true });
+        }
+        throw new Error("scan detail must not be requested from partial history");
+      },
+    };
+
+    const result = await fetchPackageVulnerabilities(
+      api,
+      "workspace-a",
+      "repo-a",
+      "package-a",
+      1
+    );
+
+    assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.results, []);
+    assert.strictEqual(result.error.kind, "rate_limited");
+  });
+
+  test("rejects oversized identifiers and ambiguous complete scan histories", async () => {
+    const oversized = await fetchPackageVulnerabilities({
+      async get(_endpoint, options) {
+        const data = [{ identifier: "x".repeat(513), has_vulnerabilities: true }];
+        assert.strictEqual(options.validate(data), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "repo-a", "package-a", 1);
+    assert.strictEqual(oversized.error.kind, "invalid_response");
+
+    const ambiguous = await fetchPackageVulnerabilities({
+      async get(endpoint) {
+        if (endpoint.includes("?page=1")) {
+          return page([
+            { identifier: "scan-a", has_vulnerabilities: true },
+            { identifier: "scan-b", has_vulnerabilities: true },
+          ], 1, 1, 2);
+        }
+        throw new Error("an ambiguous scan history must not select a detail endpoint");
+      },
+    }, "workspace-a", "repo-a", "package-a", 1);
+    assert.strictEqual(ambiguous.complete, false);
+    assert.strictEqual(ambiguous.error.kind, "invalid_response");
+  });
+
+  test("keeps bounded successful details partial when they contradict the scan count", async () => {
+    const api = {
+      async get(endpoint) {
+        if (endpoint.includes("?page=1")) {
+          return page([{
+            identifier: "scan-a",
+            created_at: "2026-02-01T00:00:00Z",
+            has_vulnerabilities: true,
+            num_vulnerabilities: 2,
+            max_severity: "High",
+          }], 1, 1, 1);
+        }
+        return apiSuccess({
+          results: [{ vulnerability_id: "CVE-1", severity: "High" }],
+        });
+      },
+    };
+
+    const result = await fetchPackageVulnerabilities(
+      api,
+      "workspace-a",
+      "repo-a",
+      "package-a",
+      2
+    );
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.numVulns, -1);
+    assert.deepStrictEqual(result.results.map(item => item.vulnerability_id), ["CVE-1"]);
+    assert.strictEqual(result.error.kind, "invalid_response");
+  });
+
+  test("rejects vulnerability detail arrays beyond the structural item cap", async () => {
+    const api = {
+      async get(endpoint) {
+        if (endpoint.includes("?page=1")) {
+          return page([{
+            identifier: "scan-a",
+            created_at: "2026-02-01T00:00:00Z",
+            has_vulnerabilities: true,
+          }], 1, 1, 1);
+        }
+        return apiSuccess({
+          results: Array.from(
+            { length: 5001 },
+            (_value, index) => ({ vulnerability_id: `CVE-${index}`, severity: "Low" })
+          ),
+        });
+      },
+    };
+
+    const result = await fetchPackageVulnerabilities(
+      api,
+      "workspace-a",
+      "repo-a",
+      "package-a",
+      1
+    );
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, false);
+    assert.deepStrictEqual(result.results, []);
+    assert.strictEqual(result.error.kind, "invalid_response");
+  });
+
+  test("rejects nested vulnerability arrays whose aggregate exceeds the item cap", async () => {
+    const nested = {
+      scans: [0, 2501].map((offset) => ({
+        results: Array.from(
+          { length: 2501 },
+          (_value, index) => ({ vulnerability_id: `CVE-${offset + index}`, severity: "Low" })
+        ),
+      })),
+    };
+    const result = await fetchPackageVulnerabilities({
+      async get(endpoint, options) {
+        if (endpoint.includes("?page=1")) {
+          return page([{
+            identifier: "scan-a",
+            created_at: "2026-02-01T00:00:00Z",
+            has_vulnerabilities: true,
+          }], 1, 1, 1);
+        }
+        assert.strictEqual(options.validate(nested), false);
+        return apiSuccess(nested);
+      },
+    }, "workspace-a", "repo-a", "package-a", 1);
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, false);
+    assert.deepStrictEqual(result.results, []);
+    assert.strictEqual(result.error.kind, "invalid_response");
+  });
+
+  test("rejects duplicate and conflicting vulnerability identities", async () => {
+    for (const results of [
+      [
+        { vulnerability_id: "CVE-1", severity: "High" },
+        { vulnerability_id: "cve-1", severity: "Low" },
+      ],
+      [{ vulnerability_id: "CVE-1", identifier: "CVE-2", severity: "High" }],
+    ]) {
+      const result = await fetchPackageVulnerabilities({
+        async get(endpoint) {
+          if (endpoint.includes("?page=1")) {
+            return page([{
+              identifier: "scan-a",
+              created_at: "2026-02-01T00:00:00Z",
+              has_vulnerabilities: true,
+              num_vulnerabilities: results.length,
+            }], 1, 1, 1);
+          }
+          return apiSuccess({ results });
+        },
+      }, "workspace-a", "repo-a", "package-a", results.length);
+
+      assert.strictEqual(result.complete, false);
+      assert.strictEqual(result.partial, false);
+      assert.deepStrictEqual(result.results, []);
+      assert.strictEqual(result.numVulns, -1);
+      assert.strictEqual(result.error.kind, "invalid_response");
+    }
+  });
+
+  test("strictly reconciles count, presence, and detected-status indicators", () => {
+    for (const malformed of ["0x10", "1e3", " 1 "]) {
+      assert.strictEqual(getPackageVulnerabilityCount({ num_vulnerabilities: malformed }), null);
+    }
+    assert.strictEqual(getPackageVulnerabilityCount({
+      num_vulnerabilities: 0,
+      has_vulnerabilities: true,
+    }), -1);
+    assert.strictEqual(getPackageVulnerabilityCount({
+      num_vulnerabilities: 0,
+      security_scan_status: "scan detected vulnerabilities",
+    }), -1);
+    assert.strictEqual(getPackageVulnerabilityCount({
+      num_vulnerabilities: "2",
+      has_vulnerabilities: true,
+    }), 2);
+    assert.strictEqual(getPackageVulnerabilityCount({
+      num_vulnerabilities: undefined,
+      vulnerability_scan_results_count: null,
+      vulnerabilityCount: "",
+      has_vulnerabilities: false,
+    }), 0);
+    assert.strictEqual(getPackageVulnerabilityCount({
+      security_scan_status: "Scan Detected No Vulnerabilities",
+    }), 0);
+    assert.strictEqual(getPackageVulnerabilityCount({
+      security_scan_status: "Scan Pending",
+    }), null);
+  });
+});

--- a/test/paginatedFetch.test.js
+++ b/test/paginatedFetch.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { PaginatedFetch } = require("../util/paginatedFetch");
+const { PaginatedFetch, replaceCollectionItems } = require("../util/paginatedFetch");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("PaginatedFetch typed API boundary", () => {
@@ -31,7 +31,13 @@ suite("PaginatedFetch typed API boundary", () => {
     );
 
     assert.strictEqual(result.error, null);
-    assert.deepStrictEqual(result.pagination, { page: 2, pageTotal: 2, count: 3, pageSize: 2 });
+    assert.deepStrictEqual(result.pagination, {
+      page: 2,
+      pageTotal: 2,
+      count: 3,
+      countAuthoritative: true,
+      pageSize: 2,
+    });
     assert.strictEqual(requestOptions.cancellationToken, token);
     assert.strictEqual(requestOptions.retry, "never");
     assert.strictEqual(requestOptions.apiKey, apiKey);
@@ -115,4 +121,408 @@ suite("PaginatedFetch typed API boundary", () => {
     assert.strictEqual(capturedValidator([{}]), false);
     assert.strictEqual(capturedValidator([{ slug: "repo" }]), true);
   });
+
+  test("keeps a missing count non-authoritative when page totals prove exhaustion", async () => {
+    const paginated = new PaginatedFetch({
+      async get() {
+        return apiSuccess([{ name: "artifact" }], {
+          headers: {
+            "x-pagination-page": "1",
+            "x-pagination-pagetotal": "1",
+            "x-pagination-pagesize": "100",
+          },
+        });
+      },
+    });
+
+    const result = await paginated.fetchPage("packages/workspace/", 1, 100);
+
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.pagination.count, null);
+    assert.strictEqual(result.pagination.countAuthoritative, false);
+  });
+
+  test("validates object envelopes before extracting collection items", async () => {
+    const paginated = new PaginatedFetch({
+      async get() {
+        return apiSuccess({ results: [{ name: "artifact" }] }, {
+          headers: {
+            "x-pagination-page": "1",
+            "x-pagination-pagetotal": "1",
+            "x-pagination-count": "1",
+            "x-pagination-pagesize": "100",
+          },
+        });
+      },
+    });
+
+    const result = await paginated.fetchPage("groups/", 1, 100, null, {
+      responseType: "object",
+      validateResponse: value => Boolean(value && Array.isArray(value.results)),
+      extractItems: value => value.results,
+    });
+
+    assert.strictEqual(result.error, null);
+    assert.deepStrictEqual(result.data, [{ name: "artifact" }]);
+  });
+
+  test("rejects count-backed cardinality gaps and short non-final pages", async () => {
+    const responses = [
+      apiSuccess([{ id: "a" }], {
+        headers: paginationHeaders(1, 2, 3, 2),
+      }),
+      apiSuccess([{ id: "a" }], {
+        headers: {
+          "x-pagination-page": "1",
+          "x-pagination-pagetotal": "2",
+          "x-pagination-pagesize": "2",
+        },
+      }),
+    ];
+    const paginated = new PaginatedFetch({ async get() { return responses.shift(); } });
+
+    assert.strictEqual((await paginated.fetchPage("packages/", 1, 2)).error.kind, "invalid_response");
+    assert.strictEqual((await paginated.fetchPage("packages/", 1, 2)).error.kind, "invalid_response");
+  });
 });
+
+suite("PaginatedFetch bounded collection contract", () => {
+  test("collects multiple pages and proves an authoritative empty collection", async () => {
+    const calls = [];
+    const paginated = createCollectionFetcher({
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 3, 2),
+      2: page([{ id: "c" }], 2, 2, 3, 2),
+    }, calls);
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.deepStrictEqual(result.items.map(item => item.id), ["a", "b", "c"]);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.partial, false);
+    assert.strictEqual(result.termination, "exhausted");
+    assert.strictEqual(result.pageCount, 2);
+    assert.strictEqual(result.requestCount, 2);
+    assert.deepStrictEqual(calls, [1, 2]);
+
+    const empty = createCollectionFetcher({ 1: page([], 1, 1, 0, 2) });
+    const emptyResult = await empty.fetchCollection("records/", collectionOptions());
+    assert.strictEqual(emptyResult.complete, true);
+    assert.deepStrictEqual(emptyResult.items, []);
+  });
+
+  test("preserves successful pages when a later request fails", async () => {
+    const rateLimit = apiFailure("rate_limited", { status: 429 });
+    const paginated = createCollectionFetcher({
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 4, 2),
+      2: rateLimit,
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.deepStrictEqual(result.items.map(item => item.id), ["a", "b"]);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.termination, "request_failed");
+    assert.strictEqual(result.failureCount, 1);
+    assert.strictEqual(result.failures[0].error.kind, "rate_limited");
+    assert.strictEqual(result.pageCount, 1);
+    assert.strictEqual(result.requestCount, 2);
+    assert.strictEqual(result.continuation.nextPage, 2);
+  });
+
+  test("distinguishes a failed first page from an authoritative empty collection", async () => {
+    const paginated = createCollectionFetcher({
+      1: apiFailure("network_error", { retryable: true }),
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.deepStrictEqual(result.items, []);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, false);
+    assert.strictEqual(result.termination, "request_failed");
+    assert.strictEqual(result.failureCount, 1);
+  });
+
+  test("malformed pagination is terminal and cannot be resumed into another request", async () => {
+    const calls = [];
+    const paginated = createCollectionFetcher({
+      1: apiSuccess([{ id: "a" }], { headers: {} }),
+      2: page([{ id: "b" }], 2, 2, 2, 1),
+    }, calls);
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "request_failed");
+    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+    assert.strictEqual(result.continuation, null);
+    assert.deepStrictEqual(calls, [1]);
+  });
+
+  test("does not retain a message from an unexpected thrown request", async () => {
+    const paginated = new PaginatedFetch({
+      async get() {
+        throw new Error("secret-bearing transport detail");
+      },
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "request_failed");
+    assert.strictEqual(result.failures[0].error.message, "The collection request failed unexpectedly.");
+    assert(!JSON.stringify(result).includes("secret-bearing transport detail"));
+  });
+
+  test("accepts a page-total-proven empty final page without inventing a count", async () => {
+    const paginated = createCollectionFetcher({
+      1: apiSuccess([{ id: "a" }, { id: "b" }], {
+        headers: pageTotalHeaders(1, 2, 2),
+      }),
+      2: apiSuccess([], {
+        headers: pageTotalHeaders(2, 2, 2),
+      }),
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.strictEqual(result.complete, true);
+    assert.deepStrictEqual(result.items.map(item => item.id), ["a", "b"]);
+    assert.strictEqual(result.pagination.count, null);
+    assert.strictEqual(result.pagination.countAuthoritative, false);
+  });
+
+  test("fails closed on metadata drift, duplicate identity, and no progress", async () => {
+    const drift = createCollectionFetcher({
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 4, 2),
+      2: page([{ id: "c" }, { id: "d" }], 2, 3, 6, 2),
+    });
+    const driftResult = await drift.fetchCollection("records/", collectionOptions());
+    assert.strictEqual(driftResult.complete, false);
+    assert.strictEqual(driftResult.termination, "invalid_pagination");
+    assert.deepStrictEqual(driftResult.items.map(item => item.id), ["a", "b"]);
+    assert.strictEqual(driftResult.continuation, null);
+
+    const duplicate = createCollectionFetcher({
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 4, 2),
+      2: page([{ id: "b" }, { id: "c" }], 2, 2, 4, 2),
+    });
+    const duplicateResult = await duplicate.fetchCollection("records/", collectionOptions());
+    assert.strictEqual(duplicateResult.complete, false);
+    assert.strictEqual(duplicateResult.termination, "duplicate_or_invalid_identity");
+    assert.strictEqual(duplicateResult.duplicateCount, 1);
+    assert.deepStrictEqual(duplicateResult.items.map(item => item.id), ["a", "b"]);
+    assert.strictEqual(duplicateResult.continuation, null);
+  });
+
+  test("enforces page, request, and item limits without resumable cap bypass", async () => {
+    const responses = {
+      1: page([{ id: "a" }, { id: "b" }], 1, 3, 6, 2),
+      2: page([{ id: "c" }, { id: "d" }], 2, 3, 6, 2),
+      3: page([{ id: "e" }, { id: "f" }], 3, 3, 6, 2),
+    };
+    const pageLimited = await createCollectionFetcher(responses)
+      .fetchCollection("records/", collectionOptions({ maxPages: 2, maxRequests: 3 }));
+    assert.strictEqual(pageLimited.termination, "page_limit");
+    assert.strictEqual(pageLimited.pageCount, 2);
+    assert.strictEqual(pageLimited.requestCount, 2);
+    assert.strictEqual(pageLimited.continuation, null);
+
+    const requestLimited = await createCollectionFetcher(responses)
+      .fetchCollection("records/", collectionOptions({ maxPages: 3, maxRequests: 1 }));
+    assert.strictEqual(requestLimited.termination, "request_limit");
+    assert.strictEqual(requestLimited.requestCount, 1);
+    assert.strictEqual(requestLimited.continuation, null);
+
+    const itemLimited = await createCollectionFetcher(responses)
+      .fetchCollection("records/", collectionOptions({ maxItems: 3 }));
+    assert.strictEqual(itemLimited.termination, "item_limit");
+    assert.deepStrictEqual(itemLimited.items.map(item => item.id), ["a", "b"]);
+    assert.strictEqual(itemLimited.continuation, null);
+  });
+
+  test("resumes one-page batches only with the same bound descriptor and cumulative identities", async () => {
+    const responses = {
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 3, 2),
+      2: page([{ id: "c" }], 2, 2, 3, 2),
+    };
+    const paginated = createCollectionFetcher(responses);
+    const first = await paginated.fetchCollection("records/", collectionOptions({
+      pageBatchLimit: 1,
+      descriptor: "account:workspace:records",
+    }));
+    assert.strictEqual(first.termination, "page_batch");
+    assert.strictEqual(first.continuation.nextPage, 2);
+
+    const second = await paginated.fetchCollection("records/", collectionOptions({
+      pageBatchLimit: 1,
+      descriptor: "account:workspace:records",
+      resume: first.continuation,
+      knownIdentities: new Set([JSON.stringify(["a"]), JSON.stringify(["b"])]),
+    }));
+    assert.strictEqual(second.complete, true);
+    assert.deepStrictEqual(second.items.map(item => item.id), ["c"]);
+    assert.strictEqual(second.pageCount, 2);
+    assert.strictEqual(second.requestCount, 2);
+
+    const invalid = await paginated.fetchCollection("records/", collectionOptions({
+      descriptor: "different-scope",
+      resume: first.continuation,
+      knownIdentities: new Set([JSON.stringify(["a"]), JSON.stringify(["b"])]),
+    }));
+    assert.strictEqual(invalid.termination, "invalid_continuation");
+    assert.strictEqual(invalid.requestCount, 0);
+
+    const tampered = await paginated.fetchCollection("records/", collectionOptions({
+      descriptor: "account:workspace:records",
+      resume: {
+        ...first.continuation,
+        cumulative: {
+          ...first.continuation.cumulative,
+          pageCount: 0,
+        },
+      },
+      knownIdentities: new Set([JSON.stringify(["a"]), JSON.stringify(["b"])]),
+    }));
+    assert.strictEqual(tampered.termination, "invalid_continuation");
+    assert.strictEqual(tampered.requestCount, 0);
+
+    const skippedPageCounters = await paginated.fetchCollection("records/", collectionOptions({
+      descriptor: "account:workspace:records",
+      resume: {
+        ...first.continuation,
+        nextPage: 6,
+        anchor: {
+          ...first.continuation.anchor,
+          page: 5,
+          pageTotal: 6,
+        },
+        cumulative: {
+          ...first.continuation.cumulative,
+          pageCount: 1,
+          requestCount: 1,
+        },
+      },
+      knownIdentities: new Set([JSON.stringify(["a"]), JSON.stringify(["b"])]),
+    }));
+    assert.strictEqual(skippedPageCounters.termination, "invalid_continuation");
+    assert.strictEqual(skippedPageCounters.requestCount, 0);
+
+    const skippedItems = await paginated.fetchCollection("records/", collectionOptions({
+      descriptor: "account:workspace:records",
+      resume: {
+        ...first.continuation,
+        cumulative: {
+          ...first.continuation.cumulative,
+          itemCount: 1,
+        },
+      },
+      knownIdentities: new Set([JSON.stringify(["a"])]),
+    }));
+    assert.strictEqual(skippedItems.termination, "invalid_continuation");
+    assert.strictEqual(skippedItems.requestCount, 0);
+  });
+
+  test("cancellation consumes dispatched requests and stops before the next page", async () => {
+    const token = { isCancellationRequested: false };
+    const calls = [];
+    const paginated = new PaginatedFetch({
+      async get(endpoint) {
+        const requestedPage = Number(new URL(`https://example.test/${endpoint}`).searchParams.get("page"));
+        calls.push(requestedPage);
+        token.isCancellationRequested = true;
+        return page([{ id: "a" }, { id: "b" }], 1, 2, 4, 2);
+      },
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions({
+      cancellationToken: token,
+    }));
+
+    assert.strictEqual(result.cancelled, true);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.pageCount, 0);
+    assert.strictEqual(result.requestCount, 1);
+    assert.deepStrictEqual(result.items, []);
+    assert.deepStrictEqual(calls, [1]);
+  });
+
+  test("rejects malformed identities without publishing the malformed page", async () => {
+    const paginated = createCollectionFetcher({
+      1: page([{ id: "a" }, {}], 1, 1, 2, 2),
+    });
+
+    const result = await paginated.fetchCollection("records/", collectionOptions());
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "duplicate_or_invalid_identity");
+    assert.deepStrictEqual(result.items, []);
+    assert.strictEqual(result.failureCount, 1);
+  });
+
+  test("filtered incomplete results with no retained matches are incomplete, not partial", async () => {
+    const source = await createCollectionFetcher({
+      1: page([{ id: "a" }, { id: "b" }], 1, 2, 4, 2),
+      2: apiFailure("rate_limited", { status: 429 }),
+    }).fetchCollection("records/", collectionOptions());
+
+    const filtered = replaceCollectionItems(source, []);
+
+    assert.strictEqual(filtered.complete, false);
+    assert.strictEqual(filtered.incomplete, true);
+    assert.strictEqual(filtered.partial, false);
+    assert.deepStrictEqual(filtered.items, []);
+    assert.strictEqual(filtered.failureCount, 1);
+  });
+});
+
+function paginationHeaders(pageNumber, pageTotal, count, pageSize) {
+  return {
+    "x-pagination-page": String(pageNumber),
+    "x-pagination-pagetotal": String(pageTotal),
+    "x-pagination-count": String(count),
+    "x-pagination-pagesize": String(pageSize),
+  };
+}
+
+function pageTotalHeaders(pageNumber, pageTotal, pageSize) {
+  return {
+    "x-pagination-page": String(pageNumber),
+    "x-pagination-pagetotal": String(pageTotal),
+    "x-pagination-pagesize": String(pageSize),
+  };
+}
+
+function page(items, pageNumber, pageTotal, count, pageSize) {
+  return apiSuccess(items, {
+    headers: paginationHeaders(pageNumber, pageTotal, count, pageSize),
+  });
+}
+
+function createCollectionFetcher(responses, calls = []) {
+  return new PaginatedFetch({
+    async get(endpoint) {
+      const requestedPage = Number(new URL(`https://example.test/${endpoint}`).searchParams.get("page"));
+      calls.push(requestedPage);
+      const response = responses[requestedPage];
+      return typeof response === "function" ? response() : response;
+    },
+  });
+}
+
+function collectionOptions(overrides = {}) {
+  return {
+    pageSize: 2,
+    maxPages: 3,
+    maxRequests: 3,
+    maxItems: 6,
+    canonicalIdentity: item => {
+      if (!item || typeof item.id !== "string" || item.id.length === 0) {
+        throw new TypeError("invalid identity");
+      }
+      return JSON.stringify([item.id]);
+    },
+    ...overrides,
+  };
+}

--- a/test/policyDecisionLogs.test.js
+++ b/test/policyDecisionLogs.test.js
@@ -1,0 +1,151 @@
+const assert = require("assert");
+const {
+  MAX_POLICY_STATUS_REASON_LENGTH,
+  fetchPackageDecisionLogs,
+  normalizePolicyStatusReason,
+  parsePolicyStatusReason,
+} = require("../util/policyDecisionLogs");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+suite("Policy decision log collection", () => {
+  function page(data, pageNumber, pageTotal, count = 101) {
+    return apiSuccess({ results: data }, {
+      headers: {
+        "x-pagination-page": String(pageNumber),
+        "x-pagination-pagetotal": String(pageTotal),
+        "x-pagination-pagesize": "100",
+        "x-pagination-count": String(count),
+      },
+    });
+  }
+
+  function log(index, packageIdentifier = "other-package") {
+    return {
+      slug_perm: `decision-${index}`,
+      package: { identifier: packageIdentifier },
+      policy_name: "Policy",
+    };
+  }
+
+  test("finds a package decision on a later page without returning unrelated entries", async () => {
+    const calls = [];
+    const firstPage = Array.from({ length: 100 }, (_, index) => log(index));
+    const api = {
+      async getV2(endpoint, options) {
+        calls.push(endpoint);
+        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        const response = pageNumber === 1
+          ? page(firstPage, 1, 2)
+          : page([log(100, "target-package")], 2, 2);
+        assert.strictEqual(options.validate(response.data), true);
+        return response;
+      },
+    };
+
+    const result = await fetchPackageDecisionLogs(api, "workspace-a", "target-package");
+
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.pageCount, 2);
+    assert.deepStrictEqual(result.items.map(item => item.slug_perm), ["decision-100"]);
+    assert.strictEqual(result.items[0].matched, null);
+    assert.strictEqual(calls.length, 2);
+  });
+
+  test("preserves matching decisions from successful pages and marks later failure partial", async () => {
+    const firstPage = [log(0, "target-package"), ...Array.from(
+      { length: 99 },
+      (_, index) => log(index + 1)
+    )];
+    const api = {
+      async getV2(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        return pageNumber === 1
+          ? page(firstPage, 1, 2)
+          : apiFailure("rate_limited", { status: 429, retryable: true });
+      },
+    };
+
+    const result = await fetchPackageDecisionLogs(api, "workspace-a", "target-package");
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.failureCount, 1);
+    assert.deepStrictEqual(result.items.map(item => item.slug_perm), ["decision-0"]);
+  });
+
+  test("bounds status reasons before parsing policy text", () => {
+    const hostile = `Quarantined by Policy. ${"x".repeat(10000)} (Policy: policy-a)`;
+    const normalized = normalizePolicyStatusReason(hostile);
+    const parsed = parsePolicyStatusReason(hostile);
+
+    assert.strictEqual(normalized.length, MAX_POLICY_STATUS_REASON_LENGTH);
+    assert.ok(parsed);
+    assert.ok(JSON.stringify(parsed).length <= MAX_POLICY_STATUS_REASON_LENGTH + 100);
+  });
+
+  test("rejects a decision log slug beyond the shared identity bound", async () => {
+    const result = await fetchPackageDecisionLogs({
+      async getV2(_endpoint, options) {
+        const data = {
+          results: [{
+            slug_perm: "x".repeat(513),
+            package: { identifier: "target-package" },
+          }],
+        };
+        assert.strictEqual(options.validate(data), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "target-package");
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+  });
+
+  test("rejects an overlong requested package reference before dispatch", async () => {
+    let calls = 0;
+    const result = await fetchPackageDecisionLogs({
+      async getV2() { calls += 1; throw new Error("must not dispatch"); },
+    }, "workspace-a", "x".repeat(513));
+
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "invalid_request");
+  });
+
+  test("rejects conflicting package reference aliases instead of attributing the decision", async () => {
+    const conflicting = {
+      slug_perm: "decision-conflicting",
+      package_slug_perm: "target-package",
+      package: { identifier: "different-package" },
+    };
+    const result = await fetchPackageDecisionLogs({
+      async getV2(_endpoint, options) {
+        const data = { results: [conflicting] };
+        assert.strictEqual(options.validate(data), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "target-package");
+
+    assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.items, []);
+    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+  });
+
+  test("rejects a malformed matched decision instead of normalizing it to false", async () => {
+    const result = await fetchPackageDecisionLogs({
+      async getV2(_endpoint, options) {
+        const data = { results: [{
+          slug_perm: "decision-malformed-match",
+          package_slug_perm: "target-package",
+          matched: "false",
+        }] };
+        assert.strictEqual(options.validate(data), false);
+        return apiFailure("invalid_response", { status: 200 });
+      },
+    }, "workspace-a", "target-package");
+
+    assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.items, []);
+    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+  });
+});

--- a/test/promotionContracts.test.js
+++ b/test/promotionContracts.test.js
@@ -134,6 +134,7 @@ suite("Promotion contracts", () => {
       locationRecord({ slug_perm: "package%5cid" }),
       locationRecord({ slug_perm: "package%255cid" }),
       locationRecord({ slug_perm_raw: "other-package-id" }),
+      locationRecord({ policy_violated: "false" }),
       locationRecord({ namespace: undefined }),
       locationRecord({ repository: undefined }),
       locationRecord({ slug_perm: undefined }),

--- a/test/promotionProvider.test.js
+++ b/test/promotionProvider.test.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const { PromotionProvider } = require("../views/promotionProvider");
+const { PaginatedFetch } = require("../util/paginatedFetch");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("Safe package promotion workflow", () => {
@@ -251,13 +252,15 @@ suite("Safe package promotion workflow", () => {
       },
     };
     const repositoryResult = options.repositoryResult || {
-      repositories: [
+      items: [
         { name: "Source", slug: "source", namespace: "workspace" },
         { name: "Target", slug: "target", namespace: "workspace" },
       ],
-      error: null,
-      warning: null,
+      complete: true,
+      incomplete: false,
       partial: false,
+      failureCount: 0,
+      failures: [],
       stale: false,
     };
     const provider = new PromotionProvider({}, {
@@ -409,7 +412,12 @@ suite("Safe package promotion workflow", () => {
   test("missing target, permission failure, partial repository enumeration, and malformed pagination fail closed", async () => {
     const cases = [
       { targetRepositoryFailure: true },
-      { repositoryResult: { repositories: [], error: null, warning: {}, partial: true, stale: false } },
+      {
+        repositoryResult: {
+          items: [], complete: false, incomplete: true, partial: false,
+          failureCount: 1, failures: [{ page: 2, error: { kind: "network_error" } }], stale: false,
+        },
+      },
       { malformedPaginationAt: 1 },
       { targetPageTotalAt: 1 },
     ];
@@ -827,15 +835,155 @@ suite("Safe package promotion workflow", () => {
     filtered.provider.api = {
       async get(_endpoint, requestOptions) {
         const data = [
-          filtered.sourceRecord({ format: "python" }),
+          filtered.sourceRecord({ format: "python", slug_perm: "python-package-id" }),
           filtered.sourceRecord({ status_str: "Completed" }),
         ];
         assert.strictEqual(requestOptions.validate(data), true);
-        return apiSuccess(data);
+        return page(data);
       },
     };
     const status = await filtered.provider.getPromotionStatus("workspace", "artifact", "1.0.0", "npm");
     assert.strictEqual(status.items[0].found, true);
     assert.strictEqual(status.items[0].status, "Completed");
+  });
+
+  test("promotion status discovers later-page locations and keeps positives on partial failure", async () => {
+    const later = createHarness({ pipeline: ["target"] });
+    const firstPage = Array.from({ length: 100 }, (_, index) => later.sourceRecord({
+      repository: "source",
+      slug_perm: `python-package-${index}`,
+      format: "python",
+    }));
+    later.provider.api = {
+      async get(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        return pageNumber === 1
+          ? page(firstPage, { page: 1, pageTotal: 2, count: 101 })
+          : page([later.targetRecord()], { page: 2, pageTotal: 2, count: 101 });
+      },
+    };
+    const laterStatus = await later.provider.getPromotionStatus(
+      "workspace", "artifact", "1.0.0", "npm"
+    );
+    assert.strictEqual(laterStatus.complete, true);
+    assert.strictEqual(laterStatus.items[0].found, true);
+
+    const partial = createHarness({ pipeline: ["target", "uninspected"] });
+    partial.provider.api = {
+      async get(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        if (pageNumber === 2) return apiFailure("rate_limited", { status: 429 });
+        return page([
+          partial.targetRecord(),
+          ...Array.from({ length: 99 }, (_, index) => partial.sourceRecord({
+            slug_perm: `other-${index}`,
+            format: "python",
+          })),
+        ], { page: 1, pageTotal: 2, count: 101 });
+      },
+    };
+    const partialStatus = await partial.provider.getPromotionStatus(
+      "workspace", "artifact", "1.0.0", "npm"
+    );
+    assert.strictEqual(partialStatus.partial, true);
+    assert.strictEqual(partialStatus.items[0].found, true);
+    assert.strictEqual(partialStatus.items[1].found, null);
+    assert.match(partialStatus.items[1].status, /incomplete/);
+  });
+
+  test("promotion target absence fails closed when pagination metadata drifts", async () => {
+    const harness = createHarness();
+    const pages = [];
+    const api = {
+      async get(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        pages.push(pageNumber);
+        const records = Array.from({ length: 100 }, (_value, index) => harness.targetRecord({
+          name: `other-${pageNumber}-${index}`,
+          format: "python",
+          slug_perm: `other-${pageNumber}-${index}`,
+        }));
+        return page(records, {
+          page: pageNumber,
+          pageTotal: pageNumber === 1 ? 2 : 3,
+          count: pageNumber === 1 ? 200 : 300,
+        });
+      },
+    };
+    harness.provider.api = api;
+    harness.provider._paginatedFetch = new PaginatedFetch(api);
+
+    const result = await harness.provider._findTargetPackages(
+      {
+        workspace: "workspace",
+        repository: "source",
+        packageIdentifier: "source-package-id",
+        name: "artifact",
+        version: "1.0.0",
+        format: "npm",
+      },
+      { workspace: "workspace", repository: "target" },
+      "credential-sentinel",
+      null,
+      harness.manager.getState(),
+      { stopOnPresence: false }
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.errorCode, "target_state_malformed");
+    assert.deepStrictEqual(pages, [1, 2]);
+  });
+
+  test("promotion status treats multiple exact locations in one repository as ambiguous", async () => {
+    const harness = createHarness({ pipeline: ["target"] });
+    harness.provider.api = {
+      async get() {
+        return page([
+          harness.targetRecord(),
+          harness.targetRecord({ slug_perm: "duplicate-location" }),
+        ]);
+      },
+    };
+
+    const status = await harness.provider.getPromotionStatus(
+      "workspace", "artifact", "1.0.0", "npm"
+    );
+    assert.strictEqual(status.complete, true);
+    assert.strictEqual(status.items[0].found, null);
+    assert.strictEqual(status.items[0].ambiguous, true);
+    assert.match(status.items[0].status, /multiple exact package locations/);
+  });
+
+  test("bounded exact package locations remain available when no pipeline is configured", async () => {
+    const harness = createHarness({ pipeline: [] });
+    harness.provider.api = {
+      async get() {
+        return page([harness.targetRecord()]);
+      },
+    };
+
+    const locations = await harness.provider.getPackageLocations(
+      "workspace", "artifact", "1.0.0", "npm"
+    );
+    assert.strictEqual(locations.complete, true);
+    assert.deepStrictEqual(locations.items.map(item => item.repository), ["target"]);
+  });
+
+  test("exact package locations discard an old-account completion", async () => {
+    const harness = createHarness({ pipeline: [] });
+    harness.provider.api = {
+      async get() {
+        harness.manager.changeAccount();
+        return page([harness.targetRecord()]);
+      },
+    };
+
+    const locations = await harness.provider.getPackageLocations(
+      "workspace", "artifact", "1.0.0", "npm"
+    );
+    assert.strictEqual(locations.complete, false);
+    assert.deepStrictEqual(locations.items, []);
+    assert.strictEqual(locations.error.kind, "stale_account");
   });
 });

--- a/test/quarantineExplainProvider.test.js
+++ b/test/quarantineExplainProvider.test.js
@@ -1,0 +1,117 @@
+const assert = require("assert");
+const vscode = require("vscode");
+const { QuarantineExplainProvider } = require("../views/quarantineExplainProvider");
+
+suite("QuarantineExplainProvider policy completeness", () => {
+  function render(trace) {
+    const provider = new QuarantineExplainProvider({});
+    return provider._getHtmlContent(
+      "nonce",
+      "artifact",
+      "1.0.0",
+      "npm",
+      "workspace-a",
+      "repo-a",
+      "package-a",
+      "Quarantined by Policy. Rule matched. (Policy: policy-a)",
+      null,
+      trace
+    );
+  }
+
+  test("does not claim a non-vulnerability quarantine when policy history is incomplete", () => {
+    const html = render({
+      parsedReason: null,
+      decisionLogs: [],
+      decisionLogsComplete: false,
+      decisionLogsPartial: true,
+      policyDetail: null,
+    });
+
+    assert.match(html, /Policy decision log history is incomplete/);
+    assert.doesNotMatch(html, /not a specific vulnerability/);
+  });
+
+  test("allows a non-vulnerability conclusion only after complete policy history", () => {
+    const html = render({
+      parsedReason: null,
+      decisionLogs: [],
+      decisionLogsComplete: true,
+      decisionLogsPartial: false,
+      policyDetail: null,
+    });
+
+    assert.match(html, /not a specific vulnerability/);
+    assert.doesNotMatch(html, /Policy decision log history is incomplete/);
+  });
+
+  test("renders a missing policy match flag as unknown rather than no", () => {
+    const html = render({
+      parsedReason: null,
+      decisionLogs: [{ policy_name: "Policy", matched: null }],
+      decisionLogsComplete: true,
+      decisionLogsPartial: false,
+      policyDetail: null,
+    });
+
+    assert.match(html, /<td>Unknown<\/td>/);
+    assert.doesNotMatch(html, /<td>No<\/td>/);
+  });
+
+  test("account reset aborts stale policy loading before it can render", async () => {
+    const originalCreateWebviewPanel = vscode.window.createWebviewPanel;
+    let state = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    const htmlWrites = [];
+    let disposeHandler;
+    const panel = {
+      webview: {
+        set html(value) { htmlWrites.push(value); },
+        get html() { return htmlWrites[htmlWrites.length - 1]; },
+        onDidReceiveMessage() { return { dispose() {} }; },
+      },
+      onDidDispose(handler) { disposeHandler = handler; return { dispose() {} }; },
+      dispose() { if (disposeHandler) disposeHandler(); },
+    };
+    let resolveFetch;
+    const gate = new Promise(resolve => { resolveFetch = resolve; });
+    let signal;
+    vscode.window.createWebviewPanel = () => panel;
+    try {
+      const provider = new QuarantineExplainProvider({}, {
+        connectionManager: { getState() { return { ...state }; } },
+      });
+      provider._fetchPolicyDecisionTrace = async (_api, _workspace, _slug, _reason, requestSignal) => {
+        signal = requestSignal;
+        await gate;
+        return {
+          parsedReason: null,
+          decisionLogs: [],
+          decisionLogsComplete: true,
+          policyDetail: null,
+        };
+      };
+
+      const pending = provider.show({
+        namespace: "workspace-a",
+        repository: "repo-a",
+        name: "artifact",
+        format: "npm",
+        slug_perm_raw: "package-a",
+        version: "1.0.0",
+      });
+      await new Promise(resolve => setImmediate(resolve));
+      state = { ...state, activationId: "account-b", accountEpoch: 2 };
+      provider.resetForAccountChange();
+      assert.strictEqual(signal.aborted, true);
+      resolveFetch();
+      await pending;
+      assert.strictEqual(htmlWrites.length, 1);
+    } finally {
+      vscode.window.createWebviewPanel = originalCreateWebviewPanel;
+    }
+  });
+});

--- a/test/remediationHelper.test.js
+++ b/test/remediationHelper.test.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
 const { RemediationHelper } = require("../util/remediationHelper");
-const { apiFailure } = require("./apiResultHelpers");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("RemediationHelper response validation", () => {
   test("blank package records cannot be offered as safe versions", async () => {
@@ -25,4 +25,103 @@ suite("RemediationHelper response validation", () => {
     assert.strictEqual(result.error.kind, "invalid_response");
     assert.deepStrictEqual(result.versions, []);
   });
+
+  test("returns a truthful newest-ten preview with authoritative total metadata", async () => {
+    const versions = Array.from({ length: 10 }, (_, index) => ({
+      name: "artifact",
+      version: `1.0.${index}`,
+      format: "npm",
+      repository: "repo",
+      namespace: "workspace",
+      slug_perm: `artifact-${index}`,
+    }));
+    const helper = new RemediationHelper({
+      async get(endpoint) {
+        assert.strictEqual(
+          endpoint,
+          "packages/workspace/repo/?sort=-version&page=1&page_size=10&query=name%3Aartifact+AND+format%3Anpm+AND+NOT+status%3Aquarantined+AND+deny_policy_violated%3Afalse"
+        );
+        return apiSuccess(versions, {
+          headers: paginationHeaders(1, 3, 25, 10),
+        });
+      },
+    });
+
+    const result = await helper.findSafeVersions("workspace", "repo", "artifact", "npm");
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.totalCount, 25);
+    assert.strictEqual(result.absenceProven, false);
+    assert.strictEqual(result.versions.length, 10);
+  });
+
+  test("proves no safe versions only from an authoritative zero count", async () => {
+    const helper = new RemediationHelper({
+      async get() {
+        return apiSuccess([], { headers: paginationHeaders(1, 1, 0, 10) });
+      },
+    });
+
+    const result = await helper.findSafeVersionsAcrossRepos("workspace", "artifact", "npm");
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.totalCount, 0);
+    assert.strictEqual(result.absenceProven, true);
+  });
+
+  test("rejects safe-version results outside the exact requested scope", async () => {
+    const helper = new RemediationHelper({
+      async get() {
+        return apiSuccess([{
+          name: "artifact",
+          version: "1.0.0",
+          format: "npm",
+          repository: "other-repo",
+          namespace: "workspace",
+          slug_perm: "artifact-id",
+        }], { headers: paginationHeaders(1, 1, 1, 10) });
+      },
+    });
+
+    const result = await helper.findSafeVersions("workspace", "repo", "artifact", "npm");
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error.kind, "invalid_response");
+    assert.strictEqual(result.absenceProven, false);
+  });
+
+  test("rejects duplicate safe-version identities instead of publishing repeated choices", async () => {
+    const duplicate = {
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+      repository: "repo",
+      namespace: "workspace",
+      slug_perm: "artifact-id",
+    };
+    const helper = new RemediationHelper({
+      async get() {
+        return apiSuccess([duplicate, { ...duplicate }], {
+          headers: paginationHeaders(1, 1, 2, 10),
+        });
+      },
+    });
+
+    const result = await helper.findSafeVersions("workspace", "repo", "artifact", "npm");
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error.kind, "invalid_response");
+    assert.deepStrictEqual(result.versions, []);
+  });
 });
+
+function paginationHeaders(page, pageTotal, count, pageSize) {
+  return {
+    "x-pagination-page": String(page),
+    "x-pagination-pagetotal": String(pageTotal),
+    "x-pagination-count": String(count),
+    "x-pagination-pagesize": String(pageSize),
+  };
+}

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -1,13 +1,104 @@
 const assert = require("assert");
 const vscode = require("vscode");
+const { EntitlementSummaryNode } = require("../models/entitlementNode");
 const UpstreamIndicatorNode = require("../models/upstreamIndicatorNode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const {
   bindConnectionManager,
   unbindConnectionManager,
 } = require("../util/connectionManager");
-const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+function makePackage(slug, overrides = {}) {
+  return {
+    namespace: "acme",
+    repository: "packages",
+    name: slug,
+    format: "npm",
+    slug,
+    slug_perm: slug,
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+function makePagination(page, pageTotal, pageSize, count = null) {
+  return {
+    page,
+    pageTotal,
+    pageSize,
+    count,
+    countAuthoritative: count !== null,
+  };
+}
+
+function makeContinuation(descriptor, options = {}) {
+  const nextPage = options.nextPage || 2;
+  return Object.freeze({
+    nextPage,
+    anchor: Object.freeze(options.anchor || makePagination(nextPage - 1, nextPage, 2, 3)),
+    cumulative: Object.freeze({
+      pageCount: options.pageCount ?? (nextPage - 1),
+      requestCount: options.requestCount ?? (nextPage - 1),
+      itemCount: options.itemCount ?? 2,
+      duplicateCount: options.duplicateCount ?? 0,
+      failureCount: options.failureCount ?? 0,
+    }),
+    descriptor,
+    binding: "a".repeat(64),
+  });
+}
+
+function makeCollectionResult(options = {}) {
+  const items = options.items || [];
+  const complete = options.complete === true;
+  const failures = options.failures || [];
+  return Object.freeze({
+    items: Object.freeze(items),
+    complete,
+    incomplete: !complete,
+    partial: !complete && (options.cumulativeItemCount ?? items.length) > 0,
+    cancelled: options.cancelled === true,
+    continuation: complete ? null : (options.continuation || null),
+    failures: Object.freeze(failures),
+    failureCount: options.failureCount ?? failures.length,
+    termination: options.termination || (complete ? "exhausted" : "page_batch"),
+    pageCount: options.pageCount ?? (items.length > 0 ? 1 : 0),
+    requestCount: options.requestCount ?? (items.length > 0 ? 1 : 0),
+    duplicateCount: options.duplicateCount || 0,
+    pagination: options.pagination || null,
+  });
+}
+
+function collectionFailure(page = 2, kind = "rate_limited") {
+  return Object.freeze({
+    page,
+    error: Object.freeze({
+      kind,
+      status: kind === "rate_limited" ? 429 : null,
+      retryable: kind === "rate_limited",
+      message: "The page request failed.",
+      requestId: "test-request-id",
+      retryAfterMs: null,
+      outcomeUnknown: false,
+    }),
+  });
+}
+
+function completeUpstreamState(upstreams = []) {
+  return {
+    upstreams,
+    failedFormats: [],
+    uninspectedFormats: [],
+    complete: true,
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(res => { resolve = res; });
+  return { promise, resolve };
+}
 
 suite("RepositoryNode Test Suite", () => {
   const repositoryNodePath = require.resolve("../models/repositoryNode");
@@ -61,6 +152,9 @@ suite("RepositoryNode Test Suite", () => {
         if (key === "showEntitlements") {
           return false;
         }
+        if (key === "showMaxPackages") {
+          return 30;
+        }
         return false;
       },
     });
@@ -78,7 +172,7 @@ suite("RepositoryNode Test Suite", () => {
     delete require.cache[upstreamCheckerPath];
   });
 
-  test("reconciles partial inferred-format results with the full repo upstream totals", async () => {
+  test("uses one repository-wide upstream fetch for configured totals", async () => {
     let allFormatCalls = 0;
     const targetedCalls = [];
     const partialUpstreams = [
@@ -100,7 +194,9 @@ suite("RepositoryNode Test Suite", () => {
         active: 5,
         total: 6,
         failedFormats: [],
+        uninspectedFormats: [],
         successfulFormats: 6,
+        complete: true,
       };
     };
     upstreamChecker.getUpstreamDataForFormats = async (_context, workspace, repo, formats) => {
@@ -110,7 +206,9 @@ suite("RepositoryNode Test Suite", () => {
         active: 2,
         total: 3,
         failedFormats: [],
+        uninspectedFormats: [],
         successfulFormats: 2,
+        complete: true,
       };
     };
 
@@ -126,12 +224,12 @@ suite("RepositoryNode Test Suite", () => {
       { format: "python" },
       { formats: ["docker", "unknown"] },
     ];
+    repositoryNode._packageState = { ...repositoryNode._packageState, pageCount: 1 };
 
     const children = await repositoryNode.getChildren();
 
     assert.strictEqual(allFormatCalls, 1);
-    assert.strictEqual(targetedCalls.length, 1);
-    assert.deepStrictEqual(targetedCalls[0].formats, ["docker", "python"]);
+    assert.strictEqual(targetedCalls.length, 0);
     assert.ok(children[0] instanceof UpstreamIndicatorNode);
     assert.strictEqual(children[0].upstreams.length, 6);
     assert.strictEqual(children[0].getTreeItem().label, "Upstreams: 5 active of 6 configured");
@@ -151,11 +249,12 @@ suite("RepositoryNode Test Suite", () => {
       allFormatCalls += 1;
       return {
         upstreams: [{ name: "Docker Hub", _format: "docker", upstream_url: "https://index.docker.io/" }],
+        failedFormats: [], uninspectedFormats: [], complete: true,
       };
     };
     upstreamChecker.getUpstreamDataForFormats = async () => {
       targetedCalls += 1;
-      return { upstreams: [] };
+      return completeUpstreamState();
     };
 
     const repositoryNode = new RepositoryNode(
@@ -173,18 +272,19 @@ suite("RepositoryNode Test Suite", () => {
     assert.strictEqual(upstreams[0].name, "Docker Hub");
   });
 
-  test("keeps the inferred-format fast path when every supported upstream format is covered", async () => {
+  test("does not amplify upstream requests from package format hints", async () => {
     let allFormatCalls = 0;
     const targetedCalls = [];
 
     upstreamChecker.getAllUpstreamData = async () => {
       allFormatCalls += 1;
-      return { upstreams: [] };
+      return completeUpstreamState();
     };
     upstreamChecker.getUpstreamDataForFormats = async (_context, workspace, repo, formats) => {
       targetedCalls.push({ workspace, repo, formats });
       return {
         upstreams: [{ name: "PyPI", _format: "python", upstream_url: "https://pypi.org/" }],
+        failedFormats: [], uninspectedFormats: [], complete: true,
       };
     };
 
@@ -195,12 +295,11 @@ suite("RepositoryNode Test Suite", () => {
       { connectionManager }
     );
 
-    const upstreams = await repositoryNode.getUpstreams([{ formats: SUPPORTED_UPSTREAM_FORMATS }]);
+    const upstreams = await repositoryNode.getUpstreams([{ formats: ["npm", "python"] }]);
 
-    assert.strictEqual(allFormatCalls, 0);
-    assert.strictEqual(targetedCalls.length, 1);
-    assert.deepStrictEqual(targetedCalls[0].formats, SUPPORTED_UPSTREAM_FORMATS);
-    assert.strictEqual(upstreams.length, 1);
+    assert.strictEqual(allFormatCalls, 1);
+    assert.strictEqual(targetedCalls.length, 0);
+    assert.strictEqual(upstreams.length, 0);
   });
 
   test("adds the inline upstream indicator when upstreams are present", async () => {
@@ -212,9 +311,10 @@ suite("RepositoryNode Test Suite", () => {
     );
 
     repositoryNode.getPackages = async () => [{ format: "python" }];
-    repositoryNode.getUpstreams = async () => [
+    repositoryNode._packageState = { ...repositoryNode._packageState, pageCount: 1 };
+    repositoryNode.getUpstreamState = async () => completeUpstreamState([
       { name: "PyPI", upstream_url: "https://pypi.org/", is_active: true },
-    ];
+    ]);
 
     const children = await repositoryNode.getChildren();
 
@@ -239,6 +339,7 @@ suite("RepositoryNode Test Suite", () => {
         slug: "clean-npm",
         slug_perm: "clean-npm-perm",
         version: "1.0.0",
+        num_vulnerabilities: 0,
         security_scan_status: "Scan Detected No Vulnerabilities",
       },
       {
@@ -251,7 +352,14 @@ suite("RepositoryNode Test Suite", () => {
         num_vulnerabilities: "0",
         security_scan_status: "Scan Detected No Vulnerabilities",
       },
-    ]);
+    ], {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "30",
+        "x-pagination-count": "2",
+      },
+    });
 
     const repositoryNode = new RepositoryNode(
       { slug: "packages", slug_perm: "packages", name: "Packages" },
@@ -293,7 +401,82 @@ suite("RepositoryNode Test Suite", () => {
     const packages = await repositoryNode.getPackages();
 
     assert.deepStrictEqual(packages, []);
-    assert.strictEqual(repositoryNode._lastApiFailed, true);
+    assert.strictEqual(repositoryNode._packageState.complete, false);
+    assert.strictEqual(repositoryNode._packageState.failures.length, 1);
+  });
+
+  test("rejects malformed present package policy booleans instead of publishing false", async () => {
+    CloudsmithAPI.prototype.get = async (_endpoint, options) => {
+      const malformed = [makePackage("artifact", { policy_violated: "true" })];
+      assert.strictEqual(options.validate(malformed), false);
+      return apiFailure("invalid_response", { status: 200 });
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context,
+      { connectionManager }
+    );
+
+    const packages = await repositoryNode.getPackages();
+
+    assert.deepStrictEqual(packages, []);
+    assert.strictEqual(repositoryNode._packageState.complete, false);
+  });
+
+  test("normalizes repository vulnerability evidence without making false-clean claims", async () => {
+    const packages = [
+      makePackage("no-evidence"),
+      makePackage("malformed", { num_vulnerabilities: { value: "many" } }),
+      makePackage("presence", { has_vulnerabilities: true }),
+      makePackage("status", { security_scan_status: "Scan Detected Vulnerabilities" }),
+      makePackage("zero", { num_vulnerabilities: 0 }),
+      makePackage("positive", { num_vulnerabilities: "2" }),
+    ];
+    CloudsmithAPI.prototype.get = async () => apiSuccess(packages, {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "30",
+        "x-pagination-count": String(packages.length),
+      },
+    });
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context,
+      { connectionManager }
+    );
+
+    const nodes = await repositoryNode.getPackages();
+    const vulnerabilityCounts = Object.fromEntries(nodes.map(node => [
+      node.name,
+      node.num_vulnerabilities,
+    ]));
+
+    assert.deepStrictEqual(vulnerabilityCounts, {
+      "no-evidence": null,
+      malformed: null,
+      presence: -1,
+      status: -1,
+      zero: 0,
+      positive: 2,
+    });
+    assert.strictEqual(
+      nodes.find(node => node.name === "zero").getChildren().some(child => (
+        child.getTreeItem().contextValue === "vulnerabilitySummary"
+      )),
+      false
+    );
+    for (const name of ["no-evidence", "malformed", "presence", "status", "positive"]) {
+      assert.strictEqual(
+        nodes.find(node => node.name === name).getChildren().some(child => (
+          child.getTreeItem().contextValue === "vulnerabilitySummary"
+        )),
+        true,
+        `${name} was incorrectly shown as clean`
+      );
+    }
   });
 
   test("group and entitlement validators reject blank records", async () => {
@@ -312,7 +495,7 @@ suite("RepositoryNode Test Suite", () => {
         assert.strictEqual(options.validate({ results: [{ name: "artifact", format: "npm" }] }), true);
       } else {
         assert.strictEqual(options.validate([{}]), false);
-        assert.strictEqual(options.validate([{ name: "token", is_active: false }]), true);
+        assert.strictEqual(options.validate([{ name: "token", slug_perm: "token", is_active: false }]), true);
       }
       return apiFailure("invalid_response", { status: 200 });
     };
@@ -353,8 +536,740 @@ suite("RepositoryNode Test Suite", () => {
       slug: "old-package",
       slug_perm: "old-package",
       version: "1.0.0",
-    }]));
+    }], {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "30",
+        "x-pagination-count": "1",
+      },
+    }));
 
     assert.deepStrictEqual(await pending, []);
+  });
+
+  test("does not reuse completed package state across account epochs", async () => {
+    let calls = 0;
+    const fake = {
+      async fetchCollection() {
+        calls += 1;
+        return makeCollectionResult({
+          items: [makePackage(calls === 1 ? "account-one" : "account-two")],
+          complete: true,
+          pagination: makePagination(1, 1, 30, 1),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      { connectionManager, createPaginatedFetch: () => fake }
+    );
+
+    assert.deepStrictEqual((await repositoryNode.getPackages()).map(node => node.name), ["account-one"]);
+    connectionManager.setState({ accountEpoch: 2 });
+    assert.deepStrictEqual((await repositoryNode.getPackages()).map(node => node.name), ["account-two"]);
+    assert.strictEqual(calls, 2);
+  });
+
+  test("loads one bounded package page and exposes an authoritative Load More node", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) {
+        if (key === "showMaxPackages") return 2;
+        return false;
+      },
+    });
+    const calls = [];
+    const refreshes = [];
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        calls.push(options);
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [makePackage("one"), makePackage("two")],
+            continuation: makeContinuation(options.descriptor),
+            pagination: makePagination(1, 2, 2, 3),
+          });
+        }
+        assert.strictEqual(options.knownIdentities.size, 2);
+        return makeCollectionResult({
+          items: [makePackage("three")],
+          complete: true,
+          pageCount: 2,
+          requestCount: 2,
+          pagination: makePagination(2, 2, 2, 3),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" },
+      "acme",
+      context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        upstreamChecker: {
+          getAllUpstreamData: async () => completeUpstreamState(),
+          getUpstreamDataForFormats: async () => completeUpstreamState(),
+        },
+        requestRefresh: node => refreshes.push(node),
+        withProgress: async (_options, task) => task({ report() {} }, { isCancellationRequested: false }),
+      }
+    );
+
+    let children = await repositoryNode.getChildren();
+    const loadMore = children.find(child => child.getTreeItem().contextValue === "repositoryLoadMore");
+    assert.ok(loadMore);
+    assert.strictEqual(loadMore.getTreeItem().label, "Load more packages (showing 2 of 3)");
+    assert.strictEqual(calls[0].pageBatchLimit, 1);
+    assert.strictEqual(calls[0].maxPages, 20);
+    assert.strictEqual(calls[0].maxRequests, 24);
+    assert.strictEqual(calls[0].maxItems, 600);
+
+    await repositoryNode.loadMorePackages();
+    children = await repositoryNode.getChildren();
+    assert.deepStrictEqual(repositoryNode._packageState.nodes.map(node => node.name), ["one", "two", "three"]);
+    assert.strictEqual(children.some(child => (
+      child.getTreeItem().contextValue === "repositoryLoadMore"
+    )), false);
+    assert.strictEqual(repositoryNode._packageState.complete, true);
+    assert.strictEqual(refreshes.length, 2);
+  });
+
+  test("resumes the real shared collector at the exact next package page", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 1 : false; },
+    });
+    const requests = [];
+    const api = {
+      async get(endpoint) {
+        requests.push(endpoint);
+        const page = Number(new URL(endpoint, "https://api.test/").searchParams.get("page"));
+        const item = page === 1 ? makePackage("one") : makePackage("two");
+        return apiSuccess([item], {
+          headers: {
+            "x-pagination-page": String(page),
+            "x-pagination-pagetotal": "2",
+            "x-pagination-pagesize": "1",
+            "x-pagination-count": "2",
+          },
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createCloudsmithAPI: () => api,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+
+    assert.deepStrictEqual(
+      requests.map(endpoint => new URL(endpoint, "https://api.test/").searchParams.get("page")),
+      ["1", "2"]
+    );
+    assert.deepStrictEqual(repositoryNode._packageState.nodes.map(node => node.name), ["one", "two"]);
+    assert.strictEqual(repositoryNode._packageState.pageCount, 2);
+    assert.strictEqual(repositoryNode._packageState.requestCount, 2);
+    assert.strictEqual(repositoryNode._packageState.complete, true);
+  });
+
+  test("coalesces duplicate Load More invocations into one page request", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 2 : false; },
+    });
+    const secondPage = deferred();
+    let calls = 0;
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        calls += 1;
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [makePackage("one"), makePackage("two")],
+            continuation: makeContinuation(options.descriptor),
+            pagination: makePagination(1, 2, 2, 3),
+          });
+        }
+        return secondPage.promise;
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+
+    const first = repositoryNode.loadMorePackages();
+    const second = repositoryNode.loadMorePackages();
+    assert.strictEqual(first, second);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(calls, 2);
+    secondPage.resolve(makeCollectionResult({
+      items: [makePackage("three")],
+      complete: true,
+      pageCount: 2,
+      requestCount: 2,
+      pagination: makePagination(2, 2, 2, 3),
+    }));
+    await Promise.all([first, second]);
+    assert.strictEqual(calls, 2);
+  });
+
+  test("ignores a stale continuation completion after node invalidation", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 2 : false; },
+    });
+    const secondPage = deferred();
+    const refreshes = [];
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [makePackage("one"), makePackage("two")],
+            continuation: makeContinuation(options.descriptor),
+            pagination: makePagination(1, 2, 2, 3),
+          });
+        }
+        return secondPage.promise;
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        requestRefresh: node => refreshes.push(node),
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+    const pending = repositoryNode.loadMorePackages();
+    await new Promise(resolve => setImmediate(resolve));
+    repositoryNode.invalidate();
+    secondPage.resolve(makeCollectionResult({
+      items: [makePackage("stale")],
+      complete: true,
+      pageCount: 2,
+      requestCount: 2,
+      pagination: makePagination(2, 2, 2, 3),
+    }));
+    await pending;
+
+    assert.deepStrictEqual(repositoryNode._packageState.nodes.map(node => node.name), ["one", "two"]);
+    assert.strictEqual(refreshes.length, 1);
+  });
+
+  test("preserves loaded packages across a failed page retry and clears recovered failure state", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 2 : false; },
+    });
+    let pageTwoAttempts = 0;
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [makePackage("one"), makePackage("two")],
+            continuation: makeContinuation(options.descriptor),
+            pagination: makePagination(1, 2, 2, 3),
+          });
+        }
+        pageTwoAttempts += 1;
+        assert.strictEqual(options.knownIdentities.size, 2);
+        if (pageTwoAttempts === 1) {
+          const failure = collectionFailure();
+          return makeCollectionResult({
+            continuation: makeContinuation(options.descriptor, { requestCount: 2 }),
+            failures: [failure],
+            failureCount: 1,
+            termination: "request_failed",
+            pageCount: 1,
+            requestCount: 2,
+            pagination: makePagination(1, 2, 2, 3),
+            cumulativeItemCount: 2,
+          });
+        }
+        return makeCollectionResult({
+          items: [makePackage("three")],
+          complete: true,
+          pageCount: 2,
+          requestCount: 3,
+          pagination: makePagination(2, 2, 2, 3),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+    assert.strictEqual(repositoryNode._packageState.nodes.length, 2);
+    assert.strictEqual(repositoryNode._packageState.failures.length, 1);
+    assert.ok(repositoryNode._packageState.continuation);
+
+    await repositoryNode.loadMorePackages();
+    assert.strictEqual(repositoryNode._packageState.nodes.length, 3);
+    assert.strictEqual(repositoryNode._packageState.failures.length, 0);
+    assert.strictEqual(repositoryNode._packageState.complete, true);
+  });
+
+  test("fails closed on a duplicate cross-page identity", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 1 : false; },
+    });
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [makePackage("same")],
+            continuation: makeContinuation(options.descriptor, {
+              anchor: makePagination(1, 2, 1, 2), itemCount: 1,
+            }),
+            pagination: makePagination(1, 2, 1, 2),
+          });
+        }
+        return makeCollectionResult({
+          items: [makePackage("same")],
+          complete: true,
+          pageCount: 2,
+          requestCount: 2,
+          pagination: makePagination(2, 2, 1, 2),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+
+    assert.strictEqual(repositoryNode._packageState.nodes.length, 1);
+    assert.strictEqual(repositoryNode._packageState.complete, false);
+    assert.strictEqual(repositoryNode._packageState.continuation, null);
+    assert.strictEqual(repositoryNode._packageState.termination, "duplicate_identity");
+  });
+
+  test("cancellation preserves items and advances the cumulative retry budget", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 2 : false; },
+    });
+    let initialContinuation;
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        if (!options.resume) {
+          initialContinuation = makeContinuation(options.descriptor);
+          return makeCollectionResult({
+            items: [makePackage("one"), makePackage("two")],
+            continuation: initialContinuation,
+            pagination: makePagination(1, 2, 2, 3),
+          });
+        }
+        assert.strictEqual(options.cancellationToken.isCancellationRequested, true);
+        const cancelledContinuation = makeContinuation(options.descriptor, {
+          nextPage: 2,
+          anchor: makePagination(1, 2, 2, 3),
+          pageCount: 1,
+          requestCount: 2,
+          itemCount: 2,
+        });
+        return makeCollectionResult({
+          cancelled: true,
+          continuation: cancelledContinuation,
+          termination: "cancelled",
+          pageCount: 1,
+          requestCount: 2,
+          pagination: makePagination(1, 2, 2, 3),
+          cumulativeItemCount: 2,
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: true }),
+      }
+    );
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+
+    assert.notStrictEqual(repositoryNode._packageState.continuation, initialContinuation);
+    assert.strictEqual(repositoryNode._packageState.continuation.cumulative.requestCount, 2);
+    assert.strictEqual(repositoryNode._packageState.requestCount, 2);
+    assert.deepStrictEqual(repositoryNode._packageState.nodes.map(node => node.name), ["one", "two"]);
+  });
+
+  test("never labels a cancelled initial collection as an empty repository", async () => {
+    const fake = {
+      async fetchCollection() {
+        return makeCollectionResult({ cancelled: true, termination: "cancelled" });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      { connectionManager, createPaginatedFetch: () => fake }
+    );
+
+    const children = await repositoryNode.getChildren();
+    const labels = children.map(child => child.getTreeItem().label);
+
+    assert.ok(labels.includes("Package loading cancelled"));
+    assert.strictEqual(labels.includes("Repository is empty"), false);
+    assert.strictEqual(repositoryNode._packageState.complete, false);
+  });
+
+  test("stops exposing continuation at the cumulative page cap", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 1 : false; },
+    });
+    let calls = 0;
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        calls += 1;
+        const page = options.resume?.nextPage || 1;
+        assert.strictEqual(options.knownIdentities?.size || 0, page - 1);
+        const pagination = makePagination(page, 21, 1);
+        const continuation = page < 20
+          ? makeContinuation(options.descriptor, {
+            nextPage: page + 1,
+            anchor: pagination,
+            pageCount: page,
+            requestCount: page,
+            itemCount: page,
+          })
+          : null;
+        return makeCollectionResult({
+          items: [makePackage(`package-${page}`)],
+          continuation,
+          termination: continuation ? "page_batch" : "page_limit",
+          pageCount: page,
+          requestCount: page,
+          pagination,
+          cumulativeItemCount: page,
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        upstreamChecker: {
+          getAllUpstreamData: async () => completeUpstreamState(),
+          getUpstreamDataForFormats: async () => completeUpstreamState(),
+        },
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+    for (let page = 2; page <= 20; page += 1) {
+      await repositoryNode.loadMorePackages();
+    }
+    const children = await repositoryNode.getChildren();
+
+    assert.strictEqual(calls, 20);
+    assert.strictEqual(repositoryNode._packageState.nodes.length, 20);
+    assert.strictEqual(repositoryNode._packageState.capReached, true);
+    assert.strictEqual(repositoryNode._packageState.continuation, null);
+    assert.ok(children.some(child => child.getTreeItem().label === "Package loading limit reached"));
+    assert.strictEqual(children.some(child => (
+      child.getTreeItem().contextValue === "repositoryLoadMore"
+    )), false);
+  });
+
+  test("loads package-group continuation with format-qualified canonical identities", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) {
+        if (key === "showMaxPackages") return 1;
+        if (key === "groupByPackageGroups") return true;
+        return false;
+      },
+    });
+    let calls = 0;
+    const fake = {
+      async fetchCollection(endpoint, options) {
+        calls += 1;
+        assert.ok(endpoint.includes("/groups"));
+        assert.strictEqual(options.responseType, "object");
+        assert.strictEqual(options.validate([{ name: "shared", format: "npm" }]), true);
+        assert.strictEqual(options.validateResponse({ results: [{ name: "shared", format: "npm" }] }), true);
+        assert.deepStrictEqual(options.extractItems({ results: [{ name: "shared", format: "npm" }] }), [
+          { name: "shared", format: "npm" },
+        ]);
+        if (!options.resume) {
+          return makeCollectionResult({
+            items: [{ name: "shared", format: "npm", count: 1 }],
+            continuation: makeContinuation(options.descriptor, {
+              anchor: makePagination(1, 2, 1, 2), itemCount: 1,
+            }),
+            pagination: makePagination(1, 2, 1, 2),
+          });
+        }
+        assert.strictEqual(options.knownIdentities.size, 1);
+        return makeCollectionResult({
+          items: [{ name: "shared", format: "python", count: 1 }],
+          complete: true,
+          pageCount: 2,
+          requestCount: 2,
+          pagination: makePagination(2, 2, 1, 2),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      {
+        connectionManager,
+        createPaginatedFetch: () => fake,
+        withProgress: async (_options, task) => task({}, { isCancellationRequested: false }),
+      }
+    );
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+
+    assert.strictEqual(calls, 2);
+    assert.deepStrictEqual(
+      repositoryNode._packageState.nodes.map(node => `${node.format}:${node.name}`),
+      ["npm:shared", "python:shared"]
+    );
+  });
+
+  test("rejects contradictory continuation metadata without another request", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 1 : false; },
+    });
+    let calls = 0;
+    const fake = {
+      async fetchCollection(_endpoint, options) {
+        calls += 1;
+        return makeCollectionResult({
+          items: [makePackage("one")],
+          continuation: makeContinuation(options.descriptor, {
+            anchor: makePagination(2, 3, 1),
+            itemCount: 1,
+          }),
+          pagination: makePagination(1, 3, 1),
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      { connectionManager, createPaginatedFetch: () => fake }
+    );
+    await repositoryNode.getPackages();
+    await repositoryNode.loadMorePackages();
+
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(repositoryNode._packageState.complete, false);
+    assert.strictEqual(repositoryNode._packageState.continuation, null);
+  });
+
+  test("rejects continuation counters that do not match their pagination anchor", async () => {
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "showMaxPackages" ? 1 : false; },
+    });
+    const cases = [
+      {
+        name: "page count differs from anchor page",
+        continuation(descriptor) {
+          return makeContinuation(descriptor, {
+            anchor: makePagination(1, 3, 1),
+            nextPage: 2,
+            pageCount: 2,
+            requestCount: 2,
+            itemCount: 1,
+          });
+        },
+        pageCount: 2,
+        requestCount: 2,
+        pagination: makePagination(1, 3, 1),
+      },
+      {
+        name: "next page differs from cumulative page count",
+        continuation(descriptor) {
+          return makeContinuation(descriptor, {
+            anchor: makePagination(2, 4, 1),
+            nextPage: 3,
+            pageCount: 1,
+            requestCount: 1,
+            itemCount: 1,
+          });
+        },
+        pageCount: 1,
+        requestCount: 1,
+        pagination: makePagination(2, 4, 1),
+      },
+      {
+        name: "null anchor carries committed page and item state",
+        continuation(descriptor) {
+          return Object.freeze({
+            nextPage: 1,
+            anchor: null,
+            cumulative: Object.freeze({
+              pageCount: 1,
+              requestCount: 1,
+              itemCount: 1,
+              duplicateCount: 0,
+              failureCount: 0,
+            }),
+            descriptor,
+            binding: "a".repeat(64),
+          });
+        },
+        pageCount: 1,
+        requestCount: 1,
+        pagination: null,
+      },
+      {
+        name: "item count omits records from committed full pages",
+        continuation(descriptor) {
+          return makeContinuation(descriptor, {
+            anchor: makePagination(1, 2, 2, 3),
+            nextPage: 2,
+            pageCount: 1,
+            requestCount: 1,
+            itemCount: 1,
+          });
+        },
+        pageCount: 1,
+        requestCount: 1,
+        pagination: makePagination(1, 2, 2, 3),
+      },
+      {
+        name: "request count is below committed page count",
+        continuation(descriptor) {
+          return makeContinuation(descriptor, {
+            anchor: makePagination(2, 3, 1),
+            nextPage: 3,
+            pageCount: 2,
+            requestCount: 1,
+            itemCount: 1,
+          });
+        },
+        pageCount: 2,
+        requestCount: 1,
+        pagination: makePagination(2, 3, 1),
+        expectedTermination: "invalid_response",
+      },
+    ];
+
+    for (const tampered of cases) {
+      let calls = 0;
+      const fake = {
+        async fetchCollection(_endpoint, options) {
+          calls += 1;
+          return makeCollectionResult({
+            items: [makePackage(`item-${calls}`)],
+            continuation: tampered.continuation(options.descriptor),
+            pageCount: tampered.pageCount,
+            requestCount: tampered.requestCount,
+            pagination: tampered.pagination,
+          });
+        },
+      };
+      const repositoryNode = new RepositoryNode(
+        { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+        { connectionManager, createPaginatedFetch: () => fake }
+      );
+      await repositoryNode.getPackages();
+      await repositoryNode.loadMorePackages();
+      assert.strictEqual(calls, 1, tampered.name);
+      assert.strictEqual(repositoryNode._packageState.continuation, null, tampered.name);
+      assert.strictEqual(
+        repositoryNode._packageState.termination,
+        tampered.expectedTermination || "invalid_continuation",
+        tampered.name
+      );
+    }
+  });
+
+  test("paginates entitlements with the shared bounded collector and reports partial data", async () => {
+    let captured;
+    const failure = collectionFailure(2, "server_error");
+    const fake = {
+      async fetchCollection(endpoint, options) {
+        captured = { endpoint, options };
+        return makeCollectionResult({
+          items: [{ name: "CI", slug_perm: "ci", is_active: true }],
+          failures: [failure],
+          failureCount: 1,
+          termination: "request_failed",
+          pageCount: 1,
+          requestCount: 2,
+          pagination: makePagination(1, 2, 50, 51),
+          cumulativeItemCount: 1,
+        });
+      },
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "packages", slug_perm: "packages", name: "Packages" }, "acme", context,
+      { connectionManager, createPaginatedFetch: () => fake }
+    );
+    const result = await repositoryNode.getEntitlementCollection();
+
+    assert.strictEqual(result.items.length, 1);
+    assert.strictEqual(result.partial, true);
+    assert.ok(captured.endpoint.includes("entitlements/acme/packages"));
+    assert.strictEqual(captured.options.pageSize, 50);
+    assert.strictEqual(captured.options.maxPages, 20);
+    assert.strictEqual(captured.options.maxRequests, 24);
+    assert.strictEqual(captured.options.maxItems, 600);
+  });
+
+  test("preserves upstream failures in the indicator instead of claiming a configured total", async () => {
+    const indicator = new UpstreamIndicatorNode(
+      [{ name: "PyPI", upstream_url: "https://pypi.org/", is_active: true }],
+      {},
+      context,
+      { complete: false, failedFormats: ["npm"] }
+    );
+    const item = indicator.getTreeItem();
+    assert.strictEqual(item.label, "Upstreams: 1 active among 1 loaded (partial)");
+    assert.ok(item.tooltip.includes("Could not load formats: npm"));
+
+    const summaryCached = new UpstreamIndicatorNode(
+      [{ name: "Summary-only PyPI", _format: "python", is_active: true }],
+      {},
+      context,
+      { complete: true }
+    ).getTreeItem();
+    assert.strictEqual(summaryCached.tooltip, "Summary-only PyPI");
+    assert(!summaryCached.tooltip.includes("undefined"));
+  });
+
+  test("entitlement summaries distinguish authoritative totals from partial collections", () => {
+    const partial = new EntitlementSummaryNode(
+      [{ name: "CI", slug_perm: "ci", is_active: true }],
+      context,
+      { complete: false, totalCount: 51, failureCount: 1, termination: "request_failed" }
+    );
+    assert.strictEqual(
+      partial.getTreeItem().label,
+      "Entitlement tokens: 1 active among 1 loaded (partial)"
+    );
+    assert.ok(partial.getTreeItem().tooltip.includes("1 of 51"));
+    assert.strictEqual(partial.getChildren()[0].getTreeItem().label, "Entitlement list is incomplete");
+
+    const complete = new EntitlementSummaryNode([
+      { name: "CI", slug_perm: "ci", is_active: true },
+      { name: "Legacy", slug_perm: "legacy", is_active: false },
+    ], context, { complete: true, totalCount: 2 });
+    assert.strictEqual(complete.getTreeItem().label, "Entitlement tokens: 1 active of 2");
   });
 });

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -1234,7 +1234,11 @@ suite("RepositoryNode Test Suite", () => {
 
   test("preserves upstream failures in the indicator instead of claiming a configured total", async () => {
     const indicator = new UpstreamIndicatorNode(
-      [{ name: "PyPI", upstream_url: "https://pypi.org/", is_active: true }],
+      [{
+        name: "PyPI",
+        upstream_url: "https://user:pass@pypi.org/simple/?token=secret#fragment",
+        is_active: true,
+      }],
       {},
       context,
       { complete: false, failedFormats: ["npm"] }
@@ -1242,6 +1246,11 @@ suite("RepositoryNode Test Suite", () => {
     const item = indicator.getTreeItem();
     assert.strictEqual(item.label, "Upstreams: 1 active among 1 loaded (partial)");
     assert.ok(item.tooltip.includes("Could not load formats: npm"));
+    assert.ok(item.tooltip.includes("PyPI (https://pypi.org)"));
+    assert.ok(!item.tooltip.includes("user:pass"));
+    assert.ok(!item.tooltip.includes("/simple/"));
+    assert.ok(!item.tooltip.includes("token=secret"));
+    assert.ok(!item.tooltip.includes("#fragment"));
 
     const summaryCached = new UpstreamIndicatorNode(
       [{ name: "Summary-only PyPI", _format: "python", is_active: true }],
@@ -1249,8 +1258,23 @@ suite("RepositoryNode Test Suite", () => {
       context,
       { complete: true }
     ).getTreeItem();
-    assert.strictEqual(summaryCached.tooltip, "Summary-only PyPI");
+    assert.strictEqual(summaryCached.tooltip, "Summary-only PyPI (Origin unavailable)");
     assert(!summaryCached.tooltip.includes("undefined"));
+  });
+
+  test("upstream tooltip handles missing and malformed URLs and caps displayed entries", () => {
+    const upstreams = Array.from({ length: 21 }, (_, index) => ({
+      name: `Mirror ${index}`,
+      upstream_url: index === 0 ? undefined : (index === 1 ? "not a URL" : `https://m${index}.example/path`),
+      is_active: true,
+    }));
+    const item = new UpstreamIndicatorNode(upstreams, {}, context, { complete: true }).getTreeItem();
+
+    assert.ok(item.tooltip.includes("Mirror 0 (Origin unavailable)"));
+    assert.ok(item.tooltip.includes("Mirror 1 (Origin unavailable)"));
+    assert.ok(item.tooltip.includes("Showing 20 of 21 loaded upstreams."));
+    assert.ok(!item.tooltip.includes("not a URL"));
+    assert.ok(!item.tooltip.includes("Mirror 20"));
   });
 
   test("entitlement summaries distinguish authoritative totals from partial collections", () => {

--- a/test/searchIntent.test.js
+++ b/test/searchIntent.test.js
@@ -31,6 +31,10 @@ suite("search intent command boundary", () => {
       filterState: { clear: clear("filter") },
       recentPackages: { clear: clear("recent") },
       clearVulnerabilityCache: clear("vulnerability"),
+      vulnerabilityProvider: { resetForAccountChange: clear("vulnerability-panel") },
+      quarantineExplainProvider: { resetForAccountChange: clear("quarantine-panel") },
+      upstreamPreviewProvider: { resetForAccountChange: clear("upstream-preview-panel") },
+      upstreamDetailProvider: { resetForAccountChange: clear("upstream-detail-panel") },
       dependencyHealthProvider: {
         async resetForAccountChange() {
           order.push("dependency");
@@ -47,22 +51,30 @@ suite("search intent command boundary", () => {
       },
     });
 
-    assert.deepStrictEqual(order.slice(0, 5), [
+    assert.deepStrictEqual(order.slice(0, 9), [
       "workspace",
       "search",
       "filter",
       "recent",
       "vulnerability",
+      "vulnerability-panel",
+      "quarantine-panel",
+      "upstream-preview-panel",
+      "upstream-detail-panel",
     ]);
     assert.deepStrictEqual([...cleared].sort(), [
       "filter",
+      "quarantine-panel",
       "recent",
       "search",
       "upstream",
+      "upstream-detail-panel",
+      "upstream-preview-panel",
       "vulnerability",
+      "vulnerability-panel",
       "workspace",
     ]);
-    assert.deepStrictEqual(order.slice(5), ["dependency", "projection:false", "upstream"]);
+    assert.deepStrictEqual(order.slice(9), ["dependency", "projection:false", "upstream"]);
     assert.deepStrictEqual(outcome.asyncResults.map(result => result.status), [
       "rejected",
       "rejected",

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -33,6 +33,27 @@ suite("SearchProvider atomic search state", () => {
     assert(Object.isFrozen(provider.state.committed.diagnostics));
   });
 
+  test("preserves an unknown total for page-total-only single-scope search", async () => {
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async () => page([pkg("one"), pkg("two")], {
+        pageSize: 2,
+        pageTotal: 2,
+        count: null,
+        countAuthoritative: false,
+      }),
+    });
+
+    await provider.search("workspace-a", "name:artifact");
+
+    assert.strictEqual(provider.state.committed.totalCount, null);
+    const items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.match(items[0].description, /2 packages loaded \(more available\)/);
+    const loadMore = items.find(item => item.label.startsWith("Load more results"));
+    assert.strictEqual(loadMore.label, "Load more results (2 loaded; page 1 of 2)");
+    assert(!JSON.stringify(items).includes("null total"));
+  });
+
   test("freezes the node snapshot without freezing its injected connection manager", async () => {
     const connectionManager = createConnectionManager();
     connectionManager.callerOwned = { mutable: true };
@@ -64,7 +85,7 @@ suite("SearchProvider atomic search state", () => {
       slug: { nested: "caller-owned" },
       uploaded_at: { nested: "caller-owned" },
       status_reason: { nested: "caller-owned" },
-      policy_violated: { nested: true },
+      policy_violated: true,
       max_severity: { nested: "Critical" },
       vulnerability_scan_results_url: { nested: "https://example.invalid" },
       cdn_url: { nested: "https://example.invalid" },
@@ -86,7 +107,7 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(committedNode.slug.value, null);
     assert.strictEqual(committedNode.uploaded_at.value, null);
     assert.strictEqual(committedNode.status_reason, null);
-    assert.strictEqual(committedNode.policy_violated, false);
+    assert.strictEqual(committedNode.policy_violated, true);
     assert.strictEqual(committedNode.max_severity, null);
     assert.strictEqual(committedNode.vulnerability_scan_results_url, null);
     assert.strictEqual(committedNode.cdn_url, null);
@@ -101,6 +122,28 @@ suite("SearchProvider atomic search state", () => {
     responsePackage.status_str.nested.value = "mutated";
     assert.deepStrictEqual(committedNode.tags_raw.info, ["upstream"]);
     assert.strictEqual(committedNode.status_str.value, null);
+  });
+
+  test("uses the shared vulnerability indicator contract for retained packages", async () => {
+    const packages = [
+      pkg("no-evidence"),
+      pkg("known-clean", { num_vulnerabilities: "0" }),
+      pkg("detected", { has_vulnerabilities: true }),
+      pkg("conflicting", {
+        num_vulnerabilities: 0,
+        vulnerability_scan_results_count: 2,
+      }),
+    ];
+    const { provider } = createProvider({
+      fetchPage: async () => page(packages),
+    });
+
+    await provider.search("workspace-a", "artifact");
+
+    assert.deepStrictEqual(
+      provider.searchResults.map(node => node.num_vulnerabilities),
+      [null, 0, -1, -1]
+    );
   });
 
   test("beginSearch synchronously supersedes the prior intent before either executes", async () => {
@@ -343,6 +386,17 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.state.failure.kind, "invalid_response");
   });
 
+  test("rejects malformed present package policy booleans", async () => {
+    const { provider } = createProvider({
+      fetchPage: async () => page([pkg("artifact", { deny_policy_violated: "true" })]),
+    });
+
+    await provider.search("workspace-a", "name:artifact");
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+  });
+
   test("invalid repository counts fail currently and perform no fetch", async () => {
     let fetchCount = 0;
     const { provider, messages } = createProvider({
@@ -355,13 +409,13 @@ suite("SearchProvider atomic search state", () => {
     await provider.searchRepos("workspace-a", [], "name:artifact");
     await provider.searchRepos(
       "workspace-a",
-      Array.from({ length: 101 }, (_, index) => `repo-${index}`),
+      Array.from({ length: 1001 }, (_, index) => `repo-${index}`),
       "name:artifact"
     );
 
     assert.strictEqual(fetchCount, 0);
     assert.strictEqual(provider.state.failure.kind, "invalid_request");
-    assert.match(messages.error.at(-1), /between 1 and 100/);
+    assert.match(messages.error.at(-1), /between 1 and 1,000/);
   });
 
   test("rejects over-limit descriptor and package identity strings", async () => {
@@ -390,7 +444,7 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(responseProvider.state.failure.kind, "invalid_response");
   });
 
-  test("multi-repository work uses four workers and reserves the 5000-item budget", async () => {
+  test("100 repositories are searched completely with exactly four bounded workers", async () => {
     let calls = 0;
     let active = 0;
     let maxActive = 0;
@@ -409,64 +463,189 @@ suite("SearchProvider atomic search state", () => {
 
     await provider.searchRepos("workspace-a", repositories, "name:artifact");
 
-    assert.strictEqual(calls, 50);
+    assert.strictEqual(calls, 100);
     assert.strictEqual(maxActive, 4);
     assert.strictEqual(provider.state.committed.descriptor.repositories.length, 100);
     assert(Object.isFrozen(provider.state.committed.descriptor.repositories));
-    assert.strictEqual(provider.state.committed.diagnostics.unsearchedRepositoryCount, 50);
+    assert.strictEqual(provider.state.committed.diagnostics.unsearchedRepositoryCount, 0);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, false);
+    assert.strictEqual(provider.state.committed.diagnostics.requestCount, 100);
     assert.strictEqual(provider.state.committed.pageable, false);
   });
 
-  test("reports first-page multi-repository truncation without offering paging", async () => {
-    const firstPage = Array.from({ length: 20 }, (_, index) => pkg(`artifact-${index}`));
+  test("1,000 repositories remain structurally bounded and complete", async function () {
+    this.timeout(10000);
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const repositories = Array.from({ length: 1000 }, (_, index) => `repo-${index}`);
     const { provider } = createProvider({
-      pageSize: 20,
-      fetchPage: async () => page(firstPage, {
-        pageSize: 20,
-        pageTotal: 50,
-        count: 1000,
-      }),
+      pageSize: 100,
+      fetchPage: async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await nextTurn();
+        active -= 1;
+        return page([], { pageSize: 100 });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:no-match");
+
+    assert.strictEqual(calls, 1000);
+    assert.strictEqual(maxActive, 4);
+    assert.strictEqual(provider.state.committed.diagnostics.requestCount, 1000);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, false);
+    assert.strictEqual(provider.state.committed.diagnostics.unsearchedRepositoryCount, 0);
+  });
+
+  test("FIFO reservations search every first page before any second page", async () => {
+    const calls = [];
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      pageSize: 1,
+      fetchPage: async (endpoint, requestedPage) => {
+        const repository = repositoryFromEndpoint(endpoint);
+        calls.push({ repository, page: requestedPage });
+        await nextTurn();
+        return page([pkg(`${repository}-${requestedPage}`, { repository })], {
+          requestedPage,
+          pageSize: 1,
+          pageTotal: 2,
+          count: 2,
+        });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(calls.length, 200);
+    assert(calls.slice(0, 100).every(call => call.page === 1));
+    assert(calls.slice(100).every(call => call.page === 2));
+    assert.strictEqual(new Set(calls.slice(0, 100).map(call => call.repository)).size, 100);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, false);
+  });
+
+  test("the global logical request ceiling stops at 2,000 without request amplification", async function () {
+    this.timeout(10000);
+    let calls = 0;
+    const repositories = Array.from({ length: 101 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      pageSize: 1,
+      fetchPage: async (endpoint, requestedPage) => {
+        calls += 1;
+        const repository = repositoryFromEndpoint(endpoint);
+        return page([pkg(`${repository}-${requestedPage}`, { repository })], {
+          requestedPage,
+          pageSize: 1,
+          pageTotal: 20,
+          count: 20,
+        });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(calls, 2000);
+    assert.strictEqual(provider.state.committed.diagnostics.requestCount, 2000);
+    assert.strictEqual(provider.state.committed.diagnostics.requestLimitReached, true);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+    assert(provider.state.committed.diagnostics.truncatedRepositoryCount > 0);
+  });
+
+  test("the per-repository page ceiling stops before page 21", async () => {
+    const calls = [];
+    const { provider } = createProvider({
+      pageSize: 1,
+      fetchPage: async (endpoint, requestedPage) => {
+        calls.push(requestedPage);
+        return page([pkg(`artifact-${requestedPage}`, {
+          repository: repositoryFromEndpoint(endpoint),
+        })], {
+          requestedPage,
+          pageSize: 1,
+          pageTotal: 21,
+          count: 21,
+        });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.deepStrictEqual(calls, Array.from({ length: 20 }, (_, index) => index + 1));
+    assert.strictEqual(provider.state.committed.diagnostics.pageLimitReached, true);
+    assert.strictEqual(provider.state.committed.diagnostics.truncatedRepositoryCount, 1);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+  });
+
+  test("discovers later-page results and completes anchored repository pagination", async () => {
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => requestedPage === 1
+        ? page([pkg("artifact-1"), pkg("artifact-2")], {
+          pageSize: 2,
+          pageTotal: 2,
+          count: 3,
+        })
+        : page([pkg("artifact-3")], {
+          requestedPage: 2,
+          pageSize: 2,
+          pageTotal: 2,
+          count: 3,
+        }),
     });
 
     await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
 
     const committed = provider.state.committed;
-    assert.strictEqual(committed.results.length, 20);
-    assert.strictEqual(committed.totalCount, 1000);
+    assert.deepStrictEqual(committed.results.map(node => node.name), [
+      "artifact-1", "artifact-2", "artifact-3",
+    ]);
+    assert.strictEqual(committed.totalCount, 3);
     assert.strictEqual(committed.pageable, false);
-    assert.strictEqual(committed.diagnostics.truncatedRepositoryCount, 1);
-    assert.strictEqual(committed.diagnostics.truncatedResultCount, 980);
-    assert.strictEqual(committed.diagnostics.partial, true);
-    assert.strictEqual(committed.diagnostics.capReached, true);
-    assert.strictEqual(committed.diagnostics.truncationDetails.length, 1);
-    assert(Object.isFrozen(committed.diagnostics.truncationDetails));
-    assert(Object.isFrozen(committed.diagnostics.truncationDetails[0]));
+    assert.strictEqual(committed.diagnostics.truncatedRepositoryCount, 0);
+    assert.strictEqual(committed.diagnostics.partial, false);
+    assert.strictEqual(committed.diagnostics.requestCount, 2);
+    assert.strictEqual(committed.diagnostics.pageCount, 2);
 
     const items = (await provider.getChildren()).map(node => node.getTreeItem());
-    assert.match(items[0].description, /20 of 1,000 matching packages loaded \(partial\)/);
-    assert(items.some(item => /additional matching pages/.test(item.label)));
+    assert.match(items[0].description, /3 packages/);
     assert.strictEqual(items.some(item => item.contextValue === "loadMore"), false);
   });
 
   test("multi-repository cancellation stops scheduling and preserves prior state", async () => {
     const token = { isCancellationRequested: false };
     let calls = 0;
+    let active = 0;
+    const requests = [];
     const { provider, messages } = createProvider({
       cancellationToken: token,
       fetchPage: async () => {
         calls += 1;
-        token.isCancellationRequested = true;
-        return failedPage("cancelled");
+        active += 1;
+        const request = deferred();
+        requests.push(request);
+        const result = await request.promise;
+        active -= 1;
+        return result;
       },
     });
 
-    await provider.searchRepos(
+    const search = provider.searchRepos(
       "workspace-a",
       Array.from({ length: 20 }, (_, index) => `repo-${index}`),
       "name:artifact"
     );
+    await nextTurn();
+    assert.strictEqual(calls, 4);
+    assert.strictEqual(active, 4);
+    token.isCancellationRequested = true;
+    for (const request of requests) request.resolve(failedPage("cancelled"));
+    await search;
 
-    assert(calls <= 4);
+    assert.strictEqual(calls, 4);
+    assert.strictEqual(active, 0);
     assert.strictEqual(provider.state.committed, null);
     assert.strictEqual(provider.state.failure, null);
     assert.deepStrictEqual(messages.error, []);
@@ -495,6 +674,126 @@ suite("SearchProvider atomic search state", () => {
     assert.match(messages.warning[0], /and 5 more/);
   });
 
+  test("99 successful repositories survive one repository failure", async () => {
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider, messages } = createProvider({
+      fetchPage: async endpoint => {
+        const repository = repositoryFromEndpoint(endpoint);
+        if (repository === "repo-99") return failedPage("forbidden");
+        return page([pkg(`artifact-${repository}`, { repository })]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(provider.searchResults.length, 99);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+    assert.strictEqual(messages.warning.length, 1);
+    assert.strictEqual(messages.information.length, 0);
+  });
+
+  test("HTTP 429 opens the circuit, settles active workers, and schedules no queued work", async () => {
+    let calls = 0;
+    let active = 0;
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      fetchPage: async endpoint => {
+        calls += 1;
+        active += 1;
+        const repository = repositoryFromEndpoint(endpoint);
+        await nextTurn();
+        active -= 1;
+        if (repository === "repo-0") return failedPage("rate_limited");
+        return page([pkg(`artifact-${repository}`, { repository })]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(active, 0);
+    assert.strictEqual(calls, 4);
+    assert.strictEqual(provider.state.committed.diagnostics.rateLimited, true);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+    assert(provider.state.committed.diagnostics.unsearchedRepositoryCount >= 96);
+    assert(provider.searchResults.length > 0);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+  });
+
+  test("a thrown repository request releases its worker and does not starve later work", async () => {
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      fetchPage: async endpoint => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        const repository = repositoryFromEndpoint(endpoint);
+        await nextTurn();
+        active -= 1;
+        if (repository === "repo-0") throw new Error("secret transport detail");
+        return page([pkg(`artifact-${repository}`, { repository })]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(calls, 100);
+    assert.strictEqual(active, 0);
+    assert.strictEqual(maxActive, 4);
+    assert.strictEqual(provider.searchResults.length, 99);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+  });
+
+  test("an unexpected page-processing exception settles every worker and preserves successes", async () => {
+    let calls = 0;
+    let active = 0;
+    const repositories = Array.from({ length: 100 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      fetchPage: async endpoint => {
+        calls += 1;
+        active += 1;
+        const repository = repositoryFromEndpoint(endpoint);
+        await nextTurn();
+        active -= 1;
+        if (repository === "repo-0") {
+          return {
+            data: [],
+            get pagination() { throw new Error("untrusted accessor"); },
+            error: null,
+          };
+        }
+        return page([pkg(`artifact-${repository}`, { repository })]);
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(calls, 4);
+    assert.strictEqual(active, 0);
+    assert.strictEqual(provider.searchResults.length, 3);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+  });
+
+  test("an incomplete empty multi-repository result is never announced as no packages", async () => {
+    const { provider, messages } = createProvider({
+      fetchPage: async endpoint => repositoryFromEndpoint(endpoint) === "repo-a"
+        ? page([])
+        : failedPage("forbidden"),
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a", "repo-b"], "name:missing");
+
+    assert.strictEqual(provider.searchResults.length, 0);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+    assert.strictEqual(messages.information.length, 0);
+    const summary = (await provider.getChildren())[0].getTreeItem();
+    assert.match(summary.description, /incomplete/);
+  });
+
   test("all repository failures preserve the prior committed session", async () => {
     let fail = false;
     const { provider } = createProvider({
@@ -510,7 +809,7 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.state.failure.descriptor.kind, "repositories");
   });
 
-  test("deduplicates by namespace, repository, and canonical slug_perm", async () => {
+  test("fails a single-scope page closed when it repeats a canonical package identity", async () => {
     const duplicate = pkg("artifact");
     const { provider } = createProvider({
       fetchPage: async () => page([duplicate, { ...duplicate }]),
@@ -518,7 +817,209 @@ suite("SearchProvider atomic search state", () => {
 
     await provider.search("workspace-a", "name:artifact");
 
-    assert.strictEqual(provider.searchResults.length, 1);
+    assert.strictEqual(provider.searchResults.length, 0);
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+  });
+
+  test("a repeated identity is terminal and incomplete for that repository", async () => {
+    const repeated = pkg("artifact");
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls += 1;
+        if (requestedPage === 1) {
+          return page([repeated, pkg("second")], {
+            pageSize: 2,
+            pageTotal: 2,
+            count: 4,
+          });
+        }
+        return page([{ ...repeated }, pkg("fourth")], {
+          requestedPage: 2,
+          pageSize: 2,
+          pageTotal: 2,
+          count: 4,
+        });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.strictEqual(calls, 2);
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["artifact", "second"]);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+  });
+
+  test("a conflicting canonical identity fails closed without publishing both records", async () => {
+    const sharedIdentity = "immutable-id";
+    const { provider } = createProvider({
+      fetchPage: async () => page([
+        pkg("artifact-a", { slug_perm: sharedIdentity }),
+        pkg("artifact-b", { slug_perm: sharedIdentity }),
+      ], { pageSize: 2, count: 2 }),
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), []);
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+    assert.match(provider.state.failure.message, /conflicting records/);
+  });
+
+  test("cross-page pagination metadata changes preserve prior pages as incomplete", async () => {
+    const { provider } = createProvider({
+      pageSize: 1,
+      fetchPage: async (_endpoint, requestedPage) => requestedPage === 1
+        ? page([pkg("first")], { pageSize: 1, pageTotal: 2, count: 2 })
+        : page([pkg("second")], {
+          requestedPage: 2,
+          pageSize: 1,
+          pageTotal: 3,
+          count: 3,
+        }),
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["first"]);
+    assert.strictEqual(provider.state.committed.diagnostics.failedRepositoryCount, 1);
+    assert.match(provider.state.committed.diagnostics.failureDetails[0].message, /changed pagination metadata/);
+  });
+
+  test("a short authoritative non-final page terminates without requesting another page", async () => {
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async () => {
+        calls += 1;
+        return page([pkg("only-one")], { pageSize: 2, pageTotal: 2, count: 3 });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+  });
+
+  test("page-total-only metadata permits a full non-final page and bounded final page", async () => {
+    const calls = [];
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls.push(requestedPage);
+        return requestedPage === 1
+          ? page([pkg("first"), pkg("second")], {
+            pageSize: 2,
+            pageTotal: 2,
+            count: null,
+            countAuthoritative: false,
+          })
+          : page([pkg("third")], {
+            requestedPage: 2,
+            pageSize: 2,
+            pageTotal: 2,
+            count: null,
+            countAuthoritative: false,
+          });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "name:artifact");
+
+    assert.deepStrictEqual(calls, [1, 2]);
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["first", "second", "third"]);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, false);
+  });
+
+  test("multi-repository result retention is capped with only bounded in-flight overflow", async () => {
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    const repositories = Array.from({ length: 60 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      pageSize: 100,
+      fetchPage: async endpoint => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        const repository = repositoryFromEndpoint(endpoint);
+        await nextTurn();
+        active -= 1;
+        return page(Array.from({ length: 100 }, (_, index) => (
+          pkg(`${repository}-${index}`, { repository })
+        )), { pageSize: 100, count: 100 });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(provider.searchResults.length, 5000);
+    assert.strictEqual(maxActive, 4);
+    assert(calls >= 50 && calls <= 53);
+    assert(calls * 100 <= 5300);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+    assert.strictEqual(provider.state.committed.diagnostics.capReached, true);
+    assert(provider.state.committed.diagnostics.droppedResultCount <= 300);
+  });
+
+  test("exactly 5,000 complete results do not imply omitted work", async () => {
+    const repositories = Array.from({ length: 50 }, (_, index) => `repo-${index}`);
+    const { provider } = createProvider({
+      pageSize: 100,
+      fetchPage: async endpoint => {
+        const repository = repositoryFromEndpoint(endpoint);
+        return page(Array.from({ length: 100 }, (_, index) => (
+          pkg(`${repository}-${index}`, { repository })
+        )), { pageSize: 100, count: 100 });
+      },
+    });
+
+    await provider.searchRepos("workspace-a", repositories, "name:artifact");
+
+    assert.strictEqual(provider.searchResults.length, 5000);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, false);
+    assert.strictEqual(provider.state.committed.diagnostics.capReached, false);
+    const labels = (await provider.getChildren()).map(node => node.getTreeItem().label);
+    assert.strictEqual(labels.includes("Showing the first 5,000 results"), false);
+  });
+
+  test("a stale multi-repository run settles without publishing over the current search", async () => {
+    const slow = deferred();
+    let activeSlow = 0;
+    const { provider, messages } = createProvider({
+      fetchPage: async (endpoint, _requestedPage, _pageSize, query) => {
+        const repository = repositoryFromEndpoint(endpoint);
+        if (query === "slow") {
+          activeSlow += 1;
+          const result = await slow.promise;
+          activeSlow -= 1;
+          return result;
+        }
+        return page([pkg("current", { repository })]);
+      },
+    });
+
+    const staleSearch = provider.searchRepos(
+      "workspace-a",
+      ["repo-a", "repo-b"],
+      "slow"
+    );
+    await nextTurn();
+    assert.strictEqual(activeSlow, 2);
+    await provider.searchRepos("workspace-a", ["repo-current"], "current");
+    slow.resolve(page([pkg("stale")]));
+    await staleSearch;
+
+    assert.strictEqual(activeSlow, 0);
+    assert.strictEqual(provider.currentQuery, "current");
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["current"]);
+    assert.deepStrictEqual(messages.error, []);
   });
 
   test("duplicate next-page commands return the same promise and fetch once", async () => {
@@ -599,7 +1100,7 @@ suite("SearchProvider atomic search state", () => {
     assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["new"]);
   });
 
-  test("stops page accumulation at 5000 and replaces Load More with truthful guidance", async function () {
+  test("stops single-scope pagination at the cumulative page limit", async function () {
     this.timeout(5000);
     let calls = 0;
     const { provider } = createProvider({
@@ -619,18 +1120,70 @@ suite("SearchProvider atomic search state", () => {
     });
     await provider.search("workspace-a", "name:artifact");
 
-    for (let pageNumber = 2; pageNumber <= 50; pageNumber += 1) {
+    for (let pageNumber = 2; pageNumber <= 20; pageNumber += 1) {
       await provider.loadNextPage();
     }
 
-    assert.strictEqual(calls, 50);
-    assert.strictEqual(provider.searchResults.length, 5000);
-    assert.strictEqual(provider.currentPage, 50);
+    assert.strictEqual(calls, 20);
+    assert.strictEqual(provider.searchResults.length, 2000);
+    assert.strictEqual(provider.currentPage, 20);
     assert.strictEqual(provider.state.committed.pageable, false);
     assert.strictEqual(provider.state.committed.diagnostics.capReached, true);
+    assert.strictEqual(provider.state.committed.diagnostics.pageLimitReached, true);
     const labels = (await provider.getChildren()).map(node => node.getTreeItem().label);
-    assert(labels.includes("Showing the first 5,000 results"));
+    assert(labels.includes("Search loading limit reached"));
     assert(!labels.some(label => label.startsWith("Load more results")));
+  });
+
+  test("invalid continuation metadata is terminal and cannot amplify requests", async () => {
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls += 1;
+        if (requestedPage === 1) {
+          return page([pkg("one"), pkg("two")], { pageSize: 2, pageTotal: 2, count: 3 });
+        }
+        return page([pkg("three")], {
+          requestedPage: 2,
+          pageSize: 2,
+          pageTotal: 3,
+          count: 5,
+        });
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    await provider.loadNextPage();
+    await provider.loadNextPage();
+
+    assert.strictEqual(calls, 2);
+    assert.strictEqual(provider.state.committed.pageable, false);
+    assert.strictEqual(provider.state.committed.diagnostics.partial, true);
+    assert.strictEqual(provider.state.failure.kind, "invalid_response");
+  });
+
+  test("transient continuation retries consume a cumulative request budget", async () => {
+    let calls = 0;
+    const { provider } = createProvider({
+      pageSize: 2,
+      fetchPage: async (_endpoint, requestedPage) => {
+        calls += 1;
+        return requestedPage === 1
+          ? page([pkg("one"), pkg("two")], { pageSize: 2, pageTotal: 2, count: 3 })
+          : failedPage("rate_limited", 2, 2);
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await provider.loadNextPage();
+    }
+
+    assert.strictEqual(calls, 24);
+    assert.strictEqual(provider.state.committed.diagnostics.requestCount, 24);
+    assert.strictEqual(provider.state.committed.diagnostics.requestLimitReached, true);
+    assert.strictEqual(provider.state.committed.pageable, false);
   });
 
   test("clear invalidates a pending root and publishes no later result", async () => {
@@ -733,12 +1286,15 @@ function pkg(name, overrides = {}) {
 function page(data, options = {}) {
   const requestedPage = options.requestedPage || 1;
   const pageTotal = options.pageTotal || requestedPage;
+  const hasCount = Object.prototype.hasOwnProperty.call(options, "count");
+  const hasCountAuthority = Object.prototype.hasOwnProperty.call(options, "countAuthoritative");
   return {
     data,
     pagination: {
       page: requestedPage,
       pageTotal,
-      count: options.count ?? data.length,
+      count: hasCount ? options.count : data.length,
+      ...(hasCountAuthority ? { countAuthoritative: options.countAuthoritative } : {}),
       pageSize: options.pageSize || 50,
     },
     error: null,

--- a/test/terraformExporter.test.js
+++ b/test/terraformExporter.test.js
@@ -236,4 +236,22 @@ suite("TerraformExporter Test Suite", () => {
     assert.ok(output.includes("# Could not load upstream data. Add upstream resources manually."));
     assert.ok(!output.includes("cloudsmith_repository_upstream"));
   });
+
+  test("partial upstream export keeps verified resources and marks the file incomplete", () => {
+    const output = generateTerraformConfig({
+      repo: { name: "Partial Repo", slug: "partial-repo" },
+      workspace,
+      upstreams: [{
+        name: "npm",
+        format: "npm",
+        upstream_url: "https://registry.npmjs.org/",
+      }],
+      upstreamLoadPartial: true,
+      upstreamFailedFormats: ["python"],
+      exportedAt,
+    });
+
+    assert.match(output, /Upstream data is incomplete for: python/);
+    assert.ok(output.includes('resource "cloudsmith_repository_upstream"'));
+  });
 });

--- a/test/terraformExporter.test.js
+++ b/test/terraformExporter.test.js
@@ -93,6 +93,102 @@ suite("TerraformExporter Test Suite", () => {
     assert.ok(output.includes('upstream_url  = "https://pypi.org"'));
   });
 
+  test("omits unsafe upstream URLs without exposing secrets or dropping safe siblings", () => {
+    const unsafeUrls = [
+      "https://user:pass@example.com/private",
+      "https://example.com/private?token=query-secret",
+      "https://example.com/private#fragment-secret",
+      "https://example.com/private?",
+      "https://example.com/private#",
+      "https://example.com/private\\normalized-secret",
+      "https:example.com/missing-authority",
+      "https:///example.com/extra-authority-slash",
+      "https:////example.com/many-authority-slashes",
+      "https://example.com/%2e%2e/dot-secret",
+      "file:///tmp/path-secret",
+      "not-a-url-secret",
+    ];
+    const output = generateTerraformConfig({
+      repo: { name: "Proxy Repo", slug: "proxy-repo" },
+      workspace,
+      upstreams: [
+        {
+          name: "Safe mirror",
+          format: "python",
+          upstream_url: "https://safe.example:8443/simple/%3Fencoded",
+        },
+        ...unsafeUrls.map((upstream_url, index) => ({
+          name: `Unsafe ${index}`,
+          format: "npm",
+          upstream_url,
+        })),
+        { name: "Missing URL", format: "ruby" },
+      ],
+      exportedAt,
+    });
+
+    assert.ok(output.includes('upstream_url  = "https://safe.example:8443/simple/%3Fencoded"'));
+    assert.ok(output.includes("13 upstream resources were omitted"));
+    assert.ok(!output.includes("Missing URL"));
+    for (const secret of [
+      "user:pass",
+      "private?",
+      "fragment-secret",
+      "normalized-secret",
+      "missing-authority",
+      "extra-authority-slash",
+      "many-authority-slashes",
+      "dot-secret",
+      "path-secret",
+      "not-a-url-secret",
+    ]) {
+      assert.ok(!output.includes(secret), secret);
+    }
+  });
+
+  test("escapes Terraform template introducers in URLs and other string fields", () => {
+    const output = generateTerraformConfig({
+      repo: {
+        name: "Template Repo",
+        slug: "template-repo",
+        description: 'description %{ if file("/private") }',
+      },
+      workspace,
+      upstreams: [{
+        name: "Template mirror",
+        format: "python",
+        upstream_url: 'https://example.com/${file("/etc/passwd")}',
+      }],
+      exportedAt,
+    });
+
+    assert.ok(output.includes('$${file(\\"/etc/passwd\\")}'));
+    assert.ok(output.includes('description %%{ if file(\\"/private\\") }'));
+    assert.ok(!output.includes('https://example.com/${file'));
+    assert.ok(!output.includes('description %{ if'));
+  });
+
+  test("keeps dynamic Terraform header values on one bounded comment line", () => {
+    const output = generateTerraformConfig({
+      repo: {
+        name: 'safe\nresource "evil" "x" {}\u202e',
+        slug: "safe-repo",
+      },
+      workspace: "acme\nmodule evil {}",
+      exportedAt: "now\u2028resource evil {}",
+    });
+
+    assert.ok(output.includes(
+      '# Terraform configuration for repository "safe resource "evil" "x" {}" in workspace "acme module evil {}"'
+    ));
+    assert.ok(output.includes("# Exported at now resource evil {}"));
+    assert.ok(!output.includes('\nresource "evil"'));
+    assert.ok(!output.includes("\nmodule evil"));
+    const header = output.split("\n").slice(0, 2).join("\n");
+    assert.ok(!header.includes("\u202e"));
+    assert.ok(!header.includes("\u2028"));
+  });
+
   test("upstream auth exports variable placeholders instead of secrets", () => {
     const output = generateTerraformConfig({
       repo: {

--- a/test/terraformExporterFetch.test.js
+++ b/test/terraformExporterFetch.test.js
@@ -21,13 +21,16 @@ suite("TerraformExporter Fetch Test Suite", () => {
 
   test("keeps upstream data when some formats fail", async () => {
     const upstreamChecker = require(upstreamCheckerPath);
-    upstreamChecker.getAllUpstreamData = async () => ({
-      upstreams: [{ name: "PyPI", _format: "python", upstream_url: "https://pypi.org/" }],
-      active: 1,
-      total: 1,
-      failedFormats: ["alpine"],
-      successfulFormats: 1,
-    });
+    upstreamChecker.getAllUpstreamData = async (_context, _workspace, _repo, options) => {
+      assert.strictEqual(options.bypassCache, true);
+      return {
+        upstreams: [{ name: "PyPI", _format: "python", upstream_url: "https://pypi.org/" }],
+        active: 1,
+        total: 1,
+        failedFormats: ["alpine"],
+        successfulFormats: 1,
+      };
+    };
 
     const { fetchRepositoryUpstreams } = require(terraformExporterPath);
     const result = await fetchRepositoryUpstreams({}, "acme", "example-repo");
@@ -35,6 +38,28 @@ suite("TerraformExporter Fetch Test Suite", () => {
     assert.strictEqual(result.error, null);
     assert.strictEqual(result.data.length, 1);
     assert.deepStrictEqual(result.failedFormats, ["alpine"]);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, true);
+  });
+
+  test("reports scheduler-uninspected formats without discarding successful data", async () => {
+    const upstreamChecker = require(upstreamCheckerPath);
+    upstreamChecker.getAllUpstreamData = async () => ({
+      upstreams: [{ name: "npm", _format: "npm", upstream_url: "https://registry.npmjs.org/" }],
+      active: 1,
+      total: 1,
+      failedFormats: [],
+      uninspectedFormats: ["python"],
+      successfulFormats: 1,
+      complete: false,
+    });
+
+    const { fetchRepositoryUpstreams } = require(terraformExporterPath);
+    const result = await fetchRepositoryUpstreams({}, "acme", "example-repo");
+
+    assert.strictEqual(result.error, null);
+    assert.strictEqual(result.partial, true);
+    assert.deepStrictEqual(result.uninspectedFormats, ["python"]);
   });
 
   test("reports an error only when no upstream data is available", async () => {

--- a/test/treeVisualization.test.js
+++ b/test/treeVisualization.test.js
@@ -190,8 +190,8 @@ suite("tree visualization", () => {
     const summary = buildDependencySummary([tree], [tree], {});
     const report = buildDependencyHealthReport("fixture-app", tree.dependencies, summary, "2026-04-05");
 
-    assert.match(report, /## Vulnerable Dependencies/);
-    assert.match(report, /\| shared-lib \| 1.0.0 \| Transitive \| High \| CVE-2024-1234 \| Yes \(1.0.1\) \|/);
+    assert.match(report, /## Dependency Vulnerability Status/);
+    assert.match(report, /\| shared-lib \| 1.0.0 \| Transitive \| High \| Detected \| Yes \(1.0.1\) \|/);
     assert.match(report, /## Uncovered Dependencies/);
     assert.match(report, /\| missing-lib \| 0.1.0 \| npm \| Reachable \| npm proxy on production \|/);
   });

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -122,7 +122,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       successfulFormats: 1,
       groupedUpstreams: {
         python: [
-          { name: "PyPI" },
+          { name: "PyPI", _format: "python", format: "python" },
         ],
       },
       ...overrides,
@@ -149,7 +149,8 @@ suite("UpstreamChecker repository upstream cache", () => {
           name: "PyPI",
           upstream_url: "https://user:path-secret@example.com/path-secret?token=query-secret",
           api_key: "never-persist",
-          mode: { nested_secret: "nested-secret" },
+          mode: "proxy_only",
+          opaque_metadata: { nested_secret: "nested-secret" },
         },
         { name: "Internal mirror", upstream_url: "https://mirror.example/python" },
         { name: "Legacy", upstream_url: "https://legacy.example/python" },
@@ -193,6 +194,25 @@ suite("UpstreamChecker repository upstream cache", () => {
     assert.strictEqual(secondState.groupedUpstreams.get("python")[0].name, "Internal mirror");
   });
 
+  test("repository workflow inspection requests only the relevant formats", async () => {
+    formatResponses = {
+      npm: [{ name: "npmjs", upstream_url: "https://registry.npmjs.org/" }],
+      python: [{ name: "PyPI", upstream_url: "https://pypi.org/" }],
+    };
+    const checker = createChecker({});
+
+    const state = await checker.getRepositoryUpstreamStateForFormats(
+      "workspace-a",
+      "repo-a",
+      ["npm"]
+    );
+
+    assert.strictEqual(requestCount, 1);
+    assert.strictEqual(state.complete, true);
+    assert.deepStrictEqual([...state.groupedUpstreams.keys()], ["npm"]);
+    assert.deepStrictEqual(state.upstreams.map(upstream => upstream.name), ["npmjs"]);
+  });
+
   test("does not cache partial upstream data when any format fails", async () => {
     formatResponses = {
       python: [
@@ -226,6 +246,23 @@ suite("UpstreamChecker repository upstream cache", () => {
     assert.strictEqual(state.active, 0);
     assert.strictEqual(state.total, 0);
     assert.ok(state.failedFormats.includes("python"));
+    assert.strictEqual(store.size, 0);
+  });
+
+  test("rejects malformed active fields instead of treating them as active upstreams", async () => {
+    formatResponses = { python: [{ name: "PyPI", is_active: "false" }] };
+
+    const checker = createChecker(context);
+    const state = await checker.getRepositoryUpstreamStateForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python"]
+    );
+
+    assert.strictEqual(state.complete, false);
+    assert.strictEqual(state.active, 0);
+    assert.strictEqual(state.total, 0);
+    assert.deepStrictEqual(state.failedFormats, ["python"]);
     assert.strictEqual(store.size, 0);
   });
 
@@ -278,15 +315,25 @@ suite("UpstreamChecker repository upstream cache", () => {
   test("accepts a valid cached repository upstream state", () => {
     const checker = createChecker(context);
     const cacheKey = checker._getRepositoryUpstreamCacheKey("workspace-a", "repo-a");
-    store.set(cacheKey, createCachedEntry({ successfulFormats: 7 }));
+    store.set(cacheKey, createCachedEntry({ successfulFormats: SUPPORTED_UPSTREAM_FORMATS.length }));
 
     const cachedState = checker._getCachedRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.ok(cachedState);
-    assert.strictEqual(cachedState.successfulFormats, 7);
+    assert.strictEqual(cachedState.successfulFormats, SUPPORTED_UPSTREAM_FORMATS.length);
     assert.strictEqual(cachedState.total, 1);
     assert.strictEqual(cachedState.active, 1);
     assert.strictEqual(cachedState.groupedUpstreams.get("python").length, 1);
+  });
+
+  test("evicts repository cache entries that do not prove every supported format was inspected", async () => {
+    const checker = createChecker(context);
+    const cacheKey = checker._getRepositoryUpstreamCacheKey("workspace-a", "repo-a");
+    store.set(cacheKey, createCachedEntry({ successfulFormats: SUPPORTED_UPSTREAM_FORMATS.length - 1 }));
+
+    assert.strictEqual(checker._getCachedRepositoryUpstreamState("workspace-a", "repo-a"), null);
+    await Promise.resolve();
+    assert.strictEqual(store.has(cacheKey), false);
   });
 
   test("returns computed upstream state when repository cache persistence fails", async () => {
@@ -469,7 +516,8 @@ suite("UpstreamChecker shared helper and format handling", () => {
         {
           name: "PyPI",
           upstream_url: "https://user:url-secret@example.com/url-secret?token=url-secret",
-          mode: { token: "nested-secret" },
+          mode: "proxy_only",
+          opaque_metadata: { token: "nested-secret" },
         },
         { name: "Internal mirror", upstream_url: "https://mirror.example/python" },
         { name: "Legacy", upstream_url: "https://legacy.example/python" },
@@ -653,6 +701,93 @@ suite("UpstreamChecker shared helper and format handling", () => {
     assert.strictEqual(updates[0].value, undefined);
   });
 
+  test("evicts flat cache entries whose completion count does not match the requested formats", async () => {
+    const { context, store, updates } = createContext();
+    const { checker, getRequestCount } = createResponseAwareChecker(context, {});
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a", ["python", "npm"]);
+    store.set(cacheKey, createCachedEntry({ successfulFormats: 1 }));
+
+    const result = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python", "npm"]
+    );
+
+    assert.strictEqual(getRequestCount(), 2);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(updates[0].key, cacheKey);
+    assert.strictEqual(updates[0].value, undefined);
+  });
+
+  test("bypassCache refetches runtime upstream details instead of serving a summary-only warm cache", async () => {
+    const { context, store } = createContext();
+    const { checker, getRequestCount } = createResponseAwareChecker(context, {
+      python: [{ name: "PyPI", upstream_url: "https://pypi.org/simple/" }],
+    });
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a", ["python"]);
+    store.set(cacheKey, createCachedEntry());
+
+    const result = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python"],
+      { bypassCache: true }
+    );
+
+    assert.strictEqual(getRequestCount(), 1);
+    assert.strictEqual(result.upstreams[0].upstream_url, "https://pypi.org/simple/");
+  });
+
+  test("evicts cached upstream summaries with duplicate, conflicting, or stale derived metadata", async () => {
+    const { context, store, updates } = createContext();
+    const { checker } = createResponseAwareChecker(context, {});
+    const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a", ["python"]);
+    for (const poisoned of [
+      createCachedEntry({
+        upstreams: [
+          { name: "PyPI", _format: "python", format: "python", is_active: true },
+          { name: "PyPI", _format: "python", format: "python", is_active: true },
+        ],
+        active: 2,
+        total: 2,
+      }),
+      createCachedEntry({
+        upstreams: [{ name: "PyPI", _format: "python", format: "npm", is_active: true }],
+      }),
+      createCachedEntry({ active: 0 }),
+    ]) {
+      store.set(cacheKey, poisoned);
+      await checker.getUpstreamDataForFormats("workspace-a", "repo-a", ["python"]);
+      assert.strictEqual(updates[updates.length - 2].value, undefined);
+    }
+  });
+
+  test("rejects duplicate and format-conflicting upstream records", async () => {
+    const { checker } = createResponseAwareChecker(createContext().context, {
+      python: [
+        { name: "PyPI", format: "python" },
+        { name: "PyPI", format: "python" },
+      ],
+      npm: [{ name: "npmjs", format: "python" }],
+    });
+
+    const duplicate = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-a",
+      ["python"]
+    );
+    const conflicting = await checker.getUpstreamDataForFormats(
+      "workspace-a",
+      "repo-b",
+      ["npm"]
+    );
+
+    assert.deepStrictEqual(duplicate.upstreams, []);
+    assert.deepStrictEqual(duplicate.failedFormats, ["python"]);
+    assert.strictEqual(duplicate.complete, false);
+    assert.deepStrictEqual(conflicting.failedFormats, ["npm"]);
+  });
+
   test("evicts a flat cache envelope containing nested secret-bearing fields", async () => {
     const { context, store, updates } = createContext();
     const { checker } = createResponseAwareChecker(context, {});
@@ -786,6 +921,93 @@ suite("UpstreamChecker shared helper and format handling", () => {
 });
 
 suite("UpstreamChecker preview resolution", () => {
+  setup(() => resetAccount());
+
+  test("local package lookup discovers later pages with strict bounded pagination", async () => {
+    const calls = [];
+    const firstPage = Array.from({ length: 100 }, (_value, index) => ({
+      name: `other-${index}`,
+      format: "python",
+      namespace: "acme",
+      repository: "example-repo",
+      slug_perm: `other-${index}`,
+    }));
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get(endpoint) {
+          const pageNumber = Number(new URL(`https://example.test/${endpoint}`).searchParams.get("page"));
+          calls.push(pageNumber);
+          const data = pageNumber === 1 ? firstPage : [{
+            name: "flask",
+            format: "python",
+            namespace: "acme",
+            repository: "example-repo",
+            slug_perm: "flask-1",
+          }];
+          return apiSuccess(data, {
+            headers: {
+              "x-pagination-page": String(pageNumber),
+              "x-pagination-pagetotal": "2",
+              "x-pagination-count": "101",
+              "x-pagination-pagesize": "100",
+            },
+          });
+        },
+      },
+    });
+
+    const result = await checker.existsLocally(
+      "acme",
+      "example-repo",
+      "flask",
+      "python"
+    );
+
+    assert.strictEqual(result.data.slug_perm, "flask-1");
+    assert.strictEqual(result.complete, true);
+    assert.deepStrictEqual(calls, [1, 2]);
+  });
+
+  test("local package lookup short-circuits after a validated positive page", async () => {
+    const calls = [];
+    const firstPage = Array.from({ length: 100 }, (_value, index) => ({
+      name: index === 0 ? "flask" : `other-${index}`,
+      format: "python",
+      namespace: "acme",
+      repository: "example-repo",
+      slug_perm: `package-${index}`,
+    }));
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get(endpoint) {
+          const pageNumber = Number(new URL(`https://example.test/${endpoint}`).searchParams.get("page"));
+          calls.push(pageNumber);
+          if (pageNumber === 2) return apiFailure("rate_limited", { status: 429 });
+          return apiSuccess(firstPage, {
+            headers: {
+              "x-pagination-page": "1",
+              "x-pagination-pagetotal": "2",
+              "x-pagination-count": "200",
+              "x-pagination-pagesize": "100",
+            },
+          });
+        },
+      },
+    });
+
+    const result = await checker.existsLocally(
+      "acme",
+      "example-repo",
+      "flask",
+      "python"
+    );
+
+    assert.strictEqual(result.data.slug_perm, "package-0");
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.error, null);
+    assert.deepStrictEqual(calls, [1]);
+  });
+
   test("previewResolution does not trigger policy fetches and still returns upstream data", async () => {
     const checker = createChecker({});
     let policyFetchCount = 0;
@@ -793,6 +1015,7 @@ suite("UpstreamChecker preview resolution", () => {
     checker.existsLocally = async () => ({
       data: null,
       error: null,
+      complete: true,
     });
     checker.getUpstreamsForFormat = async () => ({
       data: [

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -1046,4 +1046,40 @@ suite("UpstreamChecker preview resolution", () => {
     assert.strictEqual(result.upstreams.data.active, 1);
     assert.strictEqual(result.upstreams.data.configs[0].name, "PyPI");
   });
+
+  test("previewResolution settles sibling failures and exposes only normalized error strings", async () => {
+    const checker = createChecker({});
+    checker.existsLocally = async () => {
+      throw new Error("https://user:pass@example.com/private?token=secret\nprivate stack");
+    };
+    checker.getUpstreamsForFormat = async () => ({
+      data: [{ name: "PyPI", upstream_url: "https://pypi.org/simple/", is_active: true }],
+      error: null,
+      complete: true,
+    });
+
+    const result = await checker.previewResolution("acme", "repo", "flask", "python");
+
+    assert.strictEqual(result.local.errorMessage, "The local package collection could not be verified.");
+    assert.strictEqual(typeof result.local.errorMessage, "string");
+    assert.strictEqual(result.upstreams.data.total, 1);
+    assert.strictEqual(result.canResolveViaUpstream, true);
+    assert.ok(!JSON.stringify(result).includes("user:pass"));
+    assert.ok(!JSON.stringify(result).includes("token=secret"));
+  });
+
+  test("previewResolution normalizes structured upstream failures", async () => {
+    const checker = createChecker({});
+    checker.existsLocally = async () => ({ data: null, error: null, complete: true });
+    checker.getUpstreamsForFormat = async () => ({
+      data: [],
+      error: { message: "Upstream request failed", status: 500, body: "private body" },
+      complete: false,
+    });
+
+    const result = await checker.previewResolution("acme", "repo", "flask", "python");
+    assert.strictEqual(result.upstreams.errorMessage, "Upstream request failed");
+    assert.strictEqual("error" in result.upstreams, false);
+    assert.ok(!JSON.stringify(result).includes("private body"));
+  });
 });

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -30,7 +30,10 @@ suite("UpstreamDetailProvider Test Suite", () => {
 
     assert.ok(html.includes("PyPI"));
     assert.ok(html.includes("Origin"));
-    assert.ok(html.includes("https://pypi.org"));
+    assert.match(
+      html,
+      /<div class="detail-label">Origin<\/div><div class="detail-value mono">https:\/\/pypi\.org<\/div>/
+    );
     assert.ok(!html.includes("user:pass"));
     assert.ok(!html.includes("/simple/"));
     assert.ok(!html.includes("token=secret"));

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -7,7 +7,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
     assert.strictEqual(SUPPORTED_FORMATS, SUPPORTED_UPSTREAM_FORMATS);
   });
 
-  test("does not show the partial warning banner when upstreams are available", () => {
+  test("shows successful upstreams together with a truthful partial warning", () => {
     const provider = new UpstreamDetailProvider({});
     const groupedUpstreams = new Map([
       [
@@ -29,7 +29,8 @@ suite("UpstreamDetailProvider Test Suite", () => {
     });
 
     assert.ok(html.includes("PyPI"));
-    assert.ok(!html.includes("Some upstream data could not be loaded."));
+    assert.ok(html.includes("Some upstream data could not be loaded."));
+    assert.ok(html.includes("alpine"));
     assert.ok(!html.includes("Could not load upstreams."));
   });
 
@@ -44,5 +45,39 @@ suite("UpstreamDetailProvider Test Suite", () => {
 
     assert.ok(html.includes("Could not load upstreams."));
     assert.ok(html.includes("The upstream configuration could not be loaded for this repository."));
+  });
+
+  test("account reset aborts in-flight work and disposes the panel", () => {
+    const provider = new UpstreamDetailProvider({});
+    let aborted = 0;
+    let disposed = 0;
+    provider._abortController = { abort() { aborted += 1; } };
+    provider._panel = { dispose() { disposed += 1; } };
+
+    provider.resetForAccountChange();
+
+    assert.strictEqual(aborted, 1);
+    assert.strictEqual(disposed, 1);
+    assert.strictEqual(provider._abortController, null);
+    assert.strictEqual(provider._panel, null);
+  });
+
+  test("a null fetch result replaces loading state with a bounded failure state", async () => {
+    const provider = new UpstreamDetailProvider({});
+    const panel = {
+      title: "",
+      webview: { html: "" },
+      reveal() {},
+    };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+    provider._fetchGroupedUpstreams = async () => null;
+
+    await provider.show("acme", "example-repo", "Example Repo");
+
+    assert.ok(panel.webview.html.includes("Could not load upstreams."));
+    assert.ok(!panel.webview.html.includes("Loading upstreams..."));
   });
 });

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -15,7 +15,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
         [
           {
             name: "PyPI",
-            upstream_url: "https://pypi.org/",
+            upstream_url: "https://user:pass@pypi.org/simple/?token=secret#fragment",
             is_active: true,
           },
         ],
@@ -29,9 +29,69 @@ suite("UpstreamDetailProvider Test Suite", () => {
     });
 
     assert.ok(html.includes("PyPI"));
+    assert.ok(html.includes("Origin"));
+    assert.ok(html.includes("https://pypi.org"));
+    assert.ok(!html.includes("user:pass"));
+    assert.ok(!html.includes("/simple/"));
+    assert.ok(!html.includes("token=secret"));
+    assert.ok(!html.includes("#fragment"));
     assert.ok(html.includes("Some upstream data could not be loaded."));
     assert.ok(html.includes("alpine"));
     assert.ok(!html.includes("Could not load upstreams."));
+  });
+
+  test("malformed and unsupported URLs fail closed without breaking cards", () => {
+    const provider = new UpstreamDetailProvider({});
+    const groupedUpstreams = new Map([
+      ["python", [
+        {
+          name: "Malformed\u202ename",
+          upstream_url: "not a URL",
+          is_active: true,
+          mode: { private: true },
+          index_status: { private: true },
+          distro_versions: ["version\u202eone", { private: true }, "x".repeat(10_000)],
+        },
+        { name: "Local file", upstream_url: "file:///tmp/secret", is_active: false },
+      ]],
+    ]);
+
+    const html = provider._getHtmlContent("acme", "repo", "Repo", {
+      groupedUpstreams,
+      failedFormats: [],
+      uninspectedFormats: [],
+      successfulFormats: 26,
+      complete: true,
+    });
+
+    assert.ok(html.includes("Malformed name"));
+    assert.ok(html.includes("Local file"));
+    assert.ok(html.includes("Origin unavailable"));
+    assert.ok(!html.includes("not a URL"));
+    assert.ok(!html.includes("file:///"));
+    assert.ok(!html.includes("[object Object]"));
+    assert.ok(!html.includes("\u202e"));
+    assert.ok(html.length < 20_000);
+  });
+
+  test("caps rendered cards before joining HTML", () => {
+    const provider = new UpstreamDetailProvider({});
+    const groupedUpstreams = new Map([
+      ["python", Array.from({ length: 201 }, (_, index) => ({
+        name: `Mirror ${index}`,
+        upstream_url: `https://mirror-${index}.example/path`,
+      }))],
+    ]);
+
+    const html = provider._getHtmlContent("acme", "repo", "Repo", {
+      groupedUpstreams,
+      failedFormats: [],
+      uninspectedFormats: [],
+      successfulFormats: 26,
+      complete: true,
+    });
+    assert.ok(html.includes("Showing 200 of 201 loaded upstreams."));
+    assert.ok(!html.includes("Mirror 200"));
   });
 
   test("shows an error state when upstream data cannot be determined", () => {

--- a/test/upstreamGapAnalyzer.test.js
+++ b/test/upstreamGapAnalyzer.test.js
@@ -2,11 +2,15 @@ const assert = require("assert");
 const {
   analyzeUpstreamGaps,
 } = require("../util/upstreamGapAnalyzer");
+const { UpstreamOperationScheduler } = require("../util/upstreamOperationScheduler");
 
 suite("upstreamGapAnalyzer", () => {
   function createState(entries = {}) {
     return {
       groupedUpstreams: new Map(Object.entries(entries)),
+      complete: true,
+      failedFormats: [],
+      uninspectedFormats: [],
     };
   }
 
@@ -83,7 +87,7 @@ suite("upstreamGapAnalyzer", () => {
     assert.strictEqual(enriched[0].upstreamDetail, "Not available through Cloudsmith");
   });
 
-  test("limits upstream repository lookups to five concurrent requests and emits one final patch", async () => {
+  test("limits upstream repository lookups to four concurrent requests and emits one final patch", async () => {
     const dependencies = [
       {
         name: "accepts",
@@ -126,12 +130,39 @@ suite("upstreamGapAnalyzer", () => {
       },
     });
 
-    assert.ok(maxInFlight <= 5);
+    assert.ok(maxInFlight <= 4);
     assert.strictEqual(progressEvents.filter((event) => event.size > 0).length, 1);
     assert.strictEqual(progressEvents[progressEvents.length - 1].completed, repositories.length);
     assert.strictEqual(progressEvents[progressEvents.length - 1].size, 1);
     assert.strictEqual(enriched[0].upstreamStatus, "reachable");
     assert.strictEqual(enriched[0].upstreamDetail, "npm proxy on repo-9");
+  });
+
+  test("contains throwing progress observers until every repository worker settles", async () => {
+    const dependencies = [{
+      name: "accepts",
+      version: "1.3.8",
+      format: "npm",
+      cloudsmithStatus: "NOT_FOUND",
+    }];
+    let completed = 0;
+    const enriched = await analyzeUpstreamGaps(
+      dependencies,
+      "workspace-a",
+      Array.from({ length: 12 }, (_value, index) => `repo-${index}`),
+      {
+        onProgress() { throw new Error("observer failure"); },
+        upstreamChecker: {
+          async getRepositoryUpstreamState() {
+            completed += 1;
+            return createState();
+          },
+        },
+      }
+    );
+
+    assert.strictEqual(completed, 12);
+    assert.strictEqual(enriched[0].upstreamStatus, "no_proxy");
   });
 
   test("accepts conclusive absence and ignores unresolved lookup states", async () => {
@@ -154,5 +185,85 @@ suite("upstreamGapAnalyzer", () => {
 
     assert.strictEqual(enriched[0].upstreamStatus, "no_proxy");
     assert.strictEqual(enriched[1].upstreamStatus, undefined);
+  });
+
+  test("keeps positive matches but reports unknown when relevant inspection is incomplete", async () => {
+    const dependencies = [{
+      name: "package-a",
+      version: "1.0.0",
+      format: "npm",
+      cloudsmithStatus: "ABSENT",
+    }];
+    const unknown = await analyzeUpstreamGaps(dependencies, "workspace-a", ["repo-a"], {
+      upstreamChecker: {
+        async getRepositoryUpstreamState() {
+          return {
+            groupedUpstreams: new Map(),
+            complete: false,
+            failedFormats: ["npm"],
+            uninspectedFormats: [],
+          };
+        },
+      },
+    });
+    assert.strictEqual(unknown[0].upstreamStatus, "unknown");
+
+    const unrelatedFailure = await analyzeUpstreamGaps(
+      dependencies,
+      "workspace-a",
+      ["repo-a"],
+      {
+        upstreamChecker: {
+          async getRepositoryUpstreamState() {
+            return {
+              groupedUpstreams: new Map(),
+              complete: false,
+              failedFormats: ["python"],
+              uninspectedFormats: [],
+            };
+          },
+        },
+      }
+    );
+    assert.strictEqual(unrelatedFailure[0].upstreamStatus, "no_proxy");
+
+    const positive = await analyzeUpstreamGaps(dependencies, "workspace-a", ["repo-a"], {
+      repositoriesComplete: false,
+      upstreamChecker: {
+        async getRepositoryUpstreamState() {
+          return {
+            groupedUpstreams: new Map([["npm", [{ name: "npm", is_active: true }]]]),
+            complete: false,
+            failedFormats: [],
+            uninspectedFormats: ["python"],
+          };
+        },
+      },
+    });
+    assert.strictEqual(positive[0].upstreamStatus, "reachable");
+  });
+
+  test("stops repository fan-out structurally when the shared request budget is exhausted", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 1, maxRequests: 1 });
+    let repositoryCalls = 0;
+    const enriched = await analyzeUpstreamGaps([{
+      name: "package-a",
+      version: "1.0.0",
+      format: "npm",
+      cloudsmithStatus: "ABSENT",
+    }], "workspace-a", Array.from({ length: 1000 }, (_, index) => `repo-${index}`), {
+      scheduler,
+      upstreamChecker: {
+        async getRepositoryUpstreamState(_workspace, _repo, options) {
+          repositoryCalls += 1;
+          await options.scheduler.run(async () => ({ ok: true }));
+          return createState();
+        },
+      },
+    });
+
+    assert.strictEqual(repositoryCalls, 1);
+    assert.strictEqual(scheduler.requestCount, 1);
+    assert.strictEqual(enriched[0].upstreamStatus, "unknown");
   });
 });

--- a/test/upstreamOperationScheduler.test.js
+++ b/test/upstreamOperationScheduler.test.js
@@ -1,0 +1,90 @@
+const assert = require("assert");
+const { UpstreamOperationScheduler } = require("../util/upstreamOperationScheduler");
+
+suite("UpstreamOperationScheduler", () => {
+  function deferred() {
+    let resolve;
+    const promise = new Promise(settle => { resolve = settle; });
+    return { promise, resolve };
+  }
+
+  test("bounds 100 repository-format requests to four active operations", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 4, maxRequests: 1000 });
+    const gate = deferred();
+    let active = 0;
+    let maxActive = 0;
+    const work = Array.from({ length: 100 }, (_, index) => scheduler.run(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await gate.promise;
+      active -= 1;
+      return index;
+    }));
+
+    assert.strictEqual(scheduler.activeCount, 4);
+    assert.strictEqual(scheduler.queuedCount, 96);
+    gate.resolve();
+    assert.deepStrictEqual(await Promise.all(work), Array.from({ length: 100 }, (_, index) => index));
+    assert.strictEqual(maxActive, 4);
+    assert.strictEqual(scheduler.maxActiveCount, 4);
+    assert.strictEqual(scheduler.requestCount, 100);
+    assert.strictEqual(scheduler.activeCount, 0);
+  });
+
+  test("releases a slot after a thrown task and does not starve queued work", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 1, maxRequests: 3 });
+    const results = await Promise.allSettled([
+      scheduler.run(async () => { throw new Error("request failed"); }),
+      scheduler.run(async () => "second"),
+      scheduler.run(async () => "third"),
+    ]);
+
+    assert.strictEqual(results[0].status, "rejected");
+    assert.deepStrictEqual(results.slice(1).map(result => result.value), ["second", "third"]);
+    assert.strictEqual(scheduler.activeCount, 0);
+    assert.strictEqual(scheduler.requestCount, 3);
+  });
+
+  test("opens the rate-limit circuit and rejects queued requests without dispatch", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 1, maxRequests: 1000 });
+    const first = scheduler.run(async () => ({
+      ok: false,
+      error: { kind: "rate_limited", status: 429 },
+    }));
+    const queued = Array.from({ length: 20 }, () => scheduler.run(async () => ({ ok: true })));
+
+    const [firstResult, ...queuedResults] = await Promise.allSettled([first, ...queued]);
+    assert.strictEqual(firstResult.status, "fulfilled");
+    assert.ok(queuedResults.every(result => (
+      result.status === "rejected" && result.reason.kind === "rate_limit_circuit"
+    )));
+    assert.strictEqual(scheduler.requestCount, 1);
+    assert.strictEqual(scheduler.activeCount, 0);
+  });
+
+  test("cancellation removes queued work and leaves no active slot", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 1, maxRequests: 10 });
+    const gate = deferred();
+    const token = { isCancellationRequested: false };
+    const active = scheduler.run(() => gate.promise);
+    const queued = scheduler.run(async () => "must-not-run", { cancellationToken: token });
+    token.isCancellationRequested = true;
+    gate.resolve("done");
+
+    assert.strictEqual(await active, "done");
+    await assert.rejects(queued, error => error.kind === "cancelled");
+    assert.strictEqual(scheduler.activeCount, 0);
+    assert.strictEqual(scheduler.requestCount, 1);
+  });
+
+  test("rejects accepted work beyond the operation request budget", async () => {
+    const scheduler = new UpstreamOperationScheduler({ concurrency: 1, maxRequests: 2 });
+    assert.strictEqual(await scheduler.run(async () => "first"), "first");
+    assert.strictEqual(await scheduler.run(async () => "second"), "second");
+    await assert.rejects(
+      scheduler.run(async () => "third"),
+      error => error.kind === "request_limit"
+    );
+    assert.strictEqual(scheduler.requestCount, 2);
+  });
+});

--- a/test/upstreamPresentation.test.js
+++ b/test/upstreamPresentation.test.js
@@ -1,0 +1,124 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const assert = require("assert");
+const {
+  formatUpstreamError,
+  formatUpstreamOrigin,
+  formatUpstreamText,
+  getTerraformUpstreamUrl,
+} = require("../util/upstreamPresentation");
+
+suite("Upstream presentation safety", () => {
+  test("normalizes supported error shapes without object, stack, body, or secret exposure", () => {
+    assert.strictEqual(formatUpstreamError("Request failed"), "Request failed");
+    assert.strictEqual(formatUpstreamError(new Error("Request failed")), "Request failed");
+    assert.strictEqual(
+      formatUpstreamError({ message: "Upstream request failed", status: 500 }),
+      "Upstream request failed"
+    );
+    assert.strictEqual(
+      formatUpstreamError({ message: "unexpected response", body: "private body" }),
+      "Upstream availability could not be determined."
+    );
+    assert.strictEqual(
+      formatUpstreamError(new Error("https://user:pass@example.com/path?token=secret")),
+      "Upstream availability could not be determined."
+    );
+    assert.strictEqual(
+      formatUpstreamError({ message: "<script>alert(1)</script>" }),
+      "Upstream availability could not be determined."
+    );
+    assert.strictEqual(formatUpstreamError(null), "Upstream availability could not be determined.");
+    assert.strictEqual(
+      formatUpstreamError("Request failed".repeat(100_000)),
+      "Upstream availability could not be determined."
+    );
+    for (const kind of ["toString", "constructor", "__proto__"]) {
+      assert.strictEqual(
+        formatUpstreamError({ kind }),
+        "Upstream availability could not be determined.",
+        kind
+      );
+    }
+    assert.strictEqual(
+      formatUpstreamError({ unexpected: true }, "toString"),
+      "Upstream availability could not be determined."
+    );
+
+    const hostile = new Proxy({}, {
+      get() { throw new Error("secret stack"); },
+      getOwnPropertyDescriptor() { throw new Error("secret body"); },
+    });
+    assert.strictEqual(
+      formatUpstreamError(hostile),
+      "Upstream availability could not be determined."
+    );
+  });
+
+  test("projects only safe HTTP origins and fails closed", () => {
+    const cases = [
+      ["https://example.com/path", "https://example.com"],
+      ["https://user:pass@example.com/path", "https://example.com"],
+      ["https://example.com/path?token=secret", "https://example.com"],
+      ["https://example.com/path#fragment", "https://example.com"],
+      ["https://example.com/object?X-Amz-Signature=signed", "https://example.com"],
+      ["https://example.com:8443/path", "https://example.com:8443"],
+      ["http://example.com/path", "http://example.com"],
+      ["not a URL", "Origin unavailable"],
+      ["/relative/path", "Origin unavailable"],
+      ["file:///tmp/secret", "Origin unavailable"],
+      ["data:text/plain,secret", "Origin unavailable"],
+      ["javascript:alert(1)", "Origin unavailable"],
+      ["https:example.com/path", "Origin unavailable"],
+      ["https:///example.com/path", "Origin unavailable"],
+      ["https:////example.com/path", "Origin unavailable"],
+      ["https://example.com/path\\other", "Origin unavailable"],
+      [" https://example.com/path", "Origin unavailable"],
+      ["https://example.com/path\u202esecret", "Origin unavailable"],
+    ];
+
+    for (const [input, expected] of cases) {
+      assert.strictEqual(formatUpstreamOrigin(input), expected, input);
+    }
+  });
+
+  test("bounds and neutralizes controls in presentation text before transformation", () => {
+    const huge = `${"a".repeat(1_000_000)}\u202eprivate\nvalue`;
+    const formatted = formatUpstreamText(huge);
+    assert.strictEqual(formatted.length, 500);
+    assert.ok(!formatted.includes("\u202e"));
+    assert.ok(!formatted.includes("\n"));
+    assert.strictEqual(formatUpstreamText({ value: "secret" }, "Unknown"), "Unknown");
+    assert.strictEqual(getTerraformUpstreamUrl(`https://example.com/${"a".repeat(9000)}`), null);
+  });
+
+  test("validates Terraform URLs without semantic secret stripping", () => {
+    assert.strictEqual(getTerraformUpstreamUrl("https://example.com/"), "https://example.com");
+    assert.strictEqual(
+      getTerraformUpstreamUrl("https://example.com:8443/simple/%3Fencoded"),
+      "https://example.com:8443/simple/%3Fencoded"
+    );
+    assert.strictEqual(
+      getTerraformUpstreamUrl("https://example.com/simple/%40encoded"),
+      "https://example.com/simple/%40encoded"
+    );
+    for (const input of [
+      "https://user:pass@example.com/path",
+      "https://@example.com/path",
+      "https://:@example.com/path",
+      "https://example.com/path?",
+      "https://example.com/path#",
+      "https://example.com/path?token=secret",
+      "https://example.com/path\\other",
+      "https:example.com/path",
+      "https:///example.com/path",
+      "https:////example.com/path",
+      "https://example.com/%2e%2e/secret",
+      " https://example.com/path",
+      "file:///tmp/secret",
+      "not a URL",
+    ]) {
+      assert.strictEqual(getTerraformUpstreamUrl(input), null, input);
+    }
+  });
+});

--- a/test/upstreamPreviewProvider.test.js
+++ b/test/upstreamPreviewProvider.test.js
@@ -12,7 +12,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
       repo: "example-repo",
       local: {
         data: null,
-        error: null,
+        errorMessage: null,
         complete: true,
       },
       upstreams: {
@@ -32,7 +32,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
             },
           ],
         },
-        error: null,
+        errorMessage: null,
         complete: true,
       },
       canResolveViaUpstream: true,
@@ -41,6 +41,9 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     assert.ok(html.includes("Upstream resolution preview"));
     assert.ok(html.includes("PyPI"));
     assert.ok(html.includes("Legacy mirror"));
+    assert.ok(html.includes("<th>Origin</th>"));
+    assert.ok(html.includes("https://pypi.org"));
+    assert.ok(!html.includes("/simple/"));
     assert.ok(html.includes("Upstreams (1 active of 2)"));
     assert.ok(!html.includes("Active policies"));
     assert.ok(!html.includes("policy simulation"));
@@ -58,7 +61,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
       repo: "example-repo",
       local: {
         data: null,
-        error: null,
+        errorMessage: null,
         complete: false,
       },
       upstreams: {
@@ -67,18 +70,137 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           active: 0,
           configs: [],
         },
-        error: "Upstream availability could not be determined.",
+        errorMessage: { message: "Upstream request failed", status: 500 },
         complete: false,
       },
       canResolveViaUpstream: false,
     });
 
     assert.ok(html.includes("Could not load upstream data"));
+    assert.ok(html.includes("Upstream request failed"));
+    assert.ok(!html.includes("[object Object]"));
     assert.ok(html.includes("Local package status is incomplete"));
     assert.ok(!html.includes("Not found in example-repo"));
     assert.ok(!html.includes("Active policies"));
     assert.ok(!html.includes("No active upstreams"));
     assert.ok(!html.includes("Upload the package directly"));
+  });
+
+  test("normalizes object errors, escapes HTML, and never exposes URL secrets", () => {
+    const provider = new UpstreamPreviewProvider({});
+    const html = provider._getHtmlContent({
+      name: "<script>alert(1)</script>",
+      format: "python",
+      workspace: "acme",
+      repo: "example-repo",
+      local: { data: null, errorMessage: new Error("Request failed"), complete: false },
+      upstreams: {
+        data: {
+          total: 1,
+          active: 1,
+          configs: [{
+            name: "Private mirror",
+            upstream_url: "https://user:pass@example.com/private/path?token=secret#fragment",
+            is_active: true,
+          }],
+        },
+        errorMessage: null,
+        complete: false,
+      },
+      canResolveViaUpstream: false,
+    });
+
+    assert.ok(html.includes("Request failed"));
+    assert.ok(html.includes("https://example.com"));
+    assert.ok(!html.includes("[object Object]"));
+    assert.ok(!html.includes("user:pass"));
+    assert.ok(!html.includes("private/path"));
+    assert.ok(!html.includes("token=secret"));
+    assert.ok(!html.includes("#fragment"));
+    assert.ok(!html.includes("<script>"));
+    assert.ok(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"));
+  });
+
+  test("replaces secret-bearing and HTML-shaped error messages with fixed public copy", () => {
+    const provider = new UpstreamPreviewProvider({});
+    for (const errorMessage of [
+      new Error("https://user:pass@example.com/private?token=secret"),
+      { message: "<script>alert(1)</script>", body: "private response body" },
+      { unexpected: true },
+    ]) {
+      const html = provider._getHtmlContent({
+        name: "package",
+        format: "python",
+        workspace: "acme",
+        repo: "repo",
+        local: { data: null, errorMessage: null, complete: true },
+        upstreams: {
+          data: { total: 0, active: 0, configs: [] },
+          errorMessage,
+          complete: false,
+        },
+        canResolveViaUpstream: false,
+      });
+      assert.ok(html.includes("Upstream availability could not be determined."));
+      assert.ok(!html.includes("[object Object]"));
+      assert.ok(!html.includes("user:pass"));
+      assert.ok(!html.includes("token=secret"));
+      assert.ok(!html.includes("private response body"));
+      assert.ok(!html.includes("<script>"));
+    }
+  });
+
+  test("bounds direct oversized upstream presentation truthfully", () => {
+    const provider = new UpstreamPreviewProvider({});
+    const configs = Array.from({ length: 101 }, (_, index) => ({
+      name: `Mirror ${index}`,
+      upstream_url: `https://mirror-${index}.example/path`,
+      is_active: true,
+    }));
+    const html = provider._getHtmlContent({
+      name: "package",
+      format: "python",
+      workspace: "acme",
+      repo: "repo",
+      local: { data: null, errorMessage: null, complete: true },
+      upstreams: {
+        data: { total: 101, active: 101, configs },
+        errorMessage: null,
+        complete: true,
+      },
+      canResolveViaUpstream: true,
+    });
+
+    assert.ok(html.includes("Showing 100 of 101 loaded upstreams."));
+    assert.ok(!html.includes("Mirror 100"));
+  });
+
+  test("fails incomplete on contradictory counts and malformed configurations", () => {
+    const provider = new UpstreamPreviewProvider({});
+    const html = provider._getHtmlContent({
+      name: "package",
+      format: "python",
+      workspace: "acme",
+      repo: "repo",
+      local: { data: null, errorMessage: null, complete: true },
+      upstreams: {
+        data: {
+          total: 99,
+          active: 99,
+          configs: [{ name: "Malformed", is_active: "true", upstream_url: {} }],
+        },
+        errorMessage: null,
+        complete: true,
+      },
+      canResolveViaUpstream: "yes",
+    });
+
+    assert.ok(html.includes("Upstream inspection is incomplete"));
+    assert.ok(html.includes("Upstream resolution could not be determined"));
+    assert.ok(html.includes("0 active of 0 loaded"));
+    assert.ok(!html.includes("99 active"));
+    assert.ok(!html.includes("can likely resolve"));
+    assert.ok(!html.includes("[object Object]"));
   });
 
   test("account reset disposes the panel and null preview results are ignored", () => {

--- a/test/upstreamPreviewProvider.test.js
+++ b/test/upstreamPreviewProvider.test.js
@@ -42,7 +42,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     assert.ok(html.includes("PyPI"));
     assert.ok(html.includes("Legacy mirror"));
     assert.ok(html.includes("<th>Origin</th>"));
-    assert.ok(html.includes("https://pypi.org"));
+    assert.match(html, /<td class="mono">https:\/\/pypi\.org<\/td>/);
     assert.ok(!html.includes("/simple/"));
     assert.ok(html.includes("Upstreams (1 active of 2)"));
     assert.ok(!html.includes("Active policies"));
@@ -111,7 +111,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     });
 
     assert.ok(html.includes("Request failed"));
-    assert.ok(html.includes("https://example.com"));
+    assert.match(html, /<td class="mono">https:\/\/example\.com<\/td>/);
     assert.ok(!html.includes("[object Object]"));
     assert.ok(!html.includes("user:pass"));
     assert.ok(!html.includes("private/path"));

--- a/test/upstreamPreviewProvider.test.js
+++ b/test/upstreamPreviewProvider.test.js
@@ -13,6 +13,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
       local: {
         data: null,
         error: null,
+        complete: true,
       },
       upstreams: {
         data: {
@@ -32,6 +33,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           ],
         },
         error: null,
+        complete: true,
       },
       canResolveViaUpstream: true,
     });
@@ -57,6 +59,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
       local: {
         data: null,
         error: null,
+        complete: false,
       },
       upstreams: {
         data: {
@@ -65,11 +68,28 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           configs: [],
         },
         error: "Upstream availability could not be determined.",
+        complete: false,
       },
       canResolveViaUpstream: false,
     });
 
     assert.ok(html.includes("Could not load upstream data"));
+    assert.ok(html.includes("Local package status is incomplete"));
+    assert.ok(!html.includes("Not found in example-repo"));
     assert.ok(!html.includes("Active policies"));
+    assert.ok(!html.includes("No active upstreams"));
+    assert.ok(!html.includes("Upload the package directly"));
+  });
+
+  test("account reset disposes the panel and null preview results are ignored", () => {
+    const provider = new UpstreamPreviewProvider({});
+    let disposed = 0;
+    provider._panel = { dispose() { disposed += 1; } };
+
+    provider.resetForAccountChange();
+    provider.show(null);
+
+    assert.strictEqual(disposed, 1);
+    assert.strictEqual(provider._panel, null);
   });
 });

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -634,6 +634,43 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(result.pullResult.errors, 1);
   });
 
+  test("never exposes registry request URLs through status or terminal details", async () => {
+    const statuses = [];
+    const dependency = {
+      name: "private-package",
+      version: "1.0.0",
+      format: "npm",
+      cloudsmithStatus: "NOT_FOUND",
+    };
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+    service._pullDependency = async () => ({
+      dependency,
+      status: "cached",
+      errorMessage: null,
+      requestUrl: "https://user:pass@npm.cloudsmith.io/private/repo/package?token=secret#fragment",
+      networkError: false,
+    });
+
+    const result = await service.execute({
+      workspace: "private-workspace",
+      repository: { slug: "private-repo" },
+      plan: { pullableDependencies: [dependency], skippedDependencies: [] },
+    }, {
+      onStatus(detail) { statuses.push(detail); },
+    });
+
+    assert.ok(statuses.length >= 2);
+    assert.ok(statuses.every(detail => !("requestUrl" in detail)));
+    assert.ok(result.pullResult.details.every(detail => !("requestUrl" in detail)));
+    assert.ok(!JSON.stringify(statuses).includes("token=secret"));
+    assert.ok(!JSON.stringify(result.pullResult).includes("private-workspace"));
+  });
+
   test("does not dispatch after the prepared account changes while loading credentials", async () => {
     let accountState = {
       activationId: "account-a",

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -11,6 +11,27 @@ function createResponse(status, body, headers = {}) {
   return new Response(body, { status, headers });
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise(resolvePromise => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+function cancellationToken() {
+  const listeners = new Set();
+  return {
+    isCancellationRequested: false,
+    cancel() {
+      this.isCancellationRequested = true;
+      for (const listener of listeners) listener();
+    },
+    onCancellationRequested(listener) {
+      listeners.add(listener);
+      return { dispose() { listeners.delete(listener); } };
+    },
+  };
+}
+
 suite("UpstreamPullService", () => {
   test("builds canonical registry trigger URLs for supported formats", () => {
     const mavenPlan = buildRegistryTriggerPlan("workspace", "repo", {
@@ -106,13 +127,17 @@ suite("UpstreamPullService", () => {
   test("prepare builds a mixed-ecosystem confirmation with skipped formats", async () => {
     const warnings = [];
     const service = new UpstreamPullService({}, {
-      fetchRepositories: async () => [{ slug: "repo", name: "Repo" }],
+      fetchRepositories: async () => ({
+        items: [{ slug: "repo", name: "Repo" }],
+        complete: true,
+      }),
       upstreamChecker: {
         async getRepositoryUpstreamState() {
           return {
             groupedUpstreams: new Map([
               ["maven", [{ name: "Maven Central", is_active: true }]],
             ]),
+            complete: true,
           };
         },
       },
@@ -158,13 +183,17 @@ suite("UpstreamPullService", () => {
 
   test("prepare preserves exact versions that differ only by prerelease identifier case", async () => {
     const service = new UpstreamPullService({}, {
-      fetchRepositories: async () => [{ slug: "repo", name: "Repo" }],
+      fetchRepositories: async () => ({
+        items: [{ slug: "repo", name: "Repo" }],
+        complete: true,
+      }),
       upstreamChecker: {
         async getRepositoryUpstreamState() {
           return {
             groupedUpstreams: new Map([
               ["npm", [{ name: "npm", is_active: true }]],
             ]),
+            complete: true,
           };
         },
       },
@@ -549,20 +578,163 @@ suite("UpstreamPullService", () => {
     ]);
   });
 
+  test("contains throwing status observers and drains every launched pull before returning", async () => {
+    const gate = deferred();
+    const threeStarted = deferred();
+    let calls = 0;
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+    service._pullDependency = async (_workspace, _repo, dependency) => {
+      calls += 1;
+      if (calls === 3) threeStarted.resolve();
+      if (dependency.name === "package-0") {
+        throw new Error("worker failed");
+      }
+      await gate.promise;
+      return {
+        dependency,
+        status: "cached",
+        errorMessage: null,
+        requestUrl: "https://npm.cloudsmith.io/workspace/repo/package",
+        networkError: false,
+      };
+    };
+
+    const dependencies = Array.from({ length: 8 }, (_, index) => ({
+      name: `package-${index}`,
+      version: "1.0.0",
+      format: "npm",
+      cloudsmithStatus: "NOT_FOUND",
+    }));
+    let returned = false;
+    const pending = service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: { pullableDependencies: dependencies, skippedDependencies: [] },
+    }, {
+      onStatus() { throw new Error("observer failed"); },
+      progress: { report() { throw new Error("progress observer failed"); } },
+    }).then((value) => {
+      returned = true;
+      return value;
+    });
+
+    await threeStarted.promise;
+    assert.strictEqual(returned, false);
+    gate.resolve();
+    const result = await pending;
+
+    assert.strictEqual(calls, dependencies.length);
+    assert.strictEqual(result.pullResult.details.length, dependencies.length);
+    assert.strictEqual(result.pullResult.cached, dependencies.length - 1);
+    assert.strictEqual(result.pullResult.errors, 1);
+  });
+
+  test("does not dispatch after the prepared account changes while loading credentials", async () => {
+    let accountState = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    const apiKey = deferred();
+    let pulls = 0;
+    const service = new UpstreamPullService({}, {
+      connectionManager: { getState() { return { ...accountState }; } },
+      credentialManager: { async getApiKey() { return apiKey.promise; } },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+    service._pullDependency = async () => {
+      pulls += 1;
+      throw new Error("must not dispatch");
+    };
+
+    const pending = service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      account: { activationId: "account-a", accountEpoch: 1 },
+      plan: {
+        pullableDependencies: [{
+          name: "package-a",
+          version: "1.0.0",
+          format: "npm",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+    accountState = { ...accountState, activationId: "account-b", accountEpoch: 2 };
+    apiKey.resolve("api-key");
+
+    assert.deepStrictEqual(await pending, { canceled: true, stale: true });
+    assert.strictEqual(pulls, 0);
+  });
+
+  test("does not issue an artifact request after the prepared account changes", async () => {
+    let accountState = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    const calls = [];
+    const service = new UpstreamPullService({}, {
+      connectionManager: { getState() { return { ...accountState }; } },
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        accountState = { ...accountState, activationId: "account-b", accountEpoch: 2 };
+        return createResponse(
+          200,
+          '<a href="../../packages/requests-2.31.0-py3-none-any.whl">requests</a>'
+        );
+      },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      account: { activationId: "account-a", accountEpoch: 1 },
+      plan: {
+        pullableDependencies: [{
+          name: "requests",
+          version: "2.31.0",
+          format: "python",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.deepStrictEqual(result, { canceled: true, stale: true });
+    assert.strictEqual(calls.length, 1);
+  });
+
   test("prepareSingle only offers repositories with a matching upstream", async () => {
     const quickPickCalls = [];
     let warningCalls = 0;
     const service = new UpstreamPullService({}, {
-      fetchRepositories: async () => [
-        { slug: "repo-a", name: "Repo A" },
-        { slug: "repo-b", name: "Repo B" },
-      ],
+      fetchRepositories: async () => ({
+        items: [
+          { slug: "repo-a", name: "Repo A" },
+          { slug: "repo-b", name: "Repo B" },
+        ],
+        complete: true,
+      }),
       upstreamChecker: {
         async getRepositoryUpstreamState(_workspace, repo) {
           return {
             groupedUpstreams: new Map([
               ["python", repo === "repo-b" ? [{ name: "PyPI", is_active: true }] : []],
             ]),
+            complete: true,
           };
         },
       },
@@ -596,6 +768,128 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(quickPickCalls[0][0].label, "repo-b");
     assert.match(quickPickCalls[0][0].detail, /Python upstream \(PyPI\)/);
     assert.strictEqual(warningCalls, 0);
+  });
+
+  test("preparation reports a fixed repository error without exposing thrown detail", async () => {
+    const errors = [];
+    const service = new UpstreamPullService({}, {
+      fetchRepositories: async () => {
+        throw new Error("secret-token-and-internal-host");
+      },
+      showErrorMessage: async (message) => { errors.push(message); },
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+
+    const prepared = await service.prepareSingle({
+      workspace: "workspace",
+      dependency: {
+        name: "requests",
+        version: "2.31.0",
+        format: "python",
+        cloudsmithStatus: "NOT_FOUND",
+      },
+    });
+
+    assert.strictEqual(prepared, null);
+    assert.deepStrictEqual(errors, ["Could not fetch workspace repositories."]);
+    assert.doesNotMatch(errors[0], /secret|internal-host/i);
+  });
+
+  test("prepareSingle cancellation stops repository inspection from scheduling more work", async () => {
+    const token = cancellationToken();
+    const gate = deferred();
+    let inspectionCalls = 0;
+    let quickPickCalls = 0;
+    const service = new UpstreamPullService({}, {
+      fetchRepositories: async (_workspace, operation) => {
+        assert.strictEqual(operation.cancellationToken, token);
+        return {
+          items: Array.from({ length: 1000 }, (_value, index) => ({ slug: `repo-${index}` })),
+          complete: true,
+        };
+      },
+      upstreamChecker: {
+        async getRepositoryUpstreamStateForFormats(_workspace, _repo, _formats, options) {
+          inspectionCalls += 1;
+          assert.strictEqual(options.cancellationToken, token);
+          await gate.promise;
+          return {
+            groupedUpstreams: new Map(),
+            complete: false,
+            failedFormats: [],
+            uninspectedFormats: ["python"],
+          };
+        },
+      },
+      showQuickPick: async () => { quickPickCalls += 1; return null; },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+
+    const pending = service.prepareSingle({
+      workspace: "workspace",
+      dependency: {
+        name: "requests",
+        version: "2.31.0",
+        format: "python",
+        cloudsmithStatus: "NOT_FOUND",
+      },
+      cancellationToken: token,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(inspectionCalls, 4);
+    token.cancel();
+    gate.resolve();
+
+    assert.strictEqual(await pending, null);
+    assert.strictEqual(inspectionCalls, 4);
+    assert.strictEqual(quickPickCalls, 0);
+  });
+
+  test("prepareSingle discards repository results completed by a superseded account", async () => {
+    let state = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    const repositories = deferred();
+    let inspectionCalls = 0;
+    const service = new UpstreamPullService({}, {
+      connectionManager: { getState() { return { ...state }; } },
+      fetchRepositories: async (_workspace, operation) => {
+        assert.deepStrictEqual(operation.account, {
+          activationId: "account-a",
+          accountEpoch: 1,
+        });
+        return repositories.promise;
+      },
+      upstreamChecker: {
+        async getRepositoryUpstreamStateForFormats() {
+          inspectionCalls += 1;
+          return { groupedUpstreams: new Map(), complete: true };
+        },
+      },
+      showErrorMessage: async () => {},
+      showInformationMessage: async () => {},
+      showWarningMessage: async () => {},
+    });
+
+    const pending = service.prepareSingle({
+      workspace: "workspace",
+      dependency: {
+        name: "requests",
+        version: "2.31.0",
+        format: "python",
+        cloudsmithStatus: "NOT_FOUND",
+      },
+    });
+    state = { ...state, activationId: "account-b", accountEpoch: 2 };
+    repositories.resolve({ items: [{ slug: "repo" }], complete: true });
+
+    assert.strictEqual(await pending, null);
+    assert.strictEqual(inspectionCalls, 0);
   });
 
   test("does not offer uncertain dependencies for upstream pull", async () => {

--- a/test/vulnerabilityProvider.test.js
+++ b/test/vulnerabilityProvider.test.js
@@ -1,8 +1,20 @@
 const assert = require("assert");
+const vscode = require("vscode");
 const { VulnerabilityProvider } = require("../views/vulnerabilityProvider");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("VulnerabilityProvider Test Suite", () => {
+  function scanPage(data) {
+    return apiSuccess(data, {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "100",
+        "x-pagination-count": String(data.length),
+      },
+    });
+  }
+
   test("webview fetch preserves multiple records from the canonical scan response", async () => {
     const calls = [];
     const provider = new VulnerabilityProvider({});
@@ -10,7 +22,7 @@ suite("VulnerabilityProvider Test Suite", () => {
       async get(endpoint) {
         calls.push(endpoint);
         if (calls.length === 1) {
-          return apiSuccess([{
+          return scanPage([{
             identifier: "scan-webview",
             has_vulnerabilities: true,
             num_vulnerabilities: 2,
@@ -36,7 +48,7 @@ suite("VulnerabilityProvider Test Suite", () => {
     );
 
     assert.deepStrictEqual(calls, [
-      "vulnerabilities/workspace-a/repo-a/immutable-package-id/",
+      "vulnerabilities/workspace-a/repo-a/immutable-package-id/?page=1&page_size=100",
       "vulnerabilities/workspace-a/repo-a/immutable-package-id/scan-webview/",
     ]);
     assert.deepStrictEqual(result.results.map(vulnerability => vulnerability.vulnerability_id), [
@@ -52,8 +64,8 @@ suite("VulnerabilityProvider Test Suite", () => {
     const provider = new VulnerabilityProvider({});
     const api = {
       async get(endpoint) {
-        if (endpoint.endsWith("immutable-package-id/")) {
-          return apiSuccess([{
+        if (endpoint.includes("immutable-package-id/?page=")) {
+          return scanPage([{
             identifier: "scan-webview",
             has_vulnerabilities: true,
             max_severity: "High",
@@ -97,6 +109,11 @@ suite("VulnerabilityProvider Test Suite", () => {
     );
     assert.match(html, /<strong>detected<\/strong> vulnerabilities/);
     assert.doesNotMatch(html, /<strong>0<\/strong> vulnerabilities/);
+
+    const report = provider._buildPlainTextReport("artifact", "1.0.0", [], result);
+    assert.match(report, /Completeness: Incomplete/);
+    assert.doesNotMatch(report, /^Total:/m);
+    assert.doesNotMatch(html, /\[object Object\]/);
   });
 
   test("rejects unsafe scan identifiers and primitive nested vulnerability entries", async () => {
@@ -120,7 +137,7 @@ suite("VulnerabilityProvider Test Suite", () => {
         if (detailCalls === 1) {
           const payload = [{ identifier: "scan-id", has_vulnerabilities: true }];
           assert.strictEqual(options.validate(payload), true);
-          return apiSuccess(payload);
+          return scanPage(payload);
         }
         const payload = { results: [null] };
         assert.strictEqual(options.validate(payload), false);
@@ -130,5 +147,72 @@ suite("VulnerabilityProvider Test Suite", () => {
     assert.strictEqual(detailCalls, 2);
     assert.strictEqual(malformedDetail.error.kind, "invalid_response");
     assert.deepStrictEqual(malformedDetail.results, []);
+  });
+
+  test("account reset aborts the panel operation and stale results cannot render", async () => {
+    const originalCreateWebviewPanel = vscode.window.createWebviewPanel;
+    let state = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    let disposeHandler = null;
+    let disposed = false;
+    const htmlWrites = [];
+    const webview = {
+      set html(value) { htmlWrites.push(value); },
+      get html() { return htmlWrites[htmlWrites.length - 1]; },
+      onDidReceiveMessage() { return { dispose() {} }; },
+    };
+    const panel = {
+      webview,
+      onDidDispose(handler) { disposeHandler = handler; return { dispose() {} }; },
+      dispose() {
+        if (disposed) return;
+        disposed = true;
+        if (disposeHandler) disposeHandler();
+      },
+    };
+    let resolveFetch;
+    const fetchGate = new Promise(resolve => { resolveFetch = resolve; });
+    let signal;
+    vscode.window.createWebviewPanel = () => panel;
+    try {
+      const provider = new VulnerabilityProvider({}, {
+        connectionManager: { getState() { return { ...state }; } },
+      });
+      provider._fetchVulnerabilities = async (_api, _workspace, _repo, _slug, requestSignal) => {
+        signal = requestSignal;
+        await fetchGate;
+        return {
+          results: [], maxSeverity: "Unknown", numVulns: 0, error: null, complete: true,
+        };
+      };
+      provider._fetchPolicyDecisionTrace = async () => ({
+        parsedReason: null,
+        decisionLogs: [],
+        decisionLogsComplete: true,
+      });
+
+      const pending = provider.show({
+        namespace: "workspace-a",
+        repository: "repo-a",
+        name: "artifact",
+        format: "npm",
+        slug_perm_raw: "package-a",
+        version: "1.0.0",
+      });
+      await new Promise(resolve => setImmediate(resolve));
+      state = { ...state, activationId: "account-b", accountEpoch: 2 };
+      provider.resetForAccountChange();
+      assert.strictEqual(signal.aborted, true);
+      resolveFetch();
+      await pending;
+
+      assert.strictEqual(disposed, true);
+      assert.strictEqual(htmlWrites.length, 1);
+    } finally {
+      vscode.window.createWebviewPanel = originalCreateWebviewPanel;
+    }
   });
 });

--- a/test/vulnerabilitySummaryNode.test.js
+++ b/test/vulnerabilitySummaryNode.test.js
@@ -3,6 +3,17 @@ const VulnerabilitySummaryNode = require("../models/vulnerabilitySummaryNode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
+function scanPage(data) {
+  return apiSuccess(data, {
+    headers: {
+      "x-pagination-page": "1",
+      "x-pagination-pagetotal": "1",
+      "x-pagination-pagesize": "100",
+      "x-pagination-count": String(data.length),
+    },
+  });
+}
+
 suite("VulnerabilitySummaryNode Test Suite", () => {
   const context = {};
   let originalApiGet;
@@ -116,7 +127,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
       calls.push(endpoint);
       if (calls.length === 1) {
-        return apiSuccess([{
+        return scanPage([{
           identifier: "scan-123",
           has_vulnerabilities: true,
           num_vulnerabilities: 2,
@@ -158,7 +169,7 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
     const children = await node.getChildren();
 
     assert.deepStrictEqual(calls, [
-      "vulnerabilities/workspace-a/repo-a/immutable-package-id/",
+      "vulnerabilities/workspace-a/repo-a/immutable-package-id/?page=1&page_size=100",
       "vulnerabilities/workspace-a/repo-a/immutable-package-id/scan-123/",
     ]);
     assert.strictEqual(children.length, 2);
@@ -175,8 +186,8 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
 
   test("shows a retryable error node when vulnerability details fail to load", async () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
-      if (endpoint.endsWith("immutable-package-id/")) {
-        return apiSuccess([{
+      if (endpoint.includes("immutable-package-id/?page=")) {
+        return scanPage([{
           identifier: "scan-123",
           has_vulnerabilities: true,
           num_vulnerabilities: 1,
@@ -204,8 +215,8 @@ suite("VulnerabilitySummaryNode Test Suite", () => {
   test("a failed package lookup cannot reuse vulnerability data from another package", async () => {
     CloudsmithAPI.prototype.get = async (endpoint) => {
       if (endpoint.includes("vulnerable-package")) {
-        if (endpoint.endsWith("vulnerable-package/")) {
-          return apiSuccess([{
+        if (endpoint.includes("vulnerable-package/?page=")) {
+          return scanPage([{
             identifier: "scan-vulnerable",
             has_vulnerabilities: true,
             num_vulnerabilities: 1,

--- a/test/workspaceFetcher.test.js
+++ b/test/workspaceFetcher.test.js
@@ -1,0 +1,126 @@
+const assert = require("assert");
+const { PaginatedFetch } = require("../util/paginatedFetch");
+const { fetchWorkspaces } = require("../util/workspaceFetcher");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
+
+suite("WorkspaceFetcher", () => {
+  test("discovers and stably sorts 1,000 workspaces across pages", async () => {
+    const workspaces = Array.from({ length: 1000 }, (_, index) => ({
+      slug: `workspace-${String(index).padStart(4, "0")}`,
+      name: index === 999 ? "A workspace" : `Workspace ${index}`,
+    }));
+    const calls = [];
+    const api = {
+      async get(endpoint) {
+        const page = requestedPage(endpoint);
+        calls.push(page);
+        const items = workspaces.slice((page - 1) * 500, page * 500);
+        return pageResult(items, page, 2, 1000, 500);
+      },
+    };
+
+    const result = await fetchWorkspaces({}, fetchOptions(api));
+
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.items.length, 1000);
+    assert.strictEqual(result.items[0].slug, "workspace-0999");
+    assert.deepStrictEqual(calls, [1, 2]);
+  });
+
+  test("retains a successful page and reports a later rate limit as incomplete", async () => {
+    const api = {
+      async get(endpoint) {
+        if (requestedPage(endpoint) === 2) return apiFailure("rate_limited", { status: 429 });
+        return pageResult(
+          Array.from({ length: 500 }, (_, index) => ({
+            slug: `workspace-${index}`,
+            name: `Workspace ${index}`,
+          })),
+          1,
+          2,
+          501,
+          500
+        );
+      },
+    };
+
+    const result = await fetchWorkspaces({}, fetchOptions(api));
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.partial, true);
+    assert.strictEqual(result.items.length, 500);
+    assert.strictEqual(result.failureCount, 1);
+    assert.strictEqual(result.failures[0].error.kind, "rate_limited");
+  });
+
+  test("duplicate workspace slugs fail closed and are not published twice", async () => {
+    const api = {
+      async get() {
+        return pageResult(
+          [{ slug: "duplicate", name: "One" }, { slug: "duplicate", name: "Two" }],
+          1,
+          1,
+          2,
+          500
+        );
+      },
+    };
+
+    const result = await fetchWorkspaces({}, fetchOptions(api));
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "duplicate_or_invalid_identity");
+    assert.deepStrictEqual(result.items, []);
+  });
+
+  test("account replacement discards a stale completion", async () => {
+    let state = connectedState(1);
+    let resolveRequest;
+    const api = {
+      async get() {
+        return new Promise(resolve => { resolveRequest = resolve; });
+      },
+    };
+    const promise = fetchWorkspaces({}, fetchOptions(api, () => state));
+    await new Promise(resolve => setImmediate(resolve));
+    state = connectedState(2);
+    resolveRequest(pageResult([], 1, 1, 0, 500));
+
+    const result = await promise;
+
+    assert.strictEqual(result.stale, true);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "stale_account");
+  });
+});
+
+function fetchOptions(api, getState = () => connectedState(1)) {
+  return {
+    cloudsmithAPI: api,
+    paginatedFetch: new PaginatedFetch(api),
+    connectionManager: { getState },
+  };
+}
+
+function connectedState(accountEpoch) {
+  return {
+    sessionConnected: true,
+    accountEpoch,
+    activationId: "activation",
+  };
+}
+
+function requestedPage(endpoint) {
+  return Number(new URL(`https://example.test/${endpoint}`).searchParams.get("page"));
+}
+
+function pageResult(items, page, pageTotal, count, pageSize) {
+  return apiSuccess(items, {
+    headers: {
+      "x-pagination-page": String(page),
+      "x-pagination-pagetotal": String(pageTotal),
+      "x-pagination-count": String(count),
+      "x-pagination-pagesize": String(pageSize),
+    },
+  });
+}

--- a/test/workspaceNode.test.js
+++ b/test/workspaceNode.test.js
@@ -37,10 +37,11 @@ suite("WorkspaceNode", () => {
 
   test("shows an error child when the first repository page fails", async () => {
     const node = createNode(async () => ({
-      repositories: [],
-      error: apiFailure("server_error", { status: 500 }).error,
-      warning: null,
+      items: [],
+      complete: false,
+      incomplete: true,
       partial: false,
+      failures: [{ error: apiFailure("server_error", { status: 500 }).error }],
       stale: false,
     }));
 
@@ -53,13 +54,14 @@ suite("WorkspaceNode", () => {
 
   test("keeps fetched repositories in memory and never writes CloudsmithCache", async () => {
     const node = createNode(async () => ({
-      repositories: [
+      items: [
         { name: "repo-a", slug: "repo-a" },
         { name: "repo-b", slug: "repo-b" },
       ],
-      error: null,
-      warning: null,
+      complete: true,
+      incomplete: false,
       partial: false,
+      failures: [],
       stale: false,
     }));
 
@@ -76,8 +78,9 @@ suite("WorkspaceNode", () => {
     const resultPromise = node.getRepositories();
     manager.setState({ accountEpoch: 2 });
     release({
-      repositories: [{ name: "old", slug: "old" }],
-      error: null,
+      items: [{ name: "old", slug: "old" }],
+      complete: true,
+      failures: [],
       stale: false,
     });
     assert.deepStrictEqual(await resultPromise, []);
@@ -89,7 +92,7 @@ suite("WorkspaceNode", () => {
     let repositoryFetches = 0;
     const node = createNode(async () => {
       repositoryFetches += 1;
-      return { repositories: [], error: null, stale: false };
+      return { items: [], complete: true, failures: [], stale: false };
     }, async () => pendingQuota);
     const resultPromise = node.getChildren();
     manager.setState({ accountEpoch: 2 });
@@ -97,5 +100,61 @@ suite("WorkspaceNode", () => {
 
     assert.deepStrictEqual(await resultPromise, []);
     assert.strictEqual(repositoryFetches, 0);
+  });
+
+  test("preserves repositories from successful pages and labels the collection incomplete", async () => {
+    const created = [];
+    const node = new WorkspaceNode({ name: "Workspace A", slug: "workspace-a" }, context, {
+      connectionManager: manager,
+      createCloudsmithAPI: () => ({ get: async () => apiFailure("forbidden", { status: 403 }) }),
+      fetchWorkspaceRepositories: async () => ({
+        items: [{ name: "repo-a", slug: "repo-a" }],
+        complete: false,
+        incomplete: true,
+        partial: true,
+        failures: [{ error: apiFailure("rate_limited", { status: 429 }).error }],
+        stale: false,
+      }),
+      createRepositoryNode: (repo, workspace) => {
+        const value = { ...repo, workspace };
+        created.push(value);
+        return value;
+      },
+    });
+
+    const repositories = await node.getRepositories();
+
+    assert.deepStrictEqual(created, [{ name: "repo-a", slug: "repo-a", workspace: "workspace-a" }]);
+    assert.strictEqual(repositories[0].name, "repo-a");
+    assert.strictEqual(repositories[1].getTreeItem().label, "Repository list is incomplete");
+  });
+
+  test("propagates its provider lifecycle signal to quota and repository requests", async () => {
+    const controller = new AbortController();
+    let quotaSignal;
+    let repositorySignal;
+    const node = new WorkspaceNode({ name: "Workspace A", slug: "workspace-a" }, context, {
+      connectionManager: manager,
+      signal: controller.signal,
+      createCloudsmithAPI: () => ({
+        get: async (_endpoint, options) => {
+          quotaSignal = options.signal;
+          return apiSuccess({ usage: {} });
+        },
+      }),
+      fetchWorkspaceRepositories: async (_context, _workspace, options) => {
+        repositorySignal = options.signal;
+        return {
+          items: [], complete: true, incomplete: false, partial: false, failures: [], stale: false,
+        };
+      },
+    });
+
+    await node.getChildren();
+    assert.strictEqual(quotaSignal, controller.signal);
+    assert.strictEqual(repositorySignal, controller.signal);
+    controller.abort();
+    assert.strictEqual(quotaSignal.aborted, true);
+    assert.strictEqual(repositorySignal.aborted, true);
   });
 });

--- a/test/workspaceRepositoryFetcher.test.js
+++ b/test/workspaceRepositoryFetcher.test.js
@@ -4,373 +4,197 @@ const { PaginatedFetch } = require("../util/paginatedFetch");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
 const { apiFailure } = require("./apiResultHelpers");
 
-suite("WorkspaceRepositoryFetcher Test Suite", () => {
-  let originalConsole;
+suite("WorkspaceRepositoryFetcher", () => {
   let originalWithProgress;
   let originalFetchPage;
-  let progressOptions;
-  let progressReports;
-  let warnCalls;
   let manager;
 
   setup(() => {
-    originalConsole = global.console;
     originalWithProgress = vscode.window.withProgress;
     originalFetchPage = PaginatedFetch.prototype.fetchPage;
-    progressOptions = null;
-    progressReports = [];
-    warnCalls = [];
-    let state = {
-      activationId: "activation-a",
-      accountEpoch: 1,
-      sessionConnected: true,
-    };
-    manager = {
-      getState() { return { ...state }; },
-      setState(next) { state = { ...state, ...next }; },
-    };
-
-    global.console = new Proxy(originalConsole, {
-      get(target, property) {
-        if (property === "warn") {
-          return (...args) => {
-            warnCalls.push(args);
-          };
-        }
-
-        const value = Reflect.get(target, property, target);
-        return typeof value === "function" ? value.bind(target) : value;
-      },
+    vscode.window.withProgress = async (_options, task) => task({ report() {} }, {
+      isCancellationRequested: false,
     });
-
-    vscode.window.withProgress = async (options, task) => {
-      progressOptions = options;
-      progressReports = [];
-      return task({
-        report(update) {
-          progressReports.push(update);
-        },
-      });
+    let state = connectedState(1);
+    manager = {
+      getState: () => ({ ...state }),
+      setState: next => { state = { ...state, ...next }; },
     };
+    managerForHelper = manager;
   });
 
   teardown(() => {
-    global.console = originalConsole;
     vscode.window.withProgress = originalWithProgress;
     PaginatedFetch.prototype.fetchPage = originalFetchPage;
   });
 
-  function buildRepositories(start, end) {
-    const repositories = [];
-
-    for (let index = start; index >= end; index -= 1) {
-      const suffix = String(index).padStart(3, "0");
-      repositories.push({
-        name: `repo-${suffix}`,
-        slug: `repo-${suffix}`,
-      });
-    }
-
-    return repositories;
-  }
-
-  function fetchRepositories(options = {}) {
-    return workspaceRepositoryFetcher.fetchWorkspaceRepositories({}, "workspace-a", {
-      connectionManager: manager,
-      ...options,
-    });
-  }
-
-  test("stubs console.warn during test setup", () => {
-    console.warn("warning-path");
-
-    assert.deepStrictEqual(warnCalls, [["warning-path"]]);
-  });
-
-  test("fetches and sorts repositories across multiple pages", async () => {
+  test("discovers and stably sorts 1,000 repositories across pages", async () => {
+    const repositories = buildRepositories(1000);
     const calls = [];
-    const firstPageData = buildRepositories(500, 1);
-
-    PaginatedFetch.prototype.fetchPage = async (endpoint, page, pageSize) => {
-      calls.push({ endpoint, page, pageSize });
-
-      if (page === 1) {
-        return {
-          data: firstPageData,
-          pagination: { page: 1, pageTotal: 2, count: 501, pageSize },
-        };
-      }
-
-      return {
-        data: [{ name: "repo-000", slug: "repo-000" }],
-        pagination: { page: 2, pageTotal: 2, count: 501, pageSize },
-      };
-    };
-
-    const result = await fetchRepositories();
-
-    assert.strictEqual(progressOptions.title, "Loading repositories for workspace-a...");
-    assert.deepStrictEqual(
-      progressReports.map(report => report.message),
-      ["Page 1", "Page 2 of 2"]
-    );
-    assert.deepStrictEqual(
-      calls,
-      [
-        { endpoint: "repos/workspace-a/?sort=name", page: 1, pageSize: 500 },
-        { endpoint: "repos/workspace-a/?sort=name", page: 2, pageSize: 500 },
-      ]
-    );
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.partial, false);
-    assert.strictEqual(result.repositories.length, 501);
-    assert.strictEqual(result.repositories[0].name, "repo-000");
-    assert.strictEqual(result.repositories[1].name, "repo-001");
-    assert.strictEqual(result.repositories[500].name, "repo-500");
-  });
-
-  test("continues fetching when the API caps page size below the requested size", async () => {
-    const calls = [];
-    const firstPageData = buildRepositories(250, 1);
-    const secondPageData = buildRepositories(500, 251);
-
-    PaginatedFetch.prototype.fetchPage = async (endpoint, page, pageSize) => {
-      calls.push({ endpoint, page, pageSize });
-
-      if (page === 1) {
-        return {
-          data: firstPageData,
-          pagination: { page: 1, pageTotal: 2, count: 500, pageSize: 250 },
-        };
-      }
-
-      return {
-        data: secondPageData,
-        pagination: { page: 2, pageTotal: 2, count: 500, pageSize: 250 },
-      };
-    };
-
-    const result = await fetchRepositories();
-
-    assert.deepStrictEqual(
-      calls,
-      [
-        { endpoint: "repos/workspace-a/?sort=name", page: 1, pageSize: 500 },
-        { endpoint: "repos/workspace-a/?sort=name", page: 2, pageSize: 500 },
-      ]
-    );
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.partial, false);
-    assert.strictEqual(result.repositories.length, 500);
-    assert.strictEqual(result.repositories[0].name, "repo-001");
-    assert.strictEqual(result.repositories[499].name, "repo-500");
-  });
-
-  test("stops when the current page reaches pageTotal even if the page is full", async () => {
-    const calls = [];
-
     PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
       calls.push(page);
-
-      if (page === 1) {
-        return {
-          data: [
-            { name: "repo-d", slug: "repo-d" },
-            { name: "repo-c", slug: "repo-c" },
-          ],
-          pagination: { page: 1, pageTotal: 2, count: 4, pageSize: 2 },
-        };
-      }
-
-      return {
-        data: [
-          { name: "repo-b", slug: "repo-b" },
-          { name: "repo-a", slug: "repo-a" },
-        ],
-        pagination: { page: 2, pageTotal: 2, count: 4, pageSize: 2 },
-      };
+      const data = repositories.slice((page - 1) * 500, page * 500);
+      return fetchedPage(data, page, 2, 1000, 500);
     };
 
     const result = await fetchRepositories();
 
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.partial, false);
+    assert.strictEqual(result.items.length, 1000);
     assert.deepStrictEqual(calls, [1, 2]);
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.partial, false);
-    assert.deepStrictEqual(
-      result.repositories.map(repository => repository.name),
-      ["repo-a", "repo-b", "repo-c", "repo-d"]
+    assert.strictEqual(result.items[0].slug, "repo-0000");
+    assert.strictEqual(result.items[999].slug, "repo-0999");
+  });
+
+  test("accepts a stable server-lowered page size", async () => {
+    const repositories = buildRepositories(500);
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => fetchedPage(
+      repositories.slice((page - 1) * 250, page * 250),
+      page,
+      2,
+      500,
+      250
     );
-  });
-
-  test("returns partial state when a short page contradicts authoritative later pages", async () => {
-    let calls = 0;
-    PaginatedFetch.prototype.fetchPage = async () => {
-      calls += 1;
-      return {
-        data: [{ name: "repo-a", slug: "repo-a" }],
-        pagination: { page: 1, pageTotal: 2, count: 2, pageSize: 2 },
-      };
-    };
 
     const result = await fetchRepositories();
 
-    assert.strictEqual(calls, 1);
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.partial, true);
-    assert.strictEqual(result.warning.kind, "pagination_incomplete");
-    assert.deepStrictEqual(result.repositories, [{ name: "repo-a", slug: "repo-a" }]);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.items.length, 500);
+    assert.strictEqual(result.pageCount, 2);
   });
 
-  test("returns an error when the first page fails", async () => {
-    const failure = apiFailure("server_error", {
-      status: 500,
-      message: "The Cloudsmith API returned an internal error.",
-    }).error;
-    PaginatedFetch.prototype.fetchPage = async () => ({
-      data: [],
-      pagination: { page: 1, pageTotal: 1, count: 0, pageSize: 500 },
-      error: failure,
-    });
-
-    const result = await fetchRepositories();
-
-    assert.strictEqual(result.error, failure);
-    assert.strictEqual(result.partial, false);
-    assert.deepStrictEqual(result.repositories, []);
-  });
-
-  test("returns partial repositories and logs a warning when a later page fails", async () => {
-    const firstPageData = buildRepositories(500, 1);
-
-    PaginatedFetch.prototype.fetchPage = async (_endpoint, page, pageSize) => {
-      if (page === 1) {
-        return {
-          data: firstPageData,
-          pagination: { page: 1, pageTotal: 2, count: 600, pageSize },
-        };
-      }
-
-      return {
-        data: [],
-        pagination: { page: 2, pageTotal: 2, count: 600, pageSize },
-        error: apiFailure("server_error", {
-          status: 502,
-          message: "The Cloudsmith API returned an internal error.",
-        }).error,
-      };
-    };
-
-    const result = await fetchRepositories();
-
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(result.partial, true);
-    assert.strictEqual(result.warning.kind, "server_error");
-    assert.strictEqual(result.repositories.length, 500);
-    assert.strictEqual(result.repositories[0].name, "repo-001");
-    assert.strictEqual(result.repositories[499].name, "repo-500");
-    assert.deepStrictEqual(warnCalls, [
-      [
-        "[WorkspaceRepositories] Failed to load an additional repository page: The Cloudsmith API returned an internal error.",
-      ],
-    ]);
-  });
-
-  test("returns an error when the first page has a non-array repository payload", async () => {
-    PaginatedFetch.prototype.fetchPage = async () => ({
-      data: { items: [] },
-      pagination: { page: 1, pageTotal: 1, count: 0, pageSize: 500 },
-    });
-
-    const result = await fetchRepositories();
-
-    assert.strictEqual(
-      result.error,
-      workspaceRepositoryFetcher.UNEXPECTED_RESPONSE_FORMAT_ERROR
-    );
-    assert.strictEqual(result.warning, null);
-    assert.strictEqual(result.partial, false);
-    assert.deepStrictEqual(result.repositories, []);
-    assert.deepStrictEqual(warnCalls, []);
-  });
-
-  test("returns partial repositories when a later page has a non-array repository payload", async () => {
+  test("retains successful repositories after a later rate limit", async () => {
     PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
-      if (page === 1) {
+      if (page === 2) {
         return {
-          data: [
-            { name: "repo-c", slug: "repo-c" },
-            { name: "repo-a", slug: "repo-a" },
-          ],
-          pagination: { page: 1, pageTotal: 3, count: 6, pageSize: 2 },
+          data: [],
+          pagination: pagination(2, 2, 501, 500),
+          error: apiFailure("rate_limited", { status: 429 }).error,
         };
       }
-
-      return {
-        data: { items: [] },
-        pagination: { page: 2, pageTotal: 3, count: 6, pageSize: 2 },
-      };
+      return fetchedPage(buildRepositories(500), 1, 2, 501, 500);
     };
 
     const result = await fetchRepositories();
 
-    assert.strictEqual(result.error, null);
-    assert.strictEqual(
-      result.warning,
-      workspaceRepositoryFetcher.UNEXPECTED_RESPONSE_FORMAT_ERROR
-    );
+    assert.strictEqual(result.complete, false);
     assert.strictEqual(result.partial, true);
-    assert.deepStrictEqual(
-      result.repositories.map(repository => repository.name),
-      ["repo-a", "repo-c"]
+    assert.strictEqual(result.items.length, 500);
+    assert.strictEqual(result.failureCount, 1);
+    assert.strictEqual(result.failures[0].error.kind, "rate_limited");
+    assert.strictEqual(result.continuation.nextPage, 2);
+  });
+
+  test("rejects a short non-final page and metadata drift", async () => {
+    PaginatedFetch.prototype.fetchPage = async () => fetchedPage(
+      [{ name: "Repo", slug: "repo" }],
+      1,
+      2,
+      2,
+      2
     );
-    assert.deepStrictEqual(warnCalls, [
-      [
-        "[WorkspaceRepositories] Failed to load additional repositories for workspace-a on page 2: Unexpected repository response format",
-      ],
-    ]);
+    const short = await fetchRepositories();
+    assert.strictEqual(short.complete, false);
+    assert.strictEqual(short.termination, "invalid_pagination");
+    assert.deepStrictEqual(short.items, []);
+
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => page === 1
+      ? fetchedPage(buildRepositories(500), 1, 2, 1000, 500)
+      : fetchedPage(buildRepositories(500, 500), 2, 3, 1500, 500);
+    const drift = await fetchRepositories();
+    assert.strictEqual(drift.complete, false);
+    assert.strictEqual(drift.termination, "invalid_pagination");
+    assert.strictEqual(drift.items.length, 500);
+    assert.strictEqual(drift.continuation, null);
   });
 
-  test("discards all partial repositories when the account changes between pages", async () => {
-    let releaseSecondPage;
-    const secondPage = new Promise(resolve => { releaseSecondPage = resolve; });
-    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
-      if (page === 1) {
-        return {
-          data: [{ name: "old-repo", slug: "old-repo" }],
-          pagination: { page: 1, pageTotal: 2, count: 2, pageSize: 1 },
-        };
-      }
-      return secondPage;
-    };
-    const pending = fetchRepositories();
-    await new Promise(resolve => setImmediate(resolve));
-    manager.setState({ accountEpoch: 2 });
-    releaseSecondPage({
-      data: [{ name: "also-old", slug: "also-old" }],
-      pagination: { page: 2, pageTotal: 2, count: 2, pageSize: 1 },
-    });
+  test("duplicate slugs fail closed without duplicate publication", async () => {
+    PaginatedFetch.prototype.fetchPage = async () => fetchedPage([
+      { name: "One", slug: "duplicate" },
+      { name: "Two", slug: "duplicate" },
+    ], 1, 1, 2, 500);
 
-    const result = await pending;
-    assert.strictEqual(result.stale, true);
-    assert.deepStrictEqual(result.repositories, []);
-    assert.strictEqual(result.error.kind, "stale_account");
+    const result = await fetchRepositories();
+
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "duplicate_or_invalid_identity");
+    assert.strictEqual(result.duplicateCount, 1);
+    assert.deepStrictEqual(result.items, []);
   });
 
-  test("returns partial state instead of looping beyond the repository page ceiling", async () => {
+  test("stops at the cumulative page ceiling without a bypass continuation", async () => {
     let calls = 0;
     PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => {
       calls += 1;
-      return {
-        data: [{ name: `repo-${page}`, slug: `repo-${page}` }],
-        pagination: { page, pageTotal: 21, count: 21, pageSize: 1 },
-      };
+      return fetchedPage(
+        Array.from({ length: 500 }, (_, index) => ({
+          name: `Repo ${page}-${index}`,
+          slug: `repo-${page}-${index}`,
+        })),
+        page,
+        21,
+        10500,
+        500
+      );
     };
 
     const result = await fetchRepositories();
 
     assert.strictEqual(calls, workspaceRepositoryFetcher.MAX_WORKSPACE_REPOSITORY_PAGES);
-    assert.strictEqual(result.partial, true);
-    assert.strictEqual(result.repositories.length, workspaceRepositoryFetcher.MAX_WORKSPACE_REPOSITORY_PAGES);
-    assert.strictEqual(result.warning.kind, "pagination_limit");
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.termination, "page_limit");
+    assert.strictEqual(result.items.length, workspaceRepositoryFetcher.MAX_WORKSPACE_REPOSITORIES);
+    assert.strictEqual(result.continuation, null);
+  });
+
+  test("discards accumulated repositories after account replacement", async () => {
+    let releaseSecondPage;
+    const secondPage = new Promise(resolve => { releaseSecondPage = resolve; });
+    PaginatedFetch.prototype.fetchPage = async (_endpoint, page) => page === 1
+      ? fetchedPage([{ name: "Old", slug: "old" }], 1, 2, 2, 1)
+      : secondPage;
+
+    const pending = fetchRepositories();
+    await new Promise(resolve => setImmediate(resolve));
+    manager.setState({ accountEpoch: 2 });
+    releaseSecondPage(fetchedPage([{ name: "Old 2", slug: "old-2" }], 2, 2, 2, 1));
+    const result = await pending;
+
+    assert.strictEqual(result.stale, true);
+    assert.strictEqual(result.termination, "stale_account");
+    assert.deepStrictEqual(result.items, []);
   });
 });
+
+function fetchRepositories(options = {}) {
+  return workspaceRepositoryFetcher.fetchWorkspaceRepositories({}, "workspace-a", {
+    connectionManager: managerForHelper,
+    ...options,
+  });
+}
+
+let managerForHelper;
+
+function connectedState(accountEpoch) {
+  return {
+    activationId: "activation-a",
+    accountEpoch,
+    sessionConnected: true,
+  };
+}
+
+function buildRepositories(count, offset = 0) {
+  return Array.from({ length: count }, (_, index) => {
+    const suffix = String(index + offset).padStart(4, "0");
+    return { name: `Repo ${suffix}`, slug: `repo-${suffix}` };
+  }).reverse();
+}
+
+function pagination(page, pageTotal, count, pageSize) {
+  return { page, pageTotal, count, countAuthoritative: true, pageSize };
+}
+
+function fetchedPage(data, page, pageTotal, count, pageSize) {
+  return { data, pagination: pagination(page, pageTotal, count, pageSize), error: null };
+}

--- a/util/collectionIdentity.js
+++ b/util/collectionIdentity.js
@@ -1,0 +1,84 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const MAX_COLLECTION_IDENTITY_PART_LENGTH = 512;
+const MAX_IDENTITY_UNWRAP_DEPTH = 4;
+
+function unwrapIdentityValue(value) {
+  let current = value;
+  for (let depth = 0; depth < MAX_IDENTITY_UNWRAP_DEPTH; depth += 1) {
+    if (
+      !current
+      || typeof current !== "object"
+      || Array.isArray(current)
+      || !Object.prototype.hasOwnProperty.call(current, "value")
+    ) {
+      return current;
+    }
+    current = current.value;
+  }
+  return current && typeof current === "object" ? null : current;
+}
+
+function exactIdentityPart(value, label = "collection") {
+  const unwrapped = unwrapIdentityValue(value);
+  if (
+    typeof unwrapped !== "string"
+    || unwrapped.length === 0
+    || unwrapped.length > MAX_COLLECTION_IDENTITY_PART_LENGTH
+    || unwrapped.trim() !== unwrapped
+  ) {
+    throw new TypeError(`The ${label} identity was invalid.`);
+  }
+  return unwrapped;
+}
+
+function canonicalCollectionIdentity(parts, label = "collection") {
+  if (!Array.isArray(parts) || parts.length === 0 || parts.length > 8) {
+    throw new TypeError(`The ${label} identity was invalid.`);
+  }
+  return JSON.stringify(parts.map(part => exactIdentityPart(part, label)));
+}
+
+function workspaceCollectionIdentity(workspace) {
+  return canonicalCollectionIdentity([workspace && workspace.slug], "workspace");
+}
+
+function repositoryCollectionIdentity(workspace, repository) {
+  return canonicalCollectionIdentity(
+    [workspace, repository && repository.slug],
+    "repository"
+  );
+}
+
+function packageCollectionIdentity(pkg) {
+  return canonicalCollectionIdentity(
+    [pkg && pkg.namespace, pkg && pkg.repository, pkg && pkg.slug_perm],
+    "package"
+  );
+}
+
+function packageGroupCollectionIdentity(workspace, repository, group) {
+  return canonicalCollectionIdentity(
+    [workspace, repository, group && group.format, group && group.name],
+    "package group"
+  );
+}
+
+function entitlementCollectionIdentity(workspace, repository, entitlement) {
+  return canonicalCollectionIdentity(
+    [workspace, repository, entitlement && entitlement.slug_perm],
+    "entitlement"
+  );
+}
+
+module.exports = {
+  MAX_COLLECTION_IDENTITY_PART_LENGTH,
+  canonicalCollectionIdentity,
+  entitlementCollectionIdentity,
+  exactIdentityPart,
+  packageCollectionIdentity,
+  packageGroupCollectionIdentity,
+  repositoryCollectionIdentity,
+  unwrapIdentityValue,
+  workspaceCollectionIdentity,
+};

--- a/util/dependencyVulnEnricher.js
+++ b/util/dependencyVulnEnricher.js
@@ -2,6 +2,7 @@
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { getFoundDependencyKey } = require("./foundDependencyKey");
+const { getPackageVulnerabilityState } = require("./packageVulnerabilities");
 const {
   captureAccount,
   isAccountCurrent,
@@ -10,7 +11,11 @@ const {
 
 const VULNERABILITY_CACHE_TTL_MS = 10 * 60 * 1000;
 const VULNERABILITY_CACHE_MAX_SIZE = 5000;
-const VULNERABILITY_CONCURRENCY = 10;
+const VULNERABILITY_CONCURRENCY = 4;
+const MAX_VULNERABILITY_DETAIL_REQUESTS = 1000;
+const MAX_VULNERABILITY_DETAIL_ENTRIES = 5000;
+const MAX_VULNERABILITY_IDENTIFIER_LENGTH = 512;
+const MAX_VULNERABILITY_DISPLAY_LENGTH = 4096;
 const vulnerabilityCache = new Map();
 
 function severityRank(severity) {
@@ -40,18 +45,34 @@ function canonicalSeverity(severity) {
     case "low":
       return "Low";
     default:
-      return severity ? String(severity).trim() : null;
+      return "Unknown";
   }
 }
 
 function getIndicatorCount(packageModel) {
-  const rawCount = packageModel && (
-    packageModel.vulnerability_scan_results_count
-    || packageModel.num_vulnerabilities
-    || packageModel.vulnerabilityCount
-  );
-  const count = Number(rawCount);
-  return Number.isFinite(count) && count > 0 ? count : 0;
+  const state = getPackageVulnerabilityState(packageModel);
+  if (state.count !== null) {
+    return {
+      count: state.count,
+      authoritative: true,
+      detected: state.count > 0,
+      unknown: false,
+    };
+  }
+  if (state.detected) {
+    return {
+      count: state.candidateCount && state.candidateCount > 0 ? state.candidateCount : 0,
+      authoritative: false,
+      detected: true,
+      unknown: state.unknown,
+    };
+  }
+  return {
+    count: 0,
+    authoritative: !state.unknown,
+    detected: false,
+    unknown: state.unknown,
+  };
 }
 
 function buildEmptySummary(packageModel) {
@@ -60,7 +81,7 @@ function buildEmptySummary(packageModel) {
     maxSeverity: canonicalSeverity(packageModel && packageModel.max_severity),
     cveIds: [],
     hasFixAvailable: false,
-    severityCounts: {},
+    severityCounts: Object.create(null),
     entries: [],
     detailsLoaded: false,
     policyViolated: Boolean(packageModel && packageModel.vulnerability_policy_violated),
@@ -68,14 +89,21 @@ function buildEmptySummary(packageModel) {
 }
 
 function buildIndicatorSummary(packageModel) {
-  const count = getIndicatorCount(packageModel);
-  if (count === 0) {
-    return buildEmptySummary(packageModel);
+  const indicator = getIndicatorCount(packageModel);
+  const { count } = indicator;
+  if (count === 0 && !indicator.detected && !indicator.unknown) {
+    return {
+      ...buildEmptySummary(packageModel),
+      countAuthoritative: indicator.authoritative,
+      countKnown: indicator.authoritative,
+      detected: false,
+      unknown: false,
+    };
   }
 
   const maxSeverity = canonicalSeverity(packageModel && packageModel.max_severity);
-  const severityCounts = {};
-  if (maxSeverity) {
+  const severityCounts = Object.create(null);
+  if (indicator.detected && maxSeverity && maxSeverity !== "Unknown") {
     severityCounts[maxSeverity] = 1;
   }
 
@@ -87,6 +115,10 @@ function buildIndicatorSummary(packageModel) {
     severityCounts,
     entries: [],
     detailsLoaded: false,
+    countAuthoritative: indicator.authoritative,
+    countKnown: indicator.authoritative,
+    detected: indicator.detected,
+    unknown: indicator.unknown,
     policyViolated: Boolean(packageModel && packageModel.vulnerability_policy_violated),
   };
 }
@@ -146,7 +178,7 @@ function extractFixVersion(entry) {
   }
 
   for (const candidate of candidates) {
-    const value = String(candidate || "").trim();
+    const value = boundedDisplayString(candidate, MAX_VULNERABILITY_IDENTIFIER_LENGTH);
     if (value) {
       return value;
     }
@@ -164,36 +196,61 @@ function normalizeEntry(entry) {
     )
   ) || "Unknown";
 
-  const cveId = String(
+  const cveId = boundedDisplayString(
     (entry && (
       entry.vulnerability_id
       || entry.identifier
       || entry.id
       || entry.name
-    )) || "Unknown"
-  ).trim();
+    )) || "Unknown",
+    MAX_VULNERABILITY_IDENTIFIER_LENGTH
+  ) || "Unknown";
 
   const fixVersion = extractFixVersion(entry);
 
   return {
     cveId,
     severity,
-    description: String(entry && (entry.title || entry.description || "") || "").trim(),
+    description: boundedDisplayString(
+      entry && (entry.title || entry.description || ""),
+      MAX_VULNERABILITY_DISPLAY_LENGTH
+    ) || "",
     fixVersion,
     hasFixAvailable: Boolean(fixVersion),
   };
 }
 
+function vulnerabilityIdentity(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  const aliases = ["vulnerability_id", "identifier", "id", "name"]
+    .filter(key => Object.prototype.hasOwnProperty.call(entry, key))
+    .map(key => boundedDisplayString(entry[key], MAX_VULNERABILITY_IDENTIFIER_LENGTH))
+    .filter(Boolean);
+  if (aliases.length === 0) return null;
+  const identities = new Set(aliases.map(value => value.toLocaleLowerCase("en-US")));
+  return identities.size === 1 ? [...identities][0] : null;
+}
+
 function summarizeEntries(entries, fallbackSummary) {
-  const severityCounts = {};
+  const identities = entries.map(vulnerabilityIdentity);
+  if (
+    identities.some(identity => !identity)
+    || new Set(identities).size !== identities.length
+    || fallbackSummary.countAuthoritative !== true
+    || entries.length !== fallbackSummary.count
+  ) return fallbackSummary;
+
+  const severityCounts = Object.create(null);
   const cveIds = [];
+  const seenCveIds = new Set();
   const normalizedEntries = [];
   let maxSeverity = null;
   let hasFixAvailable = false;
 
   for (const entry of entries.map(normalizeEntry)) {
     normalizedEntries.push(entry);
-    if (!cveIds.includes(entry.cveId)) {
+    if (!seenCveIds.has(entry.cveId)) {
+      seenCveIds.add(entry.cveId);
       cveIds.push(entry.cveId);
     }
     severityCounts[entry.severity] = (severityCounts[entry.severity] || 0) + 1;
@@ -206,13 +263,17 @@ function summarizeEntries(entries, fallbackSummary) {
   }
 
   return {
-    count: normalizedEntries.length || fallbackSummary.count || 0,
+    count: fallbackSummary.count,
     maxSeverity: maxSeverity || fallbackSummary.maxSeverity || null,
     cveIds,
     hasFixAvailable,
     severityCounts,
     entries: normalizedEntries,
     detailsLoaded: true,
+    countAuthoritative: true,
+    countKnown: true,
+    detected: normalizedEntries.length > 0,
+    unknown: false,
     policyViolated: Boolean(fallbackSummary.policyViolated),
   };
 }
@@ -291,7 +352,7 @@ async function runPool(items, concurrency, worker) {
     })());
   }
 
-  await Promise.all(workers);
+  await Promise.allSettled(workers);
 }
 
 function pruneExpiredVulnerabilityCache(now = Date.now()) {
@@ -386,12 +447,17 @@ async function fetchVulnerabilitySummary(
   } catch {
     return null;
   }
-  const response = await api.getV2(endpoint, {
-    responseType: "json",
-    validate: isRecognizedVulnerabilityDetail,
-    retry: "never",
-    cancellationToken,
-  });
+  let response;
+  try {
+    response = await api.getV2(endpoint, {
+      responseType: "json",
+      validate: isRecognizedVulnerabilityDetail,
+      retry: "never",
+      cancellationToken,
+    });
+  } catch {
+    return null;
+  }
   if (
     !response.ok
     || isCancellationRequested(cancellationToken)
@@ -400,9 +466,13 @@ async function fetchVulnerabilitySummary(
     return null;
   }
 
-  const summary = summarizeEntries(extractVulnerabilityEntries(response.data), fallbackSummary);
+  const entries = extractVulnerabilityEntries(response.data);
+  if (!isVulnerabilityRecordArray(entries)) return null;
+  const summary = summarizeEntries(entries, fallbackSummary);
   if (!isAccountCurrent(connectionManager, account)) return null;
-  setCachedVulnerabilitySummary(packageKey, summary, account, now());
+  if (summary.detailsLoaded) {
+    setCachedVulnerabilitySummary(packageKey, summary, account, now());
+  }
   return summary;
 }
 
@@ -437,16 +507,22 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
   for (const group of groups) {
     const indicatorSummary = buildIndicatorSummary(group.packageModel);
     patchMap.set(group.key, indicatorSummary);
-    if (indicatorSummary.count > 0) {
-      detailTargets.push({
-        ...group,
-        fallbackSummary: indicatorSummary,
-      });
+    if (
+      indicatorSummary.count > 0
+      && indicatorSummary.count <= MAX_VULNERABILITY_DETAIL_ENTRIES
+      && indicatorSummary.countAuthoritative === true
+    ) {
+      if (detailTargets.length < MAX_VULNERABILITY_DETAIL_REQUESTS) {
+        detailTargets.push({
+          ...group,
+          fallbackSummary: indicatorSummary,
+        });
+      }
     }
   }
 
   if (onProgress && patchMap.size > 0 && isAccountCurrent(connectionManager, account)) {
-    onProgress(new Map(patchMap), {
+    publishProgress(onProgress, new Map(patchMap), {
       completed: 0,
       total: detailTargets.length,
       workspace,
@@ -482,7 +558,7 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
     completed += 1;
 
     if (onProgress && isAccountCurrent(connectionManager, account)) {
-      onProgress(summary ? new Map([[target.key, summary]]) : new Map(), {
+      publishProgress(onProgress, summary ? new Map([[target.key, summary]]) : new Map(), {
         completed,
         total: detailTargets.length,
         workspace,
@@ -495,6 +571,14 @@ async function enrichVulnerabilities(dependencies, workspace, options = {}) {
     return Array.isArray(dependencies) ? dependencies : [];
   }
   return applyVulnerabilityPatch(dependencies, patchMap);
+}
+
+function publishProgress(onProgress, patchMap, metadata) {
+  try {
+    onProgress(patchMap, metadata);
+  } catch {
+    // Progress callbacks are observers and cannot abort or outlive the bounded work pool.
+  }
 }
 
 function isRecognizedVulnerabilityDetail(value) {
@@ -513,24 +597,50 @@ function isRecognizedVulnerabilityDetail(value) {
   if (Object.prototype.hasOwnProperty.call(value, "items")) {
     return Array.isArray(value.items) && isVulnerabilityRecordArray(value.items);
   }
-  return Array.isArray(value.scans) && value.scans.every(scan => (
-    scan
-    && typeof scan === "object"
-    && !Array.isArray(scan)
-    && Array.isArray(scan.results)
-    && isVulnerabilityRecordArray(scan.results)
-  ));
+  if (!Array.isArray(value.scans) || value.scans.length > 100) return false;
+  let totalEntries = 0;
+  for (const scan of value.scans) {
+    if (
+      !scan
+      || typeof scan !== "object"
+      || Array.isArray(scan)
+      || !Array.isArray(scan.results)
+      || !isVulnerabilityRecordArray(scan.results)
+    ) return false;
+    totalEntries += scan.results.length;
+    if (totalEntries > MAX_VULNERABILITY_DETAIL_ENTRIES) return false;
+  }
+  return true;
 }
 
 function isVulnerabilityRecordArray(value) {
-  return Array.isArray(value) && value.every(entry => (
+  if (
+    !Array.isArray(value)
+    || value.length > MAX_VULNERABILITY_DETAIL_ENTRIES
+    || !value.every(entry => (
     Boolean(entry)
     && typeof entry === "object"
     && !Array.isArray(entry)
     && [entry.vulnerability_id, entry.identifier, entry.id, entry.name]
-      .some(identifier => typeof identifier === "string" && identifier.trim().length > 0)
-    && (entry.severity === undefined || entry.severity === null || typeof entry.severity === "string")
-  ));
+      .some(identifier => Boolean(boundedDisplayString(
+        identifier,
+        MAX_VULNERABILITY_IDENTIFIER_LENGTH
+      )))
+    && (
+      entry.severity === undefined
+      || entry.severity === null
+      || Boolean(boundedDisplayString(entry.severity, 100))
+    )
+  ))
+  ) return false;
+  const identities = value.map(vulnerabilityIdentity);
+  return identities.every(Boolean) && new Set(identities).size === identities.length;
+}
+
+function boundedDisplayString(value, maxLength) {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const normalized = String(value).trim();
+  return normalized.length > 0 && normalized.length <= maxLength ? normalized : null;
 }
 
 module.exports = {
@@ -541,5 +651,6 @@ module.exports = {
   getVulnerabilityCacheSize() {
     return vulnerabilityCache.size;
   },
+  MAX_VULNERABILITY_DETAIL_REQUESTS,
   VULNERABILITY_CACHE_MAX_SIZE,
 };

--- a/util/foundDependencyKey.js
+++ b/util/foundDependencyKey.js
@@ -1,19 +1,16 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const { packageCollectionIdentity } = require("./collectionIdentity");
+
 function getFoundDependencyKey(dependency) {
   if (!dependency || !dependency.cloudsmithPackage) {
     return null;
   }
 
-  const pkg = dependency.cloudsmithPackage;
-  const workspace = String(pkg.namespace || "").trim().toLowerCase();
-  const repo = String(pkg.repository || "").trim().toLowerCase();
-  const slug = String(pkg.slug_perm || pkg.slugPerm || pkg.slug || pkg.identifier || "").trim().toLowerCase();
-
-  if (!workspace || !repo || !slug) {
+  try {
+    return packageCollectionIdentity(dependency.cloudsmithPackage);
+  } catch {
     return null;
   }
-
-  return `${workspace}:${repo}:${slug}`;
 }
 
 module.exports = {

--- a/util/packageVulnerabilities.js
+++ b/util/packageVulnerabilities.js
@@ -1,15 +1,26 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
 const { apiEndpoint, encodeApiPathSegment } = require("./apiEndpoint");
+const { PaginatedFetch } = require("./paginatedFetch");
+const { exactIdentityPart, unwrapIdentityValue } = require("./collectionIdentity");
 
 const VULNERABILITIES_DETECTED_STATUS = "scan detected vulnerabilities";
+const VULNERABILITIES_CLEAN_STATUS = "scan detected no vulnerabilities";
+const VULNERABILITY_SCAN_PAGE_SIZE = 100;
+const MAX_VULNERABILITY_SCAN_PAGES = 20;
+const MAX_VULNERABILITY_SCANS = VULNERABILITY_SCAN_PAGE_SIZE * MAX_VULNERABILITY_SCAN_PAGES;
+const MAX_VULNERABILITY_DETAILS = 5000;
+const MAX_VULNERABILITY_IDENTIFIER_LENGTH = 512;
+const MAX_VULNERABILITY_SEVERITY_LENGTH = 100;
+const PACKAGE_POLICY_FIELDS = Object.freeze([
+  "policy_violated",
+  "deny_policy_violated",
+  "license_policy_violated",
+  "vulnerability_policy_violated",
+]);
 
 function unwrapValue(value) {
-  let current = value;
-  while (current && typeof current === "object" && "value" in current) {
-    current = current.value;
-  }
-  return current;
+  return unwrapIdentityValue(value);
 }
 
 function normalizeCount(value) {
@@ -18,8 +29,10 @@ function normalizeCount(value) {
     return null;
   }
 
+  if (Number.isSafeInteger(unwrapped) && unwrapped >= 0) return unwrapped;
+  if (typeof unwrapped !== "string" || !/^(0|[1-9]\d*)$/.test(unwrapped)) return null;
   const count = Number(unwrapped);
-  return Number.isInteger(count) && count >= 0 ? count : null;
+  return Number.isSafeInteger(count) ? count : null;
 }
 
 function normalizeBoolean(value) {
@@ -37,24 +50,34 @@ function normalizeBoolean(value) {
 
 /**
  * Return a numeric package vulnerability indicator.
- * Positive values are known counts, zero means clean/unknown, and -1 means
- * the package status confirms vulnerabilities but the list response omitted a count.
+ * Positive values are known counts, zero is an authoritative clean indicator,
+ * -1 means vulnerabilities were detected without a trustworthy count, and null
+ * means the available evidence cannot establish either detection or cleanliness.
  */
 function getPackageVulnerabilityCount(pkg) {
-  const explicitCount = normalizeCount(pkg && pkg.num_vulnerabilities);
-  if (explicitCount !== null) {
-    return explicitCount;
-  }
+  const indicator = getPackageVulnerabilityState(pkg);
+  return indicator.count !== null
+    ? indicator.count
+    : indicator.detected ? -1 : indicator.unknown ? null : 0;
+}
 
-  const explicitPresence = normalizeBoolean(pkg && pkg.has_vulnerabilities);
-  if (explicitPresence !== null) {
-    return explicitPresence ? -1 : 0;
+/**
+ * Canonicalize security policy booleans without turning malformed present values
+ * into negative evidence. Missing fields retain the API's legacy false default.
+ */
+function getPackagePolicyFlags(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const flags = {};
+  for (const field of PACKAGE_POLICY_FIELDS) {
+    if (
+      Object.prototype.hasOwnProperty.call(value, field)
+      && typeof value[field] !== "boolean"
+    ) {
+      return null;
+    }
+    flags[field] = value[field] === true;
   }
-
-  const scanStatus = String(unwrapValue(pkg && pkg.security_scan_status) || "")
-    .trim()
-    .toLowerCase();
-  return scanStatus === VULNERABILITIES_DETECTED_STATUS ? -1 : 0;
+  return flags;
 }
 
 function extractResultsFromScan(scan) {
@@ -87,7 +110,7 @@ function extractVulnerabilityResults(payload) {
   }
 
   if (Array.isArray(payload.scan)) {
-    return payload.scan.flatMap(extractResultsFromScan);
+    return collectNestedVulnerabilityResults(payload.scan);
   }
   const documentedResults = extractResultsFromScan(payload.scan);
   if (documentedResults.length > 0) {
@@ -95,23 +118,94 @@ function extractVulnerabilityResults(payload) {
   }
 
   if (Array.isArray(payload.scans)) {
-    return payload.scans.flatMap(extractResultsFromScan);
+    return collectNestedVulnerabilityResults(payload.scans);
   }
 
   return [];
 }
 
-function scanReportsVulnerabilities(scan) {
-  const presence = normalizeBoolean(scan && scan.has_vulnerabilities);
-  if (presence !== null) {
-    return presence;
+function collectNestedVulnerabilityResults(scans) {
+  if (!Array.isArray(scans) || scans.length > MAX_VULNERABILITY_DETAILS) return null;
+  const results = [];
+  for (const scan of scans) {
+    const scanResults = extractResultsFromScan(scan);
+    if (results.length + scanResults.length > MAX_VULNERABILITY_DETAILS) return null;
+    results.push(...scanResults);
   }
-  const count = normalizeCount(scan && scan.num_vulnerabilities);
-  return count !== null ? count > 0 : false;
+  return results;
 }
 
-function result(error, results = [], maxSeverity = "Unknown", numVulns = 0) {
-  return { results, maxSeverity, numVulns, error };
+function scanReportsVulnerabilities(scan) {
+  const indicator = getPackageVulnerabilityState(scan);
+  return indicator.detected || indicator.unknown;
+}
+
+function getPackageVulnerabilityState(value) {
+  const record = value && typeof value === "object" ? value : {};
+  const countAliases = [
+    "num_vulnerabilities",
+    "vulnerability_scan_results_count",
+    "vulnerabilityCount",
+  ].filter(alias => (
+    Object.prototype.hasOwnProperty.call(record, alias)
+    && record[alias] !== undefined
+    && record[alias] !== null
+    && record[alias] !== ""
+  ));
+  const counts = countAliases.map(alias => normalizeCount(record[alias]));
+  const invalidCount = counts.some(count => count === null);
+  const validCounts = counts.filter(Number.isSafeInteger);
+  const uniqueCounts = new Set(validCounts);
+  const hasPresence = Object.prototype.hasOwnProperty.call(record, "has_vulnerabilities")
+    && record.has_vulnerabilities !== undefined
+    && record.has_vulnerabilities !== null
+    && record.has_vulnerabilities !== "";
+  const presence = hasPresence ? normalizeBoolean(record.has_vulnerabilities) : null;
+  const invalidPresence = hasPresence && presence === null;
+  const status = unwrapValue(record.security_scan_status);
+  const hasStatus = status !== undefined && status !== null && status !== "";
+  const validStatus = !hasStatus || (typeof status === "string" && status.length <= 256);
+  const normalizedStatus = validStatus && typeof status === "string"
+    ? status.trim().toLowerCase()
+    : null;
+  const detectedStatus = normalizedStatus === VULNERABILITIES_DETECTED_STATUS;
+  const cleanStatus = normalizedStatus === VULNERABILITIES_CLEAN_STATUS;
+  const recognizedStatus = !hasStatus || detectedStatus || cleanStatus;
+  const positiveCount = validCounts.some(count => count > 0);
+  const zeroCount = validCounts.some(count => count === 0);
+  const detected = positiveCount || presence === true || detectedStatus;
+  const conflict = uniqueCounts.size > 1
+    || (detected && (zeroCount || presence === false || cleanStatus));
+  const hasEvidence = countAliases.length > 0 || hasPresence || hasStatus;
+  const unknown = !hasEvidence
+    || invalidCount
+    || invalidPresence
+    || !validStatus
+    || !recognizedStatus
+    || conflict;
+  const explicitClean = presence === false || cleanStatus;
+  const count = !unknown && uniqueCounts.size === 1
+    ? validCounts[0]
+    : !unknown && explicitClean ? 0 : null;
+  return {
+    count,
+    detected,
+    unknown,
+    candidateCount: validCounts.length > 0 ? Math.max(...validCounts) : null,
+  };
+}
+
+function result(error, results = [], maxSeverity = "Unknown", numVulns = 0, complete = error == null) {
+  return {
+    results,
+    maxSeverity,
+    numVulns: error == null && complete ? numVulns : -1,
+    error,
+    complete,
+    incomplete: !complete,
+    partial: !complete && results.length > 0,
+    cancelled: Boolean(error && typeof error === "object" && error.kind === "cancelled"),
+  };
 }
 
 /**
@@ -127,17 +221,30 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
     return result(error, [], "Unknown", fallbackCount);
   }
 
-  const scanListResult = await api.get(scanListEndpoint, {
+  const paginatedFetch = options.paginatedFetch || new PaginatedFetch(api);
+  const scanCollection = await paginatedFetch.fetchCollection(scanListEndpoint, {
+    pageSize: VULNERABILITY_SCAN_PAGE_SIZE,
+    maxPages: MAX_VULNERABILITY_SCAN_PAGES,
+    maxRequests: MAX_VULNERABILITY_SCAN_PAGES,
+    maxItems: MAX_VULNERABILITY_SCANS,
+    canonicalIdentity: scanIdentity,
+    descriptor: `vulnerability-scans:${workspace}:${repo}:${packageIdentifier}`,
     responseType: "array",
     validate: isScanRecordArray,
     retry: options.retry || "safe-read",
     signal: options.signal,
     cancellationToken: options.cancellationToken,
   });
-  if (!scanListResult.ok) {
-    return result(scanListResult.error, [], "Unknown", fallbackCount);
+  if (!scanCollection.complete) {
+    return result(
+      scanCollection.failures[0]?.error || incompleteScanHistoryError(),
+      [],
+      "Unknown",
+      fallbackCount,
+      false
+    );
   }
-  const scanList = scanListResult.data;
+  const scanList = scanCollection.items;
   if (scanList.length === 0) {
     if (fallbackCount > 0 || expectedCount < 0) {
       return result("No vulnerability scan details were returned for this package.", [], "Unknown", fallbackCount);
@@ -145,12 +252,20 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
     return result(null);
   }
 
-  const targetScan = scanList.find(scanReportsVulnerabilities) || scanList[0];
-  const declaredCount = normalizeCount(targetScan.num_vulnerabilities);
-  const maxSeverity = targetScan.max_severity || "Unknown";
+  const targetScan = selectLatestScan(scanList);
+  if (!targetScan) {
+    return result(invalidScanHistoryError(), [], "Unknown", fallbackCount, false);
+  }
+  const scanIndicator = getPackageVulnerabilityState(targetScan);
+  const declaredCount = scanIndicator.unknown ? null : scanIndicator.count;
+  const maxSeverity = boundedString(
+    unwrapValue(targetScan.max_severity),
+    MAX_VULNERABILITY_SEVERITY_LENGTH
+  )
+    || "Unknown";
   const numVulns = declaredCount !== null
     ? declaredCount
-    : (scanReportsVulnerabilities(targetScan) ? -1 : fallbackCount);
+    : (scanIndicator.detected || scanIndicator.unknown ? -1 : fallbackCount);
   const scanId = unwrapValue(targetScan.identifier);
 
   if (!scanId) {
@@ -188,7 +303,11 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
   }
   const scanDetail = scanDetailResult.data;
 
-  const results = extractVulnerabilityResults(scanDetail).map(normalizeVulnerabilityRecord);
+  const extractedResults = extractVulnerabilityResults(scanDetail);
+  if (!isVulnerabilityRecordArray(extractedResults)) {
+    return result(invalidVulnerabilityDetailsError(), [], maxSeverity, numVulns, false);
+  }
+  const results = extractedResults.map(normalizeVulnerabilityRecord);
   if (results.length === 0 && (numVulns > 0 || scanReportsVulnerabilities(targetScan))) {
     return result(
       "The scan reports vulnerabilities, but no vulnerability detail records were returned.",
@@ -198,7 +317,104 @@ async function fetchPackageVulnerabilities(api, workspace, repo, packageIdentifi
     );
   }
 
-  return result(null, results, maxSeverity, results.length || numVulns);
+  const expectedDetailCount = declaredCount !== null
+    ? declaredCount
+    : fallbackCount > 0 ? fallbackCount : null;
+  if (expectedDetailCount !== null && results.length !== expectedDetailCount) {
+    return result(
+      invalidVulnerabilityDetailsError(),
+      results,
+      maxSeverity,
+      numVulns,
+      false
+    );
+  }
+
+  return result(null, results, maxSeverity, results.length || numVulns, true);
+}
+
+function scanIdentity(scan) {
+  const identifier = unwrapValue(scan && scan.identifier);
+  try {
+    const identity = exactIdentityPart(identifier, "vulnerability scan");
+    encodeApiPathSegment(identity);
+    return identity;
+  } catch {
+    return null;
+  }
+}
+
+function selectLatestScan(scans) {
+  if (!Array.isArray(scans) || scans.length === 0) return null;
+  if (scans.length === 1) return scans[0];
+
+  const timestamps = scans.map(scanTimestamp);
+  if (timestamps.every(Number.isFinite)) {
+    const latestTimestamp = Math.max(...timestamps);
+    const latest = scans.filter((_scan, index) => timestamps[index] === latestTimestamp);
+    if (latest.length === 1) return latest[0];
+    return selectBySafeScanId(latest);
+  }
+  return selectBySafeScanId(scans);
+}
+
+function selectBySafeScanId(scans) {
+  const scanIds = scans.map(scan => scan && scan.scan_id);
+  if (!scanIds.every(value => Number.isSafeInteger(value) && value >= 0)) return null;
+  const maxScanId = Math.max(...scanIds);
+  const latest = scans.filter((_scan, index) => scanIds[index] === maxScanId);
+  return latest.length === 1 ? latest[0] : null;
+}
+
+function scanTimestamp(scan) {
+  const value = scan && scan.created_at;
+  if (typeof value !== "string" || value.length === 0 || value.length > 128) return NaN;
+  return Date.parse(value);
+}
+
+function incompleteScanHistoryError() {
+  return Object.freeze({
+    kind: "pagination_incomplete",
+    status: null,
+    retryable: true,
+    message: "Vulnerability scan history could not be loaded completely.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
+}
+
+function invalidScanHistoryError() {
+  return Object.freeze({
+    kind: "invalid_response",
+    status: null,
+    retryable: false,
+    message: "Vulnerability scan history did not provide an unambiguous latest scan.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
+}
+
+function invalidVulnerabilityDetailsError() {
+  return Object.freeze({
+    kind: "invalid_response",
+    status: null,
+    retryable: false,
+    message: "Vulnerability details did not match the authoritative scan summary.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
+}
+
+function boundedString(value, maxLength) {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength
+    ? value
+    : null;
 }
 
 function isRecordArray(value) {
@@ -208,41 +424,62 @@ function isRecordArray(value) {
 }
 
 function hasUsableScanIdentifier(value) {
-  const identifier = unwrapValue(value && value.identifier);
-  if (typeof identifier !== "string" || identifier.length === 0) {
-    return false;
-  }
-  try {
-    encodeApiPathSegment(identifier);
-    return true;
-  } catch {
-    return false;
-  }
+  return Boolean(scanIdentity(value));
 }
 
 function isScanRecordArray(value) {
-  return isRecordArray(value) && value.every(hasUsableScanIdentifier);
+  return isRecordArray(value)
+    && value.length <= VULNERABILITY_SCAN_PAGE_SIZE
+    && value.every(hasUsableScanIdentifier);
 }
 
 function isVulnerabilityRecordArray(value) {
-  return isRecordArray(value) && value.every(isVulnerabilityRecord);
+  if (
+    !isRecordArray(value)
+    || value.length > MAX_VULNERABILITY_DETAILS
+    || !value.every(isVulnerabilityRecord)
+  ) return false;
+  const identities = value.map(vulnerabilityIdentity);
+  return identities.every(Boolean) && new Set(identities).size === identities.length;
+}
+
+function vulnerabilityIdentifiers(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  return ["vulnerability_id", "identifier", "id", "name"]
+    .filter(key => Object.prototype.hasOwnProperty.call(value, key))
+    .map(key => value[key])
+    .filter(candidate => candidate !== null && candidate !== undefined && candidate !== "")
+    .map(candidate => typeof candidate === "string" ? candidate.trim() : null);
 }
 
 function vulnerabilityIdentifier(value) {
-  const candidate = value && (
-    value.vulnerability_id
-    || value.identifier
-    || value.id
-    || value.name
-  );
-  return typeof candidate === "string" && candidate.trim().length > 0
-    ? candidate.trim()
-    : null;
+  const identifiers = vulnerabilityIdentifiers(value);
+  if (
+    identifiers.length === 0
+    || identifiers.some(identifier => (
+      !identifier
+      || identifier.length > MAX_VULNERABILITY_IDENTIFIER_LENGTH
+    ))
+  ) return null;
+  const canonical = new Set(identifiers.map(identifier => identifier.toLocaleLowerCase("en-US")));
+  return canonical.size === 1 ? identifiers[0] : null;
+}
+
+function vulnerabilityIdentity(value) {
+  const identifier = vulnerabilityIdentifier(value);
+  return identifier ? identifier.toLocaleLowerCase("en-US") : null;
 }
 
 function isVulnerabilityRecord(value) {
   return Boolean(vulnerabilityIdentifier(value))
-    && (value.severity === undefined || value.severity === null || typeof value.severity === "string");
+    && (
+      value.severity === undefined
+      || value.severity === null
+      || (
+        typeof value.severity === "string"
+        && value.severity.length <= MAX_VULNERABILITY_SEVERITY_LENGTH
+      )
+    );
 }
 
 function normalizeVulnerabilityRecord(value) {
@@ -278,18 +515,33 @@ function isRecognizedVulnerabilityPayload(value) {
     return Array.isArray(value.vulnerabilities) && isVulnerabilityRecordArray(value.vulnerabilities);
   }
   if (Array.isArray(value.scan)) {
-    return value.scan.every(hasRecognizedVulnerabilityArray);
+    return isBoundedNestedVulnerabilityPayload(value.scan);
   }
   if (value.scan && typeof value.scan === "object") {
     return hasRecognizedVulnerabilityArray(value.scan);
   }
-  return Array.isArray(value.scans) && value.scans.every(scan => (
-    hasRecognizedVulnerabilityArray(scan)
-  ));
+  return Array.isArray(value.scans) && isBoundedNestedVulnerabilityPayload(value.scans);
+}
+
+function isBoundedNestedVulnerabilityPayload(scans) {
+  if (!Array.isArray(scans) || scans.length > MAX_VULNERABILITY_DETAILS) return false;
+  let total = 0;
+  for (const scan of scans) {
+    if (!hasRecognizedVulnerabilityArray(scan)) return false;
+    const results = extractResultsFromScan(scan);
+    total += results.length;
+    if (total > MAX_VULNERABILITY_DETAILS) return false;
+  }
+  return true;
 }
 
 module.exports = {
+  MAX_VULNERABILITY_DETAILS,
+  MAX_VULNERABILITY_SCAN_PAGES,
+  VULNERABILITY_SCAN_PAGE_SIZE,
   extractVulnerabilityResults,
   fetchPackageVulnerabilities,
+  getPackagePolicyFlags,
   getPackageVulnerabilityCount,
+  getPackageVulnerabilityState,
 };

--- a/util/paginatedFetch.js
+++ b/util/paginatedFetch.js
@@ -1,202 +1,974 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
-// Handles paginated API responses from Cloudsmith.
+// Strict, bounded collection access for Cloudsmith's numeric pagination contract.
 
+const crypto = require("crypto");
 const { appendApiQuery } = require("./apiEndpoint");
 
-const MAX_FETCH_ALL_PAGES = 20;
+const MAX_COLLECTION_FAILURE_DETAILS = 20;
+const MAX_COLLECTION_DESCRIPTOR_LENGTH = 4096;
+const MAX_PAGE_SIZE = 500;
 
 class PaginatedFetch {
-    constructor(cloudsmithAPI) {
-        this.api = cloudsmithAPI;
+  constructor(cloudsmithAPI) {
+    this.api = cloudsmithAPI;
+  }
+
+  /** Fetch one validated page. Collection-wide consistency is checked by fetchCollection. */
+  async fetchPage(endpoint, page, pageSize, query, options = {}) {
+    if (!isPositiveSafeInteger(page) || !isPageSize(pageSize)) {
+      return failedPage(
+        page,
+        pageSize,
+        localInvalidResponseError("The requested pagination values were invalid.")
+      );
     }
 
-    /**
-     * Fetch a single page with pagination metadata.
-     *
-     * @param   endpoint  Base endpoint (e.g., 'packages/owner/')
-     * @param   page      Page number (1-indexed)
-     * @param   pageSize  Results per page
-     * @param   query     Optional query string to append
-     * @returns { data: [], pagination: { page, pageTotal, count, pageSize } }
-     */
-    async fetchPage(endpoint, page, pageSize, query, options = {}) {
-        let url;
+    let url;
+    try {
+      url = appendApiQuery(endpoint, {
+        page,
+        page_size: pageSize,
+        ...(query ? { query } : {}),
+      });
+    } catch {
+      return failedPage(
+        page,
+        pageSize,
+        localInvalidResponseError("The paginated API endpoint was invalid.")
+      );
+    }
+
+    const decoder = createDecoder(options);
+    if (!decoder) {
+      return failedPage(
+        page,
+        pageSize,
+        localInvalidResponseError("The paginated response decoder was invalid.")
+      );
+    }
+
+    const requestOptions = {
+      responseType: decoder.responseType,
+      validate: decoder.validateResponse,
+      retry: options.retry || "never",
+      signal: options.signal,
+      cancellationToken: options.cancellationToken,
+    };
+    if (Object.prototype.hasOwnProperty.call(options, "apiKey")) {
+      requestOptions.apiKey = options.apiKey;
+    }
+
+    let result;
+    try {
+      result = await this.api.get(url, requestOptions);
+    } catch (error) {
+      return failedPage(page, pageSize, unexpectedRequestError(error));
+    }
+
+    if (!result || !result.ok) {
+      return failedPage(
+        page,
+        pageSize,
+        result && result.error
+          ? result.error
+          : localInvalidResponseError("Cloudsmith returned an invalid transport result.")
+      );
+    }
+
+    let items;
+    try {
+      if (!decoder.validateResponse(result.data)) {
+        throw new TypeError("The response envelope was invalid.");
+      }
+      items = decoder.extractItems(result.data);
+      if (!Array.isArray(items) || !decoder.validateItems(items)) {
+        throw new TypeError("The response collection was invalid.");
+      }
+    } catch {
+      return failedPage(
+        page,
+        pageSize,
+        localInvalidResponseError("Cloudsmith returned an invalid collection response.")
+      );
+    }
+
+    const pagination = parsePagination(result.headers || {}, page, pageSize, items.length);
+    if (!pagination) {
+      return failedPage(
+        page,
+        pageSize,
+        localInvalidResponseError("Cloudsmith returned invalid pagination metadata.")
+      );
+    }
+
+    return {
+      data: items,
+      pagination,
+      error: null,
+    };
+  }
+
+  /**
+   * Collect validated pages within cumulative page, request, and item limits.
+   * `requestCount` is the number of logical page requests, including failed/cancelled calls;
+   * transport retries remain owned and bounded by CloudsmithAPI.
+   */
+  async fetchCollection(endpoint, options = {}) {
+    const settings = normalizeCollectionOptions(endpoint, options);
+    if (settings.error) {
+      return buildCollectionResult({
+        failures: [failureDetail(1, settings.error)],
+        failureCount: 1,
+        termination: "invalid_request",
+      });
+    }
+
+    const {
+      pageSize,
+      maxPages,
+      maxRequests,
+      maxItems,
+      pageBatchLimit,
+      canonicalIdentity,
+      binding,
+      descriptor,
+      resume,
+    } = settings;
+    const resumed = validateResume(resume, {
+      binding,
+      descriptor,
+      maxPages,
+      maxRequests,
+      maxItems,
+    });
+    if (resumed.error) {
+      return buildCollectionResult({
+        failures: [failureDetail(1, resumed.error)],
+        failureCount: 1,
+        termination: "invalid_continuation",
+      });
+    }
+
+    let page = resumed.nextPage;
+    let pageCount = resumed.pageCount;
+    let requestCount = resumed.requestCount;
+    let itemCount = resumed.itemCount;
+    let duplicateCount = resumed.duplicateCount;
+    let failureCount = resumed.failureCount;
+    let pagination = resumed.anchor;
+    const items = [];
+    const failures = [];
+    const seen = normalizeKnownIdentities(options.knownIdentities, itemCount);
+    if (!seen) {
+      return buildCollectionResult({
+        failures: [failureDetail(page, localInvalidResponseError(
+          "The collection continuation identities were invalid."
+        ))],
+        failureCount: failureCount + 1,
+        termination: "invalid_continuation",
+        pageCount,
+        requestCount,
+        duplicateCount,
+        pagination,
+      });
+    }
+
+    let batchPages = 0;
+    while (true) {
+      if (isCancelled(options)) {
+        return buildStoppedResult("cancelled", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+          cancelled: true,
+          continuation: makeContinuation(page, pagination, {
+            binding,
+            descriptor,
+            pageCount,
+            requestCount,
+            itemCount,
+            duplicateCount,
+            failureCount,
+            maxPages,
+            maxRequests,
+            maxItems,
+          }),
+        });
+      }
+      if (pageCount >= maxPages) {
+        return buildStoppedResult("page_limit", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
+      if (requestCount >= maxRequests) {
+        return buildStoppedResult("request_limit", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
+      if (itemCount >= maxItems) {
+        return buildStoppedResult("item_limit", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
+
+      requestCount += 1; // Reserve before dispatch so failures and cancellation consume budget.
+      const result = await this.fetchPage(
+        endpoint,
+        page,
+        pageSize,
+        options.query || null,
+        options
+      );
+
+      if (isCancelled(options) || isCancellationError(result && result.error)) {
+        return buildStoppedResult("cancelled", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+          cancelled: true,
+          continuation: requestCount < maxRequests
+            ? makeContinuation(page, pagination, {
+              binding,
+              descriptor,
+              pageCount,
+              requestCount,
+              itemCount,
+              duplicateCount,
+              failureCount: 0,
+              maxPages,
+              maxRequests,
+              maxItems,
+            })
+            : null,
+        });
+      }
+
+      if (!result || result.error) {
+        failureCount += 1;
+        if (failures.length < MAX_COLLECTION_FAILURE_DETAILS) {
+          failures.push(failureDetail(page, result && result.error));
+        }
+        const retryable = isRetryableCollectionFailure(result && result.error);
+        return buildStoppedResult("request_failed", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+          continuation: retryable && requestCount < maxRequests
+            ? makeContinuation(page, pagination, {
+              binding,
+              descriptor,
+              pageCount,
+              requestCount,
+              itemCount,
+              duplicateCount,
+              failureCount: 0,
+              maxPages,
+              maxRequests,
+              maxItems,
+            })
+            : null,
+        });
+      }
+
+      const currentPagination = normalizeFetchedPagination(
+        result.pagination,
+        page,
+        pageSize,
+        Array.isArray(result.data) ? result.data.length : -1
+      );
+      if (!currentPagination || !isStablePageSequence(pagination, currentPagination, page)) {
+        failureCount += 1;
+        if (failures.length < MAX_COLLECTION_FAILURE_DETAILS) {
+          failures.push(failureDetail(page, localInvalidResponseError(
+            "Cloudsmith changed pagination metadata while the collection was loading."
+          )));
+        }
+        return buildStoppedResult("invalid_pagination", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
+
+      const pageIdentities = new Set();
+      let identityFailure = null;
+      for (const item of result.data) {
+        let identity;
         try {
-            url = appendApiQuery(endpoint, {
-                page,
-                page_size: pageSize,
-                ...(query ? { query } : {}),
-            });
+          identity = canonicalIdentity(item);
         } catch {
-            return {
-                data: [],
-                pagination: { page: 1, pageTotal: 1, count: 0, pageSize: pageSize },
-                error: localInvalidResponseError("The paginated API endpoint was invalid."),
-            };
+          identityFailure = localInvalidResponseError(
+            "Cloudsmith returned a record with an invalid collection identity."
+          );
+          break;
         }
-
-        const requestOptions = {
-            responseType: "array",
-            validate: typeof options.validate === "function" ? options.validate : isRecordArray,
-            retry: options.retry || "never",
-            signal: options.signal,
-            cancellationToken: options.cancellationToken,
-        };
-        if (Object.prototype.hasOwnProperty.call(options, "apiKey")) {
-            requestOptions.apiKey = options.apiKey;
+        if (
+          typeof identity !== "string"
+          || identity.length === 0
+          || identity.length > MAX_COLLECTION_DESCRIPTOR_LENGTH
+        ) {
+          identityFailure = localInvalidResponseError(
+            "Cloudsmith returned a record with an invalid collection identity."
+          );
+          break;
         }
-        const result = await this.api.get(url, requestOptions);
-
-        if (!result.ok) {
-            return {
-                data: [],
-                pagination: { page: 1, pageTotal: 1, count: 0, pageSize: pageSize },
-                error: result.error,
-            };
+        if (seen.has(identity) || pageIdentities.has(identity)) {
+          duplicateCount += 1;
+          identityFailure = localInvalidResponseError(
+            "Cloudsmith returned a duplicate collection identity."
+          );
+          break;
         }
-
-        const pagination = parsePagination(result.headers, page, pageSize, result.data.length);
-        if (!pagination) {
-            return {
-                data: [],
-                pagination: { page, pageTotal: page, count: 0, pageSize },
-                error: localInvalidResponseError("Cloudsmith returned invalid pagination metadata."),
-            };
+        pageIdentities.add(identity);
+      }
+      if (identityFailure) {
+        failureCount += 1;
+        if (failures.length < MAX_COLLECTION_FAILURE_DETAILS) {
+          failures.push(failureDetail(page, identityFailure));
         }
+        return buildStoppedResult("duplicate_or_invalid_identity", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
 
-        return {
-            data: result.data,
+      if (itemCount + result.data.length > maxItems) {
+        return buildStoppedResult("item_limit", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+        });
+      }
+
+      // Commit the validated page atomically only after the final cancellation check.
+      if (isCancelled(options)) {
+        return buildStoppedResult("cancelled", {
+          items,
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+          itemCount,
+          cancelled: true,
+          continuation: requestCount < maxRequests
+            ? makeContinuation(page, pagination, {
+              binding,
+              descriptor,
+              pageCount,
+              requestCount,
+              itemCount,
+              duplicateCount,
+              failureCount,
+              maxPages,
+              maxRequests,
+              maxItems,
+            })
+            : null,
+        });
+      }
+      for (const identity of pageIdentities) seen.add(identity);
+      items.push(...result.data);
+      itemCount += result.data.length;
+      pageCount += 1;
+      batchPages += 1;
+      pagination = currentPagination;
+
+      if (page >= currentPagination.pageTotal) {
+        if (currentPagination.countAuthoritative && itemCount !== currentPagination.count) {
+          failureCount += 1;
+          if (failures.length < MAX_COLLECTION_FAILURE_DETAILS) {
+            failures.push(failureDetail(page, localInvalidResponseError(
+              "The collected records did not match Cloudsmith's authoritative count."
+            )));
+          }
+          return buildStoppedResult("invalid_pagination", {
+            items,
+            failures,
+            failureCount,
+            pageCount,
+            requestCount,
+            duplicateCount,
             pagination,
-            error: null,
-        };
-    }
-
-    /**
-     * Fetch all available pages, capped at a hard ceiling to avoid runaway scans.
-     *
-     * @param   endpoint  Base endpoint (e.g., 'packages/owner/')
-     * @param   pageSize  Results per page
-     * @param   maxPagesOrQuery  Optional max page hint or query string
-     * @param   query     Optional query string when a max page hint is supplied
-     * @returns { data: [], pagination: { page, pageTotal, count, pageSize } }
-     */
-    async fetchAll(endpoint, pageSize, maxPagesOrQuery, query) {
-        let maxPages = MAX_FETCH_ALL_PAGES;
-        let searchQuery = query;
-
-        if (typeof maxPagesOrQuery === "number") {
-            maxPages = Math.max(1, Math.floor(maxPagesOrQuery));
-        } else if (typeof maxPagesOrQuery === "string") {
-            searchQuery = maxPagesOrQuery;
+            itemCount,
+          });
         }
+        return buildCollectionResult({
+          items,
+          complete: true,
+          termination: "exhausted",
+          failures,
+          failureCount,
+          pageCount,
+          requestCount,
+          duplicateCount,
+          pagination,
+        });
+      }
 
-        maxPages = Math.min(maxPages, MAX_FETCH_ALL_PAGES);
-
-        const allData = [];
-        let pagination = {
-            page: 1,
-            pageTotal: 1,
-            count: 0,
-            pageSize: pageSize,
-        };
-
-        for (let page = 1; page <= maxPages; page++) {
-            const result = await this.fetchPage(endpoint, page, pageSize, searchQuery);
-            if (result.error) {
-                return result;
-            }
-
-            allData.push(...(result.data || []));
-            pagination = {
-                ...result.pagination,
-                pageTotal: Math.min(result.pagination.pageTotal || 1, MAX_FETCH_ALL_PAGES),
-            };
-
-            if (page >= result.pagination.pageTotal) {
-                break;
-            }
-        }
-
-        return {
-            data: allData,
+      page += 1;
+      if (batchPages >= pageBatchLimit) {
+        const continuation = pageCount < maxPages && requestCount < maxRequests
+          ? makeContinuation(page, pagination, {
+            binding,
+            descriptor,
+            pageCount,
+            requestCount,
+            itemCount,
+            duplicateCount,
+            failureCount,
+            maxPages,
+            maxRequests,
+            maxItems,
+          })
+          : null;
+        const termination = continuation
+          ? "page_batch"
+          : pageCount >= maxPages
+            ? "page_limit"
+            : requestCount >= maxRequests
+              ? "request_limit"
+              : "item_limit";
+        return buildStoppedResult(
+          termination,
+          {
+            items,
+            failures,
+            failureCount,
+            pageCount,
+            requestCount,
+            duplicateCount,
             pagination,
-        };
+            itemCount,
+            continuation,
+          }
+        );
+      }
     }
+  }
+}
+
+function createDecoder(options) {
+  const responseType = options.responseType || "array";
+  const validateItems = typeof options.validate === "function" ? options.validate : isRecordArray;
+  if (responseType === "array") {
+    return {
+      responseType,
+      validateResponse: validateItems,
+      extractItems: value => value,
+      validateItems,
+    };
+  }
+  if (
+    typeof options.validateResponse !== "function"
+    || typeof options.extractItems !== "function"
+  ) {
+    return null;
+  }
+  return {
+    responseType,
+    validateResponse: options.validateResponse,
+    extractItems: options.extractItems,
+    validateItems,
+  };
+}
+
+function normalizeCollectionOptions(endpoint, options) {
+  const pageSize = Number(options.pageSize);
+  const maxPages = Number(options.maxPages ?? 20);
+  const maxRequests = Number(options.maxRequests ?? maxPages);
+  const maxItems = Number(options.maxItems ?? (maxPages * pageSize));
+  const pageBatchLimit = Number(options.pageBatchLimit ?? maxPages);
+  const descriptor = options.descriptor === undefined ? "" : options.descriptor;
+  if (
+    typeof endpoint !== "string"
+    || endpoint.length === 0
+    || !isPageSize(pageSize)
+    || !isPositiveSafeInteger(maxPages)
+    || !isPositiveSafeInteger(maxRequests)
+    || !isPositiveSafeInteger(maxItems)
+    || !isPositiveSafeInteger(pageBatchLimit)
+    || typeof options.canonicalIdentity !== "function"
+    || typeof descriptor !== "string"
+    || descriptor.length > MAX_COLLECTION_DESCRIPTOR_LENGTH
+  ) {
+    return { error: localInvalidResponseError("The collection request was invalid.") };
+  }
+  return {
+    pageSize,
+    maxPages,
+    maxRequests,
+    maxItems,
+    pageBatchLimit: Math.min(pageBatchLimit, maxPages),
+    canonicalIdentity: options.canonicalIdentity,
+    binding: collectionBinding(endpoint, options.query || null, descriptor, pageSize),
+    descriptor,
+    resume: options.resume || null,
+  };
+}
+
+function collectionBinding(endpoint, query, descriptor, pageSize) {
+  return crypto.createHash("sha256")
+    .update(JSON.stringify([endpoint, query, descriptor, pageSize]))
+    .digest("hex");
+}
+
+function validateResume(resume, bounds) {
+  if (!resume) {
+    return {
+      nextPage: 1,
+      anchor: null,
+      pageCount: 0,
+      requestCount: 0,
+      itemCount: 0,
+      duplicateCount: 0,
+      failureCount: 0,
+    };
+  }
+  const cumulative = resume.cumulative;
+  const anchor = resume.anchor;
+  if (
+    !resume
+    || typeof resume !== "object"
+    || resume.binding !== bounds.binding
+    || resume.descriptor !== bounds.descriptor
+    || !isPositiveSafeInteger(resume.nextPage)
+    || !cumulative
+    || !isNonNegativeSafeInteger(cumulative.pageCount)
+    || !isNonNegativeSafeInteger(cumulative.requestCount)
+    || !isNonNegativeSafeInteger(cumulative.itemCount)
+    || !isNonNegativeSafeInteger(cumulative.duplicateCount)
+    || !isNonNegativeSafeInteger(cumulative.failureCount)
+    || cumulative.pageCount >= bounds.maxPages
+    || cumulative.requestCount < cumulative.pageCount
+    || cumulative.requestCount >= bounds.maxRequests
+    || cumulative.itemCount >= bounds.maxItems
+    || cumulative.duplicateCount !== 0
+    || cumulative.failureCount !== 0
+    || (anchor !== null && !isResumeAnchor(anchor, resume.nextPage))
+    || (anchor !== null && cumulative.pageCount !== anchor.page)
+    || (anchor !== null && cumulative.itemCount !== committedItemCount(anchor))
+    || (anchor === null && (
+      resume.nextPage !== 1
+      || cumulative.pageCount !== 0
+      || cumulative.itemCount !== 0
+    ))
+  ) {
+    return { error: localInvalidResponseError("The collection continuation was invalid.") };
+  }
+  return {
+    nextPage: resume.nextPage,
+    anchor,
+    ...cumulative,
+  };
+}
+
+function isResumeAnchor(anchor, nextPage) {
+  return Boolean(
+    anchor
+    && isPositiveSafeInteger(anchor.page)
+    && anchor.page + 1 === nextPage
+    && isPositiveSafeInteger(anchor.pageTotal)
+    && anchor.page < anchor.pageTotal
+    && isPageSize(anchor.pageSize)
+    && (anchor.count === null || isNonNegativeSafeInteger(anchor.count))
+    && anchor.countAuthoritative === (anchor.count !== null)
+  );
+}
+
+function committedItemCount(anchor) {
+  const fullPageCount = anchor.page * anchor.pageSize;
+  if (!Number.isSafeInteger(fullPageCount)) return -1;
+  return anchor.countAuthoritative
+    ? Math.min(anchor.count, fullPageCount)
+    : fullPageCount;
+}
+
+function normalizeKnownIdentities(value, expectedSize) {
+  if (expectedSize === 0 && (value === undefined || value === null)) return new Set();
+  if (!(value instanceof Set) || value.size !== expectedSize) return null;
+  const result = new Set();
+  for (const identity of value) {
+    if (
+      typeof identity !== "string"
+      || identity.length === 0
+      || identity.length > MAX_COLLECTION_DESCRIPTOR_LENGTH
+    ) return null;
+    result.add(identity);
+  }
+  return result;
+}
+
+function makeContinuation(nextPage, anchor, state) {
+  if (
+    state.pageCount >= state.maxPages
+    || state.requestCount >= state.maxRequests
+    || state.itemCount >= state.maxItems
+  ) return null;
+  return Object.freeze({
+    nextPage,
+    anchor: anchor ? Object.freeze({ ...anchor }) : null,
+    cumulative: Object.freeze({
+      pageCount: state.pageCount,
+      requestCount: state.requestCount,
+      itemCount: state.itemCount,
+      duplicateCount: state.duplicateCount,
+      failureCount: state.failureCount,
+    }),
+    descriptor: state.descriptor,
+    binding: state.binding,
+  });
+}
+
+function buildStoppedResult(termination, state) {
+  return buildCollectionResult({
+    items: state.items,
+    complete: false,
+    cancelled: state.cancelled === true,
+    continuation: state.continuation || null,
+    failures: state.failures,
+    failureCount: state.failureCount,
+    termination,
+    pageCount: state.pageCount,
+    requestCount: state.requestCount,
+    duplicateCount: state.duplicateCount,
+    pagination: state.pagination,
+  });
+}
+
+function buildCollectionResult(state = {}) {
+  const items = Object.freeze([...(state.items || [])]);
+  const complete = state.complete === true;
+  const cancelled = state.cancelled === true;
+  const failures = Object.freeze([...(state.failures || [])].slice(0, MAX_COLLECTION_FAILURE_DETAILS));
+  const failureCount = state.failureCount ?? 0;
+  const pageCount = state.pageCount ?? 0;
+  const requestCount = state.requestCount ?? 0;
+  const duplicateCount = state.duplicateCount ?? 0;
+  const result = {
+    items,
+    complete,
+    incomplete: !complete,
+    partial: !complete && items.length > 0,
+    cancelled,
+    continuation: complete ? null : (state.continuation || null),
+    failures,
+    failureCount,
+    termination: state.termination || (complete ? "exhausted" : "invalid_request"),
+    pageCount,
+    requestCount,
+    duplicateCount,
+    pagination: state.pagination ? Object.freeze({ ...state.pagination }) : null,
+  };
+  if (
+    (complete && (
+      result.termination !== "exhausted"
+      || result.continuation !== null
+      || result.cancelled
+      || result.partial
+      || result.failureCount > 0
+    ))
+    || result.partial !== (!result.complete && result.items.length > 0)
+    || (result.cancelled && result.complete)
+    || !isNonNegativeSafeInteger(result.pageCount)
+    || !isNonNegativeSafeInteger(result.requestCount)
+    || !isNonNegativeSafeInteger(result.duplicateCount)
+    || !isNonNegativeSafeInteger(result.failureCount)
+    || result.pageCount > result.requestCount
+    || result.failureCount < result.failures.length
+  ) {
+    throw new Error("The collection result invariants were violated.");
+  }
+  return Object.freeze(result);
+}
+
+function collectionFailureResult(error, options = {}) {
+  const page = isPositiveSafeInteger(options.page) ? options.page : 1;
+  return buildCollectionResult({
+    cancelled: options.cancelled === true,
+    failures: [failureDetail(page, error)],
+    failureCount: 1,
+    termination: options.termination || "request_failed",
+  });
+}
+
+function replaceCollectionItems(result, items) {
+  if (!result || typeof result !== "object" || !Array.isArray(items)) {
+    throw new TypeError("The collection result mapping was invalid.");
+  }
+  return buildCollectionResult({
+    items,
+    complete: result.complete === true,
+    cancelled: result.cancelled === true,
+    continuation: result.continuation || null,
+    failures: result.failures || [],
+    failureCount: result.failureCount || 0,
+    termination: result.termination,
+    pageCount: result.pageCount || 0,
+    requestCount: result.requestCount || 0,
+    duplicateCount: result.duplicateCount || 0,
+    pagination: result.pagination || null,
+  });
+}
+
+function isStablePageSequence(previous, current, requestedPage) {
+  if (!current || current.page !== requestedPage) return false;
+  if (!previous) return requestedPage === 1;
+  return current.page === previous.page + 1
+    && current.pageSize === previous.pageSize
+    && current.pageTotal === previous.pageTotal
+    && current.countAuthoritative === previous.countAuthoritative
+    && current.count === previous.count;
+}
+
+function normalizeFetchedPagination(value, requestedPage, requestedPageSize, itemCount) {
+  if (!value || typeof value !== "object" || itemCount < 0) return null;
+  const countAuthoritative = value.countAuthoritative === undefined
+    ? isNonNegativeSafeInteger(value.count)
+    : value.countAuthoritative === true;
+  const count = countAuthoritative ? value.count : null;
+  if (
+    value.page !== requestedPage
+    || !isPositiveSafeInteger(value.pageTotal)
+    || value.page > value.pageTotal
+    || !isPageSize(value.pageSize)
+    || value.pageSize > requestedPageSize
+    || itemCount > value.pageSize
+    || (countAuthoritative && !isNonNegativeSafeInteger(count))
+  ) return null;
+  if (countAuthoritative) {
+    const calculatedPageTotal = Math.max(1, Math.ceil(count / value.pageSize));
+    const expectedItems = Math.min(
+      value.pageSize,
+      Math.max(0, count - ((value.page - 1) * value.pageSize))
+    );
+    if (calculatedPageTotal !== value.pageTotal || expectedItems !== itemCount) return null;
+  } else if (value.page < value.pageTotal && itemCount !== value.pageSize) {
+    return null;
+  }
+  return Object.freeze({
+    page: value.page,
+    pageTotal: value.pageTotal,
+    pageSize: value.pageSize,
+    count,
+    countAuthoritative,
+  });
 }
 
 function isRecordArray(value) {
-    return Array.isArray(value) && value.every(item => (
-        Boolean(item) && typeof item === "object" && !Array.isArray(item)
-    ));
+  return Array.isArray(value) && value.every(item => (
+    Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  ));
 }
 
 function parseOptionalInteger(value) {
-    if (value === undefined) {
-        return { present: false, valid: true, value: null };
-    }
-    const normalized = String(value).trim();
-    const parsed = /^\d+$/.test(normalized) ? Number(normalized) : NaN;
-    return {
-        present: true,
-        valid: Number.isSafeInteger(parsed) && parsed >= 0,
-        value: parsed,
-    };
+  if (value === undefined) return { present: false, valid: true, value: null };
+  const normalized = String(value).trim();
+  const parsed = /^\d+$/.test(normalized) ? Number(normalized) : NaN;
+  return {
+    present: true,
+    valid: Number.isSafeInteger(parsed) && parsed >= 0,
+    value: parsed,
+  };
 }
 
 function parsePagination(headers, requestedPage, requestedPageSize, itemCount) {
-    const page = parseOptionalInteger(headers["x-pagination-page"]);
-    const pageTotal = parseOptionalInteger(headers["x-pagination-pagetotal"]);
-    const count = parseOptionalInteger(headers["x-pagination-count"]);
-    const pageSize = parseOptionalInteger(headers["x-pagination-pagesize"]);
-    if (![page, pageTotal, count, pageSize].every(field => field.valid)) {
-        return null;
-    }
-    const effectivePage = page.present ? page.value : requestedPage;
-    const effectivePageSize = pageSize.present ? pageSize.value : requestedPageSize;
-    if (
-        !Number.isInteger(effectivePage)
-        || effectivePage < 1
-        || effectivePage !== requestedPage
-        || !Number.isInteger(effectivePageSize)
-        || effectivePageSize < 1
-        || itemCount > effectivePageSize
-        || (!pageTotal.present && !count.present)
-    ) {
-        return null;
-    }
-    const effectivePageTotal = pageTotal.present
-        ? pageTotal.value
-        : Math.max(1, Math.ceil(count.value / effectivePageSize));
-    if (!Number.isInteger(effectivePageTotal) || effectivePageTotal < 1 || effectivePage > effectivePageTotal) {
-        return null;
-    }
-    if (count.present) {
-        const calculatedPageTotal = Math.max(1, Math.ceil(count.value / effectivePageSize));
-        const minimumReturned = ((effectivePage - 1) * effectivePageSize) + itemCount;
-        if (calculatedPageTotal !== effectivePageTotal || minimumReturned > count.value) {
-            return null;
-        }
-    }
-    return {
-        page: effectivePage,
-        pageTotal: effectivePageTotal,
-        count: count.present ? count.value : itemCount,
-        pageSize: effectivePageSize,
-    };
+  const page = parseOptionalInteger(headers["x-pagination-page"]);
+  const pageTotal = parseOptionalInteger(headers["x-pagination-pagetotal"]);
+  const count = parseOptionalInteger(headers["x-pagination-count"]);
+  const pageSize = parseOptionalInteger(headers["x-pagination-pagesize"]);
+  if (![page, pageTotal, count, pageSize].every(field => field.valid)) return null;
+
+  const effectivePage = page.present ? page.value : requestedPage;
+  const effectivePageSize = pageSize.present ? pageSize.value : requestedPageSize;
+  if (
+    !isPositiveSafeInteger(effectivePage)
+    || effectivePage !== requestedPage
+    || !isPageSize(effectivePageSize)
+    || effectivePageSize > requestedPageSize
+    || itemCount > effectivePageSize
+    || (!pageTotal.present && !count.present)
+  ) return null;
+
+  const effectivePageTotal = pageTotal.present
+    ? pageTotal.value
+    : Math.max(1, Math.ceil(count.value / effectivePageSize));
+  if (
+    !isPositiveSafeInteger(effectivePageTotal)
+    || effectivePage > effectivePageTotal
+  ) return null;
+
+  if (count.present) {
+    const calculatedPageTotal = Math.max(1, Math.ceil(count.value / effectivePageSize));
+    const expectedItems = Math.min(
+      effectivePageSize,
+      Math.max(0, count.value - ((effectivePage - 1) * effectivePageSize))
+    );
+    if (calculatedPageTotal !== effectivePageTotal || expectedItems !== itemCount) return null;
+  } else if (effectivePage < effectivePageTotal && itemCount !== effectivePageSize) {
+    return null;
+  }
+
+  return Object.freeze({
+    page: effectivePage,
+    pageTotal: effectivePageTotal,
+    count: count.present ? count.value : null,
+    countAuthoritative: count.present,
+    pageSize: effectivePageSize,
+  });
+}
+
+function failedPage(page, pageSize, error) {
+  return {
+    data: [],
+    pagination: {
+      page: isPositiveSafeInteger(page) ? page : 1,
+      pageTotal: isPositiveSafeInteger(page) ? page : 1,
+      count: null,
+      countAuthoritative: false,
+      pageSize: isPageSize(pageSize) ? pageSize : 1,
+    },
+    error,
+  };
+}
+
+function failureDetail(page, error) {
+  const safe = error && typeof error === "object" ? error : {};
+  return Object.freeze({
+    page: isPositiveSafeInteger(page) ? page : 1,
+    error: Object.freeze({
+      kind: boundedString(safe.kind, 80) || "request_failed",
+      status: Number.isSafeInteger(safe.status) ? safe.status : null,
+      retryable: safe.retryable === true,
+      message: boundedString(safe.message, 1024) || "The collection request failed.",
+      requestId: boundedString(safe.requestId, 256),
+      retryAfterMs: isNonNegativeSafeInteger(safe.retryAfterMs) ? safe.retryAfterMs : null,
+      outcomeUnknown: safe.outcomeUnknown === true,
+    }),
+  });
+}
+
+function boundedString(value, maxLength) {
+  return typeof value === "string" && value.length <= maxLength ? value : null;
+}
+
+function isCancellationError(error) {
+  return Boolean(error && typeof error === "object" && error.kind === "cancelled");
+}
+
+function isRetryableCollectionFailure(error) {
+  return Boolean(
+    error
+    && typeof error === "object"
+    && error.kind !== "invalid_response"
+    && error.kind !== "invalid_request"
+    && (error.kind === "rate_limited" || error.retryable === true)
+  );
+}
+
+function isCancelled(options) {
+  return options.signal?.aborted === true
+    || options.cancellationToken?.isCancellationRequested === true;
+}
+
+function isPositiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 1;
+}
+
+function isNonNegativeSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function isPageSize(value) {
+  return isPositiveSafeInteger(value) && value <= MAX_PAGE_SIZE;
+}
+
+function unexpectedRequestError(error) {
+  return Object.freeze({
+    kind: error && error.name === "AbortError" ? "cancelled" : "request_failed",
+    status: null,
+    retryable: false,
+    // Thrown values are outside the typed transport boundary and can contain
+    // credentials or other caller-owned data. Never retain their message.
+    message: "The collection request failed unexpectedly.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
 }
 
 function localInvalidResponseError(message) {
-    return Object.freeze({
-        kind: "invalid_response",
-        status: null,
-        retryable: false,
-        message,
-        requestId: null,
-        retryAfterMs: null,
-        outcomeUnknown: false,
-        diagnostic: Object.freeze({}),
-    });
+  return Object.freeze({
+    kind: "invalid_response",
+    status: null,
+    retryable: false,
+    message,
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
 }
 
-module.exports = { PaginatedFetch };
+module.exports = {
+  MAX_COLLECTION_FAILURE_DETAILS,
+  MAX_PAGE_SIZE,
+  PaginatedFetch,
+  collectionFailureResult,
+  replaceCollectionItems,
+};

--- a/util/policyDecisionLogs.js
+++ b/util/policyDecisionLogs.js
@@ -1,0 +1,212 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const { apiEndpoint } = require("./apiEndpoint");
+const {
+  PaginatedFetch,
+  collectionFailureResult,
+  replaceCollectionItems,
+} = require("./paginatedFetch");
+const {
+  MAX_COLLECTION_IDENTITY_PART_LENGTH,
+  exactIdentityPart,
+} = require("./collectionIdentity");
+
+const POLICY_DECISION_LOG_PAGE_SIZE = 100;
+const MAX_POLICY_DECISION_LOG_PAGES = 20;
+const MAX_POLICY_DECISION_LOG_ITEMS = POLICY_DECISION_LOG_PAGE_SIZE * MAX_POLICY_DECISION_LOG_PAGES;
+const MAX_POLICY_PACKAGE_ID_LENGTH = MAX_COLLECTION_IDENTITY_PART_LENGTH;
+const MAX_POLICY_STATUS_REASON_LENGTH = 4096;
+const MAX_POLICY_LOG_DISPLAY_LENGTH = 4096;
+const MAX_POLICY_ACTIONS = 50;
+
+async function fetchPackageDecisionLogs(api, workspace, packageIdentifier, options = {}) {
+  const normalizedPackageIdentifier = boundedString(packageIdentifier, MAX_POLICY_PACKAGE_ID_LENGTH);
+  if (!api || typeof api.getV2 !== "function" || !normalizedPackageIdentifier) {
+    return failedCollection("The policy decision log identity was invalid.");
+  }
+
+  let endpoint;
+  try {
+    endpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"]);
+  } catch {
+    return failedCollection("The policy decision log endpoint was invalid.");
+  }
+
+  const paginatedFetch = options.paginatedFetch || new PaginatedFetch({
+    get: api.getV2.bind(api),
+  });
+  const collection = await paginatedFetch.fetchCollection(endpoint, {
+    pageSize: POLICY_DECISION_LOG_PAGE_SIZE,
+    maxPages: MAX_POLICY_DECISION_LOG_PAGES,
+    maxRequests: MAX_POLICY_DECISION_LOG_PAGES,
+    maxItems: MAX_POLICY_DECISION_LOG_ITEMS,
+    canonicalIdentity: decisionLogIdentity,
+    descriptor: `policy-decision-logs:${workspace}`,
+    responseType: "json",
+    validateResponse: isDecisionLogResponse,
+    extractItems: extractDecisionLogs,
+    retry: "never",
+    signal: options.signal,
+    cancellationToken: options.cancellationToken,
+  });
+
+  return replaceCollectionItems(
+    collection,
+    collection.items.filter(entry => (
+      decisionLogMatchesPackage(entry, normalizedPackageIdentifier)
+    )).map(normalizeDecisionLog)
+  );
+}
+
+function normalizeDecisionLog(entry) {
+  const normalized = {
+    slug_perm: decisionLogIdentity(entry),
+    package_slug_perm: decisionLogPackageReference(entry),
+    policy_name: displayString(
+      entry.policy_name || entry.name || (entry.policy && entry.policy.name),
+      512
+    ),
+    matched: typeof entry.matched === "boolean" ? entry.matched : null,
+    action: normalizeActions(entry.action, entry.actions_taken),
+    reason: displayString(entry.reason, MAX_POLICY_LOG_DISPLAY_LENGTH),
+    created_at: displayString(entry.created_at, 128),
+  };
+  return Object.freeze(normalized);
+}
+
+function normalizeActions(action, actionsTaken) {
+  const direct = displayString(action, MAX_POLICY_LOG_DISPLAY_LENGTH);
+  if (direct) return direct;
+  if (!Array.isArray(actionsTaken)) return null;
+  const summaries = actionsTaken.slice(0, MAX_POLICY_ACTIONS).map(value => {
+    if (!isRecord(value)) return null;
+    const type = displayString(value.action_type, 256);
+    const state = displayString(value.package_state, 256);
+    return [type, state].filter(Boolean).join(": ") || null;
+  }).filter(Boolean);
+  return summaries.length > 0 ? summaries.join("; ") : null;
+}
+
+function normalizePolicyStatusReason(value) {
+  if (typeof value !== "string") return null;
+  const bounded = value.length <= MAX_POLICY_STATUS_REASON_LENGTH
+    ? value
+    : `${value.slice(0, MAX_POLICY_STATUS_REASON_LENGTH - 1)}…`;
+  const normalized = bounded.trim();
+  if (!normalized) return null;
+  return normalized;
+}
+
+function parsePolicyStatusReason(value) {
+  const normalized = normalizePolicyStatusReason(value);
+  if (!normalized) return null;
+
+  const match = /^Quarantined by ([^.]+)\.\s*(.*?)(?:\s*\(Policy:\s*([^()]+)\))?$/.exec(normalized);
+  if (!match) return { raw: normalized };
+  return {
+    policyName: match[1].trim(),
+    description: match[2].trim(),
+    policySlug: match[3] ? match[3].trim() : null,
+  };
+}
+
+function decisionLogIdentity(entry) {
+  try {
+    return exactIdentityPart(entry && entry.slug_perm, "policy decision log");
+  } catch {
+    return null;
+  }
+}
+
+function decisionLogMatchesPackage(entry, packageIdentifier) {
+  return decisionLogPackageReference(entry) === packageIdentifier;
+}
+
+function isDecisionLogResponse(value) {
+  const items = extractDecisionLogs(value);
+  return items !== null && items.every(isDecisionLogRecord);
+}
+
+function extractDecisionLogs(value) {
+  if (Array.isArray(value)) return value;
+  if (!isRecord(value) || !Array.isArray(value.results)) return null;
+  return value.results;
+}
+
+function isDecisionLogRecord(value) {
+  return isRecord(value)
+    && Boolean(decisionLogIdentity(value))
+    && Boolean(decisionLogPackageReference(value))
+    && (
+      !Object.prototype.hasOwnProperty.call(value, "matched")
+      || typeof value.matched === "boolean"
+    );
+}
+
+function decisionLogPackageReference(entry) {
+  if (!isRecord(entry)) return null;
+  const aliases = [];
+
+  if (Object.prototype.hasOwnProperty.call(entry, "package_slug_perm")) {
+    aliases.push(entry.package_slug_perm);
+  }
+  if (
+    isRecord(entry.package)
+    && Object.prototype.hasOwnProperty.call(entry.package, "identifier")
+  ) {
+    aliases.push(entry.package.identifier);
+  }
+  if (aliases.length === 0) return null;
+
+  try {
+    const normalized = aliases.map(value => exactIdentityPart(value, "policy package"));
+    return new Set(normalized).size === 1 ? normalized[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedString(value, maxLength) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= maxLength
+    && value.trim() === value
+    ? value
+    : null;
+}
+
+function displayString(value, maxLength) {
+  if (typeof value !== "string") return null;
+  const bounded = value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+  return bounded.trim() || null;
+}
+
+function failedCollection(message) {
+  const failure = Object.freeze({
+    kind: "invalid_request",
+    status: null,
+    retryable: false,
+    message,
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+    diagnostic: Object.freeze({}),
+  });
+  return collectionFailureResult(failure, { termination: "invalid_request" });
+}
+
+module.exports = {
+  MAX_POLICY_DECISION_LOG_ITEMS,
+  MAX_POLICY_DECISION_LOG_PAGES,
+  MAX_POLICY_STATUS_REASON_LENGTH,
+  POLICY_DECISION_LOG_PAGE_SIZE,
+  decisionLogMatchesPackage,
+  fetchPackageDecisionLogs,
+  isDecisionLogResponse,
+  normalizePolicyStatusReason,
+  parsePolicyStatusReason,
+};

--- a/util/promotionContracts.js
+++ b/util/promotionContracts.js
@@ -1,6 +1,7 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
 const { encodeApiPathSegment } = require("./apiEndpoint");
+const { getPackagePolicyFlags } = require("./packageVulnerabilities");
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 const DISPLAY_CONTROL_PATTERN = /[\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
@@ -314,6 +315,7 @@ function isPackageLocationArray(value) {
       scalarString(record.name, MAX_PACKAGE_NAME_LENGTH, "malformed_package_location");
       scalarString(record.version, MAX_PACKAGE_VERSION_LENGTH, "malformed_package_location");
       scalarString(record.format, MAX_PACKAGE_FORMAT_LENGTH, "malformed_package_location");
+      if (!getPackagePolicyFlags(record)) return false;
       const packageIdentifier = pathIdentity(
         record.slug_perm,
         MAX_PACKAGE_IDENTIFIER_LENGTH,

--- a/util/remediationHelper.js
+++ b/util/remediationHelper.js
@@ -2,75 +2,131 @@
 
 const { SearchQueryBuilder } = require('./searchQueryBuilder');
 const { apiEndpoint } = require('./apiEndpoint');
+const { PaginatedFetch } = require('./paginatedFetch');
+const { packageCollectionIdentity } = require('./collectionIdentity');
+
+const SAFE_VERSION_PREVIEW_SIZE = 10;
 
 class RemediationHelper {
   constructor(cloudsmithAPI) {
     this.api = cloudsmithAPI;
+    this._paginatedFetch = new PaginatedFetch(cloudsmithAPI);
   }
 
   /**
    * Search for clean versions of a package within a specific repo.
-   * Returns array of package objects sorted by version descending, or [] on error.
+   * Returns a bounded newest-version preview and authoritative pagination metadata.
    *
    * @param   {string} workspace  Workspace/owner slug.
    * @param   {string} repo       Repository slug.
    * @param   {string} packageName Package name.
    * @param   {string} format     Package format (e.g., 'python', 'npm').
-   * @returns {Array} Array of package objects.
+   * @returns {Object} Safe-version preview result.
    */
   async findSafeVersions(workspace, repo, packageName, format) {
     const qb = new SearchQueryBuilder();
     const query = qb.name(packageName).format(format).raw('NOT status:quarantined').raw('deny_policy_violated:false').build();
     let endpoint;
     try {
-      endpoint = apiEndpoint(["packages", workspace, repo], {
-        query: { query, sort: "-version", page_size: 10 },
-      });
+      endpoint = apiEndpoint(["packages", workspace, repo], { query: { sort: "-version" } });
     } catch (error) {
       return { success: false, versions: [], error };
     }
 
-    const result = await this.api.get(endpoint, {
-      responseType: "array",
+    const result = await this._paginatedFetch.fetchPage(endpoint, 1, SAFE_VERSION_PREVIEW_SIZE, query, {
       validate: isSafePackageArray,
       retry: "safe-read",
     });
 
-    return result.ok
-      ? { success: true, versions: result.data, error: null }
-      : { success: false, versions: [], error: result.error };
+    return safeVersionResult(result, workspace, repo, packageName, format);
   }
 
   /**
    * Search workspace-wide for clean versions of a package across all repos.
-   * Returns array of package objects sorted by version descending, or [] on error.
+   * Returns a bounded newest-version preview and authoritative pagination metadata.
    *
    * @param   {string} workspace   Workspace/owner slug.
    * @param   {string} packageName Package name.
    * @param   {string} format      Package format (e.g., 'python', 'npm').
-   * @returns {Array} Array of package objects.
+   * @returns {Object} Safe-version preview result.
    */
   async findSafeVersionsAcrossRepos(workspace, packageName, format) {
     const qb = new SearchQueryBuilder();
     const query = qb.name(packageName).format(format).raw('NOT status:quarantined').raw('deny_policy_violated:false').build();
     let endpoint;
     try {
-      endpoint = apiEndpoint(["packages", workspace], {
-        query: { query, sort: "-version", page_size: 10 },
-      });
+      endpoint = apiEndpoint(["packages", workspace], { query: { sort: "-version" } });
     } catch (error) {
       return { success: false, versions: [], error };
     }
 
-    const result = await this.api.get(endpoint, {
-      responseType: "array",
+    const result = await this._paginatedFetch.fetchPage(endpoint, 1, SAFE_VERSION_PREVIEW_SIZE, query, {
       validate: isSafePackageArray,
       retry: "safe-read",
     });
-    return result.ok
-      ? { success: true, versions: result.data, error: null }
-      : { success: false, versions: [], error: result.error };
+    return safeVersionResult(result, workspace, null, packageName, format);
   }
+}
+
+function safeVersionResult(result, workspace, repository, packageName, format) {
+  if (result.error) {
+    return {
+      success: false,
+      versions: [],
+      error: result.error,
+      complete: false,
+      totalCount: null,
+      absenceProven: false,
+    };
+  }
+  const exactScope = result.data.every(pkg => (
+    pkg.namespace === workspace
+    && (repository === null || pkg.repository === repository)
+    && pkg.name === packageName
+    && pkg.format === format
+  ));
+  if (!exactScope) {
+    return {
+      success: false,
+      versions: [],
+      error: Object.freeze({
+        kind: "invalid_response",
+        message: "Cloudsmith returned safe-version results outside the requested package scope.",
+      }),
+      complete: false,
+      totalCount: null,
+      absenceProven: false,
+    };
+  }
+  const identities = new Set();
+  try {
+    for (const pkg of result.data) {
+      const identity = packageCollectionIdentity(pkg);
+      if (identities.has(identity)) throw new TypeError("duplicate package identity");
+      identities.add(identity);
+    }
+  } catch {
+    return {
+      success: false,
+      versions: [],
+      error: Object.freeze({
+        kind: "invalid_response",
+        message: "Cloudsmith returned duplicate or invalid safe-version identities.",
+      }),
+      complete: false,
+      totalCount: null,
+      absenceProven: false,
+    };
+  }
+  const totalCount = result.pagination.countAuthoritative ? result.pagination.count : null;
+  return {
+    success: true,
+    versions: result.data,
+    error: null,
+    complete: result.pagination.page >= result.pagination.pageTotal,
+    totalCount,
+    absenceProven: totalCount === 0,
+  };
 }
 
 function isRecordArray(value) {
@@ -79,25 +135,16 @@ function isRecordArray(value) {
   ));
 }
 
-function unwrapIdentifier(value) {
-  if (typeof value === "string" && value.length > 0) {
-    return value;
-  }
-  return value && typeof value === "object" && typeof value.value === "string" && value.value.length > 0
-    ? value.value
-    : null;
-}
-
 function isSafePackageArray(value) {
   return isRecordArray(value) && value.every(pkg => (
-    typeof pkg.name === "string" && pkg.name.length > 0
-    && typeof pkg.format === "string" && pkg.format.length > 0
+    typeof pkg.name === "string" && pkg.name.length > 0 && pkg.name.length <= 2048
+    && typeof pkg.format === "string" && pkg.format.length > 0 && pkg.format.length <= 100
     && (typeof pkg.version === "string" || typeof pkg.version === "number")
-    && String(pkg.version).length > 0
-    && typeof pkg.repository === "string" && pkg.repository.length > 0
-    && typeof pkg.namespace === "string" && pkg.namespace.length > 0
-    && Boolean(unwrapIdentifier(pkg.slug_perm || pkg.slug_perm_raw || pkg.slug))
+    && String(pkg.version).length > 0 && String(pkg.version).length <= 2048
+    && typeof pkg.repository === "string" && pkg.repository.length > 0 && pkg.repository.length <= 512
+    && typeof pkg.namespace === "string" && pkg.namespace.length > 0 && pkg.namespace.length <= 512
+    && typeof pkg.slug_perm === "string" && pkg.slug_perm.length > 0 && pkg.slug_perm.length <= 512
   ));
 }
 
-module.exports = { RemediationHelper };
+module.exports = { RemediationHelper, SAFE_VERSION_PREVIEW_SIZE };

--- a/util/terraformExporter.js
+++ b/util/terraformExporter.js
@@ -2,6 +2,10 @@
 
 const { getAllUpstreamData } = require("./upstreamChecker");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("./upstreamFormats");
+const {
+  formatUpstreamText,
+  getTerraformUpstreamUrl,
+} = require("./upstreamPresentation");
 
 const REPOSITORY_OPTIONAL_FIELDS = [
   { apiField: "repository_type_str", terraformField: "repository_type", defaultValue: "Private" },
@@ -73,7 +77,10 @@ function sanitizeIdentifier(value, options = {}) {
 }
 
 function escapeHclString(value) {
-  return JSON.stringify(String(value));
+  const literal = String(value)
+    .split("${").join("$${")
+    .split("%{").join("%%{");
+  return JSON.stringify(literal);
 }
 
 function isPlainObject(value) {
@@ -278,6 +285,7 @@ function buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel) {
   const variableBlocks = [];
   const seenVariables = new Set();
   const blocks = [];
+  let omittedUnsafeUrlCount = 0;
 
   for (const upstream of upstreams) {
     const name = getStringValue(upstream && upstream.name);
@@ -286,7 +294,13 @@ function buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel) {
       upstream && (upstream._format != null ? upstream._format : upstream.format)
     );
 
-    if (!name || !upstreamUrlRaw || !upstreamType) {
+    if (!name || !upstreamType) {
+      continue;
+    }
+
+    const upstreamUrl = upstreamUrlRaw ? getTerraformUpstreamUrl(upstreamUrlRaw) : null;
+    if (!upstreamUrl) {
+      omittedUnsafeUrlCount += 1;
       continue;
     }
 
@@ -295,7 +309,6 @@ function buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel) {
       fallback: `${repoSlugIdentifier}_upstream`,
     });
     const resourceLabel = uniqueLabel(resourceBaseLabel, usedLabels, upstreamType);
-    const upstreamUrl = upstreamUrlRaw.replace(/\/+$/g, "");
     const authMode = getStringValue(upstream.auth_mode);
     const authUsername = getStringValue(upstream.auth_username);
     const comments = [];
@@ -391,7 +404,7 @@ function buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel) {
     blocks.push(blockLines.join("\n"));
   }
 
-  return { blocks, variableBlocks };
+  return { blocks, variableBlocks, omittedUnsafeUrlCount };
 }
 
 function buildRetentionBlock(retention, repoResourceLabel) {
@@ -433,10 +446,16 @@ function generateTerraformConfig(options) {
 
   const repoSlug = getStringValue(getRepoField(repo, "slug")) || "repository";
   const repoResourceLabel = sanitizeIdentifier(repoSlug, { lowercase: true, fallback: "repository" });
+  const repositoryDisplayName = formatUpstreamText(
+    getStringValue(getRepoField(repo, "name")) || repoSlug,
+    "repository"
+  );
+  const workspaceDisplayName = formatUpstreamText(workspace, "workspace");
+  const exportedAtDisplay = formatUpstreamText(exportedAt, "unknown time");
   const sections = [
     [
-      `# Terraform configuration for repository "${getStringValue(getRepoField(repo, "name")) || repoSlug}" in workspace "${workspace}"`,
-      `# Exported at ${exportedAt}`,
+      `# Terraform configuration for repository "${repositoryDisplayName}" in workspace "${workspaceDisplayName}"`,
+      `# Exported at ${exportedAtDisplay}`,
     ].join("\n"),
     formatBlock('data "cloudsmith_namespace" "this" {', [
       { key: "slug", value: workspace },
@@ -457,8 +476,17 @@ function generateTerraformConfig(options) {
         `# Upstream data is incomplete${unavailable.length > 0 ? ` for: ${unavailable.join(", ")}` : ""}. Loaded upstream resources are included; additional resources may need to be added manually.`
       );
     }
-    const { blocks, variableBlocks } = buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel);
+    const { blocks, variableBlocks, omittedUnsafeUrlCount } = buildUpstreamBlocks(
+      upstreams,
+      repoSlug,
+      repoResourceLabel
+    );
     sections.push(...blocks);
+    if (omittedUnsafeUrlCount > 0) {
+      sections.push(
+        `# ${omittedUnsafeUrlCount} upstream resource${omittedUnsafeUrlCount === 1 ? " was" : "s were"} omitted because the configured URL could not be exported safely. Add ${omittedUnsafeUrlCount === 1 ? "it" : "them"} manually.`
+      );
+    }
 
     const retentionBlock = buildRetentionBlock(retention, repoResourceLabel);
     if (retentionBlock) {

--- a/util/terraformExporter.js
+++ b/util/terraformExporter.js
@@ -1,6 +1,7 @@
 // Copyright 2026 Cloudsmith Ltd.
 
 const { getAllUpstreamData } = require("./upstreamChecker");
+const { SUPPORTED_UPSTREAM_FORMATS } = require("./upstreamFormats");
 
 const REPOSITORY_OPTIONAL_FIELDS = [
   { apiField: "repository_type_str", terraformField: "repository_type", defaultValue: "Private" },
@@ -194,20 +195,30 @@ function buildVariableBlock(name, description) {
 }
 
 async function fetchRepositoryUpstreams(context, workspace, repoSlug, options = {}) {
-  const upstreamData = await getAllUpstreamData(context, workspace, repoSlug, options);
+  const upstreamData = await getAllUpstreamData(context, workspace, repoSlug, {
+    ...options,
+    bypassCache: true,
+  });
   if (upstreamData === null) {
     return null;
   }
 
   const upstreams = Array.isArray(upstreamData.upstreams) ? upstreamData.upstreams : [];
   const failedFormats = Array.isArray(upstreamData.failedFormats) ? upstreamData.failedFormats : [];
+  const uninspectedFormats = Array.isArray(upstreamData.uninspectedFormats)
+    ? upstreamData.uninspectedFormats
+    : [];
+  const unavailableFormats = [...new Set([...failedFormats, ...uninspectedFormats])];
   const hasUsableUpstreams = upstreams.length > 0;
 
-  if (failedFormats.length > 0 && !hasUsableUpstreams) {
+  if (unavailableFormats.length > 0 && !hasUsableUpstreams) {
     return {
       data: upstreams,
-      error: `Could not load upstream data for: ${failedFormats.join(", ")}`,
+      error: `Could not load upstream data for: ${unavailableFormats.join(", ")}`,
       failedFormats,
+      uninspectedFormats,
+      complete: false,
+      partial: false,
     };
   }
 
@@ -217,6 +228,9 @@ async function fetchRepositoryUpstreams(context, workspace, repoSlug, options = 
     active: upstreamData.active,
     total: upstreamData.total,
     failedFormats,
+    uninspectedFormats,
+    complete: upstreamData.complete === true,
+    partial: upstreamData.complete !== true && hasUsableUpstreams,
   };
 }
 
@@ -413,6 +427,8 @@ function generateTerraformConfig(options) {
     retention = null,
     exportedAt = new Date().toISOString(),
     upstreamLoadFailed = false,
+    upstreamLoadPartial = false,
+    upstreamFailedFormats = [],
   } = options || {};
 
   const repoSlug = getStringValue(getRepoField(repo, "slug")) || "repository";
@@ -431,6 +447,16 @@ function generateTerraformConfig(options) {
   if (upstreamLoadFailed) {
     sections.push("# Could not load upstream data. Add upstream resources manually.");
   } else if (Array.isArray(upstreams) && upstreams.length > 0) {
+    if (upstreamLoadPartial) {
+      const unavailable = Array.isArray(upstreamFailedFormats)
+        ? [...new Set(upstreamFailedFormats.filter(value => (
+          typeof value === "string" && SUPPORTED_UPSTREAM_FORMATS.includes(value)
+        )))]
+        : [];
+      sections.push(
+        `# Upstream data is incomplete${unavailable.length > 0 ? ` for: ${unavailable.join(", ")}` : ""}. Loaded upstream resources are included; additional resources may need to be added manually.`
+      );
+    }
     const { blocks, variableBlocks } = buildUpstreamBlocks(upstreams, repoSlug, repoResourceLabel);
     sections.push(...blocks);
 

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -2,6 +2,8 @@
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
+const { PaginatedFetch } = require("./paginatedFetch");
+const { packageCollectionIdentity } = require("./collectionIdentity");
 const {
   captureAccount,
   isAccountCurrent,
@@ -11,6 +13,7 @@ const {
   getSupportedUpstreamFormats,
   SUPPORTED_UPSTREAM_FORMATS,
 } = require("./upstreamFormats");
+const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
 
 const UPSTREAM_CACHE_SCHEMA_VERSION = 3;
 const UPSTREAM_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -24,6 +27,9 @@ const MAX_PERSISTED_DISTRO_VERSIONS = 100;
 const MAX_RUNTIME_UPSTREAMS = 5000;
 const MAX_RUNTIME_UPSTREAMS_PER_FORMAT = 500;
 const MAX_RUNTIME_URL_LENGTH = 8192;
+const LOCAL_PACKAGE_PAGE_SIZE = 100;
+const MAX_LOCAL_PACKAGE_PAGES = 20;
+const MAX_LOCAL_PACKAGES = LOCAL_PACKAGE_PAGE_SIZE * MAX_LOCAL_PACKAGE_PAGES;
 const BENIGN_UPSTREAM_FORMAT_STATUS_CODES = new Set([400, 404, 405, 422]);
 const PERSISTED_UPSTREAM_KEYS = Object.freeze([
   "name",
@@ -196,23 +202,32 @@ function canonicalizeRuntimeUpstream(value) {
   for (const key of PERSISTED_UPSTREAM_KEYS) {
     if (key === "name" || value[key] === undefined) continue;
     const normalized = normalizePersistedField(key, value[key]);
-    if (normalized !== null) canonical[key] = normalized;
+    if (normalized !== null) {
+      canonical[key] = normalized;
+      continue;
+    }
+    if (
+      key === "priority"
+      && typeof value.priority === "string"
+      && boundedString(value.priority, MAX_PERSISTED_NAME_LENGTH)
+    ) {
+      canonical.priority = value.priority;
+      continue;
+    }
+    return null;
   }
-  if (typeof value.upstream_url === "string" && value.upstream_url.length <= MAX_RUNTIME_URL_LENGTH) {
+  if (value.upstream_url !== undefined) {
+    if (!boundedString(value.upstream_url, MAX_RUNTIME_URL_LENGTH)) return null;
     canonical.upstream_url = value.upstream_url;
   }
   for (const key of [
     "auth_mode", "auth_username", "extra_header_1", "extra_value_1",
     "extra_header_2", "extra_value_2",
   ]) {
+    if (value[key] === undefined) continue;
     const normalized = boundedString(value[key], MAX_PERSISTED_STRING_LENGTH);
-    if (normalized !== null) canonical[key] = normalized;
-  }
-  if (
-    typeof value.priority === "string"
-    && boundedString(value.priority, MAX_PERSISTED_NAME_LENGTH)
-  ) {
-    canonical.priority = value.priority;
+    if (normalized === null) return null;
+    canonical[key] = normalized;
   }
   return canonical;
 }
@@ -241,7 +256,15 @@ function isFresh(timestamp, now) {
   return timestamp <= now && now - timestamp < UPSTREAM_CACHE_TTL_MS;
 }
 
-function getCachedFlatResponse(globalState, cacheKey, workspace, repo, account, now) {
+function getCachedFlatResponse(
+  globalState,
+  cacheKey,
+  workspace,
+  repo,
+  requestedFormats,
+  account,
+  now
+) {
   if (!globalState || typeof globalState.get !== "function") return null;
   const cached = globalState.get(cacheKey);
   if (cached === undefined) return null;
@@ -255,11 +278,19 @@ function getCachedFlatResponse(globalState, cacheKey, workspace, repo, account, 
     && cached.upstreams.every(isPersistedUpstream)
     && Number.isInteger(cached.active) && cached.active >= 0
     && Number.isInteger(cached.total) && cached.total === cached.upstreams.length
-    && cached.active <= cached.total
+    && cached.active === cached.upstreams.filter(upstream => upstream.is_active !== false).length
     && Array.isArray(cached.failedFormats) && cached.failedFormats.length === 0
     && Number.isInteger(cached.successfulFormats)
-    && cached.successfulFormats >= 0
-    && cached.successfulFormats <= SUPPORTED_UPSTREAM_FORMATS.length;
+    && cached.successfulFormats === requestedFormats.length
+    && cached.upstreams.every((upstream) => {
+      const taggedFormats = [upstream._format, upstream.format]
+        .filter(value => value !== undefined);
+      return taggedFormats.length > 0
+        && taggedFormats.every(value => value === taggedFormats[0])
+        && requestedFormats.includes(taggedFormats[0]);
+    })
+    && new Set(cached.upstreams.map(upstream => `${upstream._format || upstream.format}\0${upstream.name}`)).size
+      === cached.upstreams.length;
   if (!valid) {
     evictCacheEntry(globalState, cacheKey, workspace, repo);
     return null;
@@ -269,7 +300,12 @@ function getCachedFlatResponse(globalState, cacheKey, workspace, repo, account, 
     active: cached.active,
     total: cached.total,
     failedFormats: [],
+    uninspectedFormats: [],
     successfulFormats: cached.successfulFormats,
+    complete: true,
+    incomplete: false,
+    partial: false,
+    cancelled: false,
   };
 }
 
@@ -282,6 +318,7 @@ async function persistFlatResponse(
   account,
   connectionManager,
   operationId,
+  requestedFormats,
   now
 ) {
   if (!globalState || typeof globalState.update !== "function") return;
@@ -293,8 +330,11 @@ async function persistFlatResponse(
     || response.active > serializedUpstreams.length
     || response.total !== serializedUpstreams.length
     || !Number.isSafeInteger(response.successfulFormats)
-    || response.successfulFormats < 0
-    || response.successfulFormats > SUPPORTED_UPSTREAM_FORMATS.length
+    || response.successfulFormats !== requestedFormats.length
+    || !serializedUpstreams.every((upstream) => {
+      const format = upstream._format || upstream.format;
+      return requestedFormats.includes(format);
+    })
   ) return;
   await queueCacheWrite(globalState, cacheKey, async () => {
     if (
@@ -358,13 +398,16 @@ function sortUpstreams(left, right) {
 async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) {
   try {
     if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
-    const result = await api.get(apiEndpoint(["repos", workspace, repo, "upstream", format]), {
-      responseType: "array",
-      validate: isUpstreamArray,
-      retry: "never",
-      signal: options.signal,
-      cancellationToken: options.cancellationToken,
-    });
+    const request = () => api.get(apiEndpoint(["repos", workspace, repo, "upstream", format]), {
+        responseType: "array",
+        validate: value => isUpstreamArray(value, format),
+        retry: "never",
+        signal: options.signal,
+        cancellationToken: options.cancellationToken,
+      });
+    const result = options.scheduler
+      ? await options.scheduler.run(request, options)
+      : await request();
     if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
     if (!result.ok) {
       if (result.error.kind === "cancelled") return { format, status: "aborted", upstreams: [] };
@@ -372,7 +415,7 @@ async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) 
         ? { format, status: "failed", error: result.error, upstreams: [] }
         : { format, status: "loaded", upstreams: [] };
     }
-    if (!isUpstreamArray(result.data)) {
+    if (!isUpstreamArray(result.data, format)) {
       return {
         format,
         status: "failed",
@@ -390,7 +433,10 @@ async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) 
       })),
     };
   } catch (error) {
-    return isAbortError(error) || isCancelled(options)
+    if (["request_limit", "rate_limit_circuit"].includes(error && error.kind)) {
+      return { format, status: "uninspected", error, upstreams: [] };
+    }
+    return isAbortError(error) || error?.kind === "cancelled" || isCancelled(options)
       ? { format, status: "aborted", upstreams: [] }
       : { format, status: "failed", error, upstreams: [] };
   }
@@ -410,57 +456,108 @@ class UpstreamChecker {
   }
 
   _emptyRepositoryState() {
-    return this._buildRepositoryUpstreamState(new Map(), [], 0);
+    return this._buildRepositoryUpstreamState(
+      new Map(),
+      [],
+      0,
+      SUPPORTED_UPSTREAM_FORMATS,
+      { cancelled: true }
+    );
   }
 
   async existsLocally(workspace, repo, name, format, options = {}) {
     const account = this._captureAccount(options);
-    if (!account) return { data: null, error: null, stale: true };
+    if (!account) return { data: null, error: null, complete: false, stale: true };
     let endpoint;
+    let query;
     try {
-      const query = new SearchQueryBuilder().name(name).format(format).build();
-      endpoint = apiEndpoint(["packages", workspace, repo], { query: { query, page_size: 1 } });
+      query = new SearchQueryBuilder().name(name).format(format).build();
+      endpoint = apiEndpoint(["packages", workspace, repo]);
     } catch (error) {
-      return { data: null, error };
+      return { data: null, error, complete: false };
     }
-    const result = await this.api.get(endpoint, {
-      responseType: "array",
-      validate: isPackageArray,
-      retry: "safe-read",
-    });
-    if (!isAccountCurrent(this.connectionManager, account)) {
-      return { data: null, error: null, stale: true };
+    const paginatedFetch = new PaginatedFetch(this.api);
+    const descriptor = `upstream-local-preview:${workspace}:${repo}:${format}`;
+    let resume = null;
+    const knownIdentities = new Set();
+    while (true) {
+      const result = await paginatedFetch.fetchCollection(endpoint, {
+        pageSize: LOCAL_PACKAGE_PAGE_SIZE,
+        maxPages: MAX_LOCAL_PACKAGE_PAGES,
+        maxRequests: MAX_LOCAL_PACKAGE_PAGES,
+        maxItems: MAX_LOCAL_PACKAGES,
+        pageBatchLimit: 1,
+        resume,
+        knownIdentities,
+        query,
+        descriptor,
+        canonicalIdentity: packageCollectionIdentity,
+        validate: value => isLocalPackageArray(value, workspace, repo),
+        retry: "never",
+        signal: options.signal,
+        cancellationToken: options.cancellationToken,
+      });
+      if (!isAccountCurrent(this.connectionManager, account)) {
+        return { data: null, error: null, complete: false, stale: true };
+      }
+      const exact = result.items.find(candidate => (
+        candidate.name === name
+        && candidate.format === format
+        && candidate.namespace === workspace
+        && candidate.repository === repo
+      ));
+      if (exact) return { data: exact, error: null, complete: result.complete, stale: false };
+      for (const candidate of result.items) {
+        const identity = packageCollectionIdentity(candidate);
+        if (identity) knownIdentities.add(identity);
+      }
+      if (result.complete) {
+        return { data: null, error: null, complete: true, stale: false };
+      }
+      if (!result.continuation) {
+        return {
+          data: null,
+          error: result.failures[0]?.error || incompleteLocalPackageError(),
+          complete: false,
+          stale: false,
+        };
+      }
+      resume = result.continuation;
     }
-    if (!result.ok) return { data: null, error: result.error };
-    return { data: result.data[0] || null, error: null };
   }
 
   async getUpstreamsForFormat(workspace, repo, format, options = {}) {
     const account = this._captureAccount(options);
-    if (!account) return { data: [], error: null, stale: true };
+    if (!account) return { data: [], error: null, complete: false, stale: true };
     let endpoint;
     try {
       endpoint = apiEndpoint(["repos", workspace, repo, "upstream", format]);
     } catch (error) {
-      return { data: [], error };
+      return { data: [], error, complete: false };
     }
     const result = await this.api.get(endpoint, {
       responseType: "array",
-      validate: isUpstreamArray,
+      validate: value => isUpstreamArray(value, format),
       retry: "safe-read",
+      signal: options.signal,
+      cancellationToken: options.cancellationToken,
     });
     if (!isAccountCurrent(this.connectionManager, account)) {
-      return { data: [], error: null, stale: true };
+      return { data: [], error: null, complete: false, stale: true };
     }
     if (!result.ok) {
       return isBenignUpstreamFormatError(result.error)
-        ? { data: [], error: null }
-        : { data: [], error: result.error };
+        ? { data: [], error: null, complete: true }
+        : { data: [], error: result.error, complete: false };
     }
-    if (!isUpstreamArray(result.data)) {
-      return { data: [], error: invalidUpstreamResponseError() };
+    if (!isUpstreamArray(result.data, format)) {
+      return { data: [], error: invalidUpstreamResponseError(), complete: false };
     }
-    return { data: result.data.map(canonicalizeRuntimeUpstream), error: null };
+    return {
+      data: result.data.map(canonicalizeRuntimeUpstream),
+      error: null,
+      complete: true,
+    };
   }
 
   async getUpstreamDataForFormats(workspace, repo, formats, options = {}) {
@@ -468,34 +565,50 @@ class UpstreamChecker {
     if (!account || isCancelled(options)) return null;
     const requestedFormats = getSupportedUpstreamFormats(formats);
     if (requestedFormats.length === 0) {
-      return { upstreams: [], active: 0, total: 0, failedFormats: [], successfulFormats: 0 };
+      return {
+        upstreams: [], active: 0, total: 0, failedFormats: [], uninspectedFormats: [],
+        successfulFormats: 0, complete: true, incomplete: false, partial: false, cancelled: false,
+      };
     }
     const cacheKey = getUpstreamCacheKey(workspace, repo, requestedFormats);
     const globalState = this.context && this.context.globalState;
     const operationToken = globalState ? beginCacheOperation(globalState, cacheKey) : null;
     try {
-      const cached = getCachedFlatResponse(
-        globalState,
-        cacheKey,
-        workspace,
-        repo,
-        account,
-        this.now()
-      );
+      const cached = options.bypassCache === true
+        ? null
+        : getCachedFlatResponse(
+          globalState,
+          cacheKey,
+          workspace,
+          repo,
+          requestedFormats,
+          account,
+          this.now()
+        );
       if (cached && isAccountCurrent(this.connectionManager, account)) return cached;
 
       const upstreams = [];
       const failedFormats = [];
+      const uninspectedFormats = [];
       let successfulFormats = 0;
+      const scheduler = options.scheduler || new UpstreamOperationScheduler();
       for (let index = 0; index < requestedFormats.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
-        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) return null;
+        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) {
+          scheduler.cancel();
+          return null;
+        }
         const batch = requestedFormats.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
         const results = await Promise.all(batch.map(format => (
-          fetchFormatUpstreams(this.api, workspace, repo, format, options)
+          fetchFormatUpstreams(this.api, workspace, repo, format, { ...options, scheduler })
         )));
-        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) return null;
+        if (!isAccountCurrent(this.connectionManager, account)) return null;
+        let cancelled = isCancelled(options);
         for (const result of results) {
-          if (result.status === "aborted") return null;
+          if (result.status === "aborted") {
+            cancelled = true;
+            uninspectedFormats.push(result.format);
+          }
+          if (result.status === "uninspected") uninspectedFormats.push(result.format);
           if (result.status === "failed") failedFormats.push(result.format);
           if (result.status === "loaded") {
             if (upstreams.length + result.upstreams.length > MAX_RUNTIME_UPSTREAMS) {
@@ -506,17 +619,31 @@ class UpstreamChecker {
             upstreams.push(...result.upstreams);
           }
         }
+        if (cancelled) {
+          scheduler.cancel();
+          uninspectedFormats.push(...requestedFormats.slice(index + batch.length));
+          break;
+        }
       }
       upstreams.sort(sortUpstreams);
+      const uniqueFailedFormats = [...new Set(failedFormats)];
+      const uniqueUninspectedFormats = [...new Set(uninspectedFormats)];
+      const complete = uniqueFailedFormats.length === 0 && uniqueUninspectedFormats.length === 0;
       const response = {
         upstreams,
         active: upstreams.filter(upstream => upstream.is_active !== false).length,
         total: upstreams.length,
-        failedFormats,
+        failedFormats: uniqueFailedFormats,
+        uninspectedFormats: uniqueUninspectedFormats,
         successfulFormats,
+        complete,
+        incomplete: !complete,
+        partial: !complete && successfulFormats > 0,
+        cancelled: isCancelled(options),
+        requestCount: scheduler.requestCount,
       };
       if (!isAccountCurrent(this.connectionManager, account)) return null;
-      if (!isCancelled(options) && failedFormats.length === 0 && globalState) {
+      if (!isCancelled(options) && complete && globalState) {
         await persistFlatResponse(
           globalState,
           cacheKey,
@@ -526,6 +653,7 @@ class UpstreamChecker {
           account,
           this.connectionManager,
           operationToken,
+          requestedFormats,
           this.now
         );
       }
@@ -542,10 +670,29 @@ class UpstreamChecker {
   async getAllUpstreams(workspace, repo, options = {}) {
     const result = await this.getAllUpstreamData(workspace, repo, options);
     if (result === null) return { data: [], error: null, aborted: true };
-    if (result.failedFormats.length > 0 && result.upstreams.length === 0) {
-      return { data: [], error: `Could not load upstream data for: ${result.failedFormats.join(", ")}` };
+    const failedFormats = Array.isArray(result.failedFormats) ? result.failedFormats : [];
+    const uninspectedFormats = Array.isArray(result.uninspectedFormats)
+      ? result.uninspectedFormats
+      : [];
+    const unavailableFormats = [...failedFormats, ...uninspectedFormats];
+    if (unavailableFormats.length > 0 && result.upstreams.length === 0) {
+      return {
+        data: [],
+        error: `Could not load upstream data for: ${unavailableFormats.join(", ")}`,
+        complete: false,
+        partial: false,
+        failedFormats,
+        uninspectedFormats,
+      };
     }
-    return { data: result.upstreams, error: null };
+    return {
+      data: result.upstreams,
+      error: null,
+      complete: result.complete,
+      partial: result.partial,
+      failedFormats,
+      uninspectedFormats,
+    };
   }
 
   async getRepositoryUpstreamState(workspace, repo, options = {}) {
@@ -562,13 +709,42 @@ class UpstreamChecker {
         account,
       });
       if (!isAccountCurrent(this.connectionManager, account)) return this._emptyRepositoryState();
-      if (!isCancelled(options) && fetched.failedFormats.length === 0) {
+      if (!isCancelled(options) && fetched.complete) {
         await this._cacheRepositoryUpstreamState(workspace, repo, fetched, account, operationToken);
       }
       return isAccountCurrent(this.connectionManager, account) ? fetched : this._emptyRepositoryState();
     } finally {
       finishCacheOperation(globalState, cacheKey, operationToken);
     }
+  }
+
+  async getRepositoryUpstreamStateForFormats(workspace, repo, formats, options = {}) {
+    const requestedFormats = getSupportedUpstreamFormats(formats);
+    const result = await this.getUpstreamDataForFormats(workspace, repo, requestedFormats, options);
+    if (result === null) {
+      return this._buildRepositoryUpstreamState(
+        new Map(),
+        [],
+        0,
+        requestedFormats,
+        { cancelled: true }
+      );
+    }
+    const grouped = new Map();
+    for (const upstream of result.upstreams) {
+      const format = typeof upstream._format === "string" ? upstream._format : upstream.format;
+      if (!requestedFormats.includes(format)) continue;
+      const values = grouped.get(format) || [];
+      values.push(upstream);
+      grouped.set(format, values);
+    }
+    return this._buildRepositoryUpstreamState(
+      grouped,
+      result.failedFormats,
+      result.successfulFormats,
+      result.uninspectedFormats,
+      { cancelled: result.cancelled, requestCount: result.requestCount }
+    );
   }
 
   async getRepositoryUpstreams(workspace, repo, options = {}) {
@@ -600,6 +776,7 @@ class UpstreamChecker {
       upstreams: {
         data: { total: configs.length, active: active.length, configs },
         error: upstreams.error,
+        complete: upstreams.complete === true,
       },
       canResolveViaUpstream: active.length > 0,
     };
@@ -639,13 +816,17 @@ class UpstreamChecker {
         Array.isArray(cached.groupedUpstreams[format])
         && cached.groupedUpstreams[format].length <= MAX_PERSISTED_UPSTREAMS_PER_FORMAT
         && cached.groupedUpstreams[format].every(isPersistedUpstream)
+        && cached.groupedUpstreams[format].every(upstream => (
+          upstream._format === format && upstream.format === format
+        ))
+        && new Set(cached.groupedUpstreams[format].map(upstream => upstream.name)).size
+          === cached.groupedUpstreams[format].length
       ))
       && formats.reduce((total, format) => (
         total + cached.groupedUpstreams[format].length
       ), 0) <= MAX_PERSISTED_UPSTREAMS
       && Number.isInteger(cached.successfulFormats)
-      && cached.successfulFormats >= 0
-      && cached.successfulFormats <= SUPPORTED_UPSTREAM_FORMATS.length;
+      && cached.successfulFormats === SUPPORTED_UPSTREAM_FORMATS.length;
     if (!valid) {
       this._evictInvalidRepositoryUpstreamCacheEntry(workspace, repo, globalState);
       return null;
@@ -653,7 +834,8 @@ class UpstreamChecker {
     return this._buildRepositoryUpstreamState(
       this._deserializeGroupedUpstreams(cached.groupedUpstreams),
       [],
-      cached.successfulFormats
+      cached.successfulFormats,
+      []
     );
   }
 
@@ -698,19 +880,26 @@ class UpstreamChecker {
   async _fetchRepositoryUpstreamState(workspace, repo, options = {}) {
     const grouped = new Map();
     const failed = [];
+    const uninspected = [];
     let successful = 0;
+    const scheduler = options.scheduler || new UpstreamOperationScheduler();
     for (let index = 0; index < SUPPORTED_UPSTREAM_FORMATS.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
       if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
-        return this._emptyRepositoryState();
+        scheduler.cancel();
+        uninspected.push(...SUPPORTED_UPSTREAM_FORMATS.slice(index));
+        return this._buildRepositoryUpstreamState(
+          grouped, failed, successful, uninspected, { cancelled: true }
+        );
       }
       const batch = SUPPORTED_UPSTREAM_FORMATS.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
       const results = await Promise.all(batch.map(format => (
-        fetchFormatUpstreams(this.api, workspace, repo, format, options)
+        fetchFormatUpstreams(this.api, workspace, repo, format, { ...options, scheduler })
       )));
       if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
-        return this._emptyRepositoryState();
+        scheduler.cancel();
       }
       for (const result of results) {
+        if (["aborted", "uninspected"].includes(result.status)) uninspected.push(result.format);
         if (result.status === "failed") failed.push(result.format);
         if (result.status === "loaded") {
           const retainedCount = Array.from(grouped.values()).reduce(
@@ -725,11 +914,27 @@ class UpstreamChecker {
           if (result.upstreams.length > 0) grouped.set(result.format, result.upstreams);
         }
       }
+      if (isCancelled(options)) {
+        uninspected.push(...SUPPORTED_UPSTREAM_FORMATS.slice(index + batch.length));
+        break;
+      }
     }
-    return this._buildRepositoryUpstreamState(grouped, failed, successful);
+    return this._buildRepositoryUpstreamState(
+      grouped,
+      failed,
+      successful,
+      uninspected,
+      { cancelled: isCancelled(options), requestCount: scheduler.requestCount }
+    );
   }
 
-  _buildRepositoryUpstreamState(groupedUpstreams, failedFormats, successfulFormats) {
+  _buildRepositoryUpstreamState(
+    groupedUpstreams,
+    failedFormats,
+    successfulFormats,
+    uninspectedFormats = [],
+    options = {}
+  ) {
     const normalizedGrouped = new Map();
     const upstreams = [];
     let active = 0;
@@ -746,13 +951,24 @@ class UpstreamChecker {
       upstreams.push(...tagged);
       active += tagged.filter(upstream => upstream.is_active !== false).length;
     }
+    const normalizedFailedFormats = [...new Set(Array.isArray(failedFormats) ? failedFormats : [])];
+    const normalizedUninspectedFormats = [
+      ...new Set(Array.isArray(uninspectedFormats) ? uninspectedFormats : []),
+    ];
+    const complete = normalizedFailedFormats.length === 0 && normalizedUninspectedFormats.length === 0;
     return {
       groupedUpstreams: normalizedGrouped,
-      failedFormats: Array.isArray(failedFormats) ? failedFormats.slice() : [],
+      failedFormats: normalizedFailedFormats,
+      uninspectedFormats: normalizedUninspectedFormats,
       successfulFormats,
       upstreams,
       active,
       total: upstreams.length,
+      complete,
+      incomplete: !complete,
+      partial: !complete && successfulFormats > 0,
+      cancelled: options.cancelled === true,
+      requestCount: Number.isSafeInteger(options.requestCount) ? options.requestCount : 0,
     };
   }
 
@@ -775,25 +991,56 @@ class UpstreamChecker {
   }
 }
 
-function isRecordArray(value) {
-  return Array.isArray(value) && value.every(item => isObjectRecord(item));
+function isLocalPackageArray(value, workspace, repository) {
+  return Array.isArray(value)
+    && value.length <= LOCAL_PACKAGE_PAGE_SIZE
+    && value.every(item => isLocalPackage(item, workspace, repository));
 }
 
-function isPackageArray(value) {
-  return isRecordArray(value) && value.length <= 100 && value.every(item => (
-    boundedString(item.name, MAX_PERSISTED_STRING_LENGTH)
-    && boundedString(item.format, MAX_PERSISTED_NAME_LENGTH)
-  ));
+function isLocalPackage(item, workspace, repository) {
+  if (
+    !isObjectRecord(item)
+    || !boundedString(item.name, MAX_PERSISTED_STRING_LENGTH)
+    || !boundedString(item.format, MAX_PERSISTED_NAME_LENGTH)
+    || item.namespace !== workspace
+    || item.repository !== repository
+  ) return false;
+  try {
+    packageCollectionIdentity(item);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function incompleteLocalPackageError() {
+  return Object.freeze({
+    kind: "incomplete_collection",
+    status: null,
+    retryable: true,
+    message: "The local package collection could not be verified completely.",
+    requestId: null,
+    retryAfterMs: null,
+    outcomeUnknown: false,
+  });
 }
 
 function isUpstreamRecord(value) {
   return canonicalizeRuntimeUpstream(value) !== null;
 }
 
-function isUpstreamArray(value) {
-  return Array.isArray(value)
-    && value.length <= MAX_RUNTIME_UPSTREAMS_PER_FORMAT
-    && value.every(isUpstreamRecord);
+function isUpstreamArray(value, expectedFormat = null) {
+  if (
+    !Array.isArray(value)
+    || value.length > MAX_RUNTIME_UPSTREAMS_PER_FORMAT
+    || !value.every(isUpstreamRecord)
+  ) return false;
+  const names = value.map(upstream => upstream.name);
+  if (new Set(names).size !== names.length) return false;
+  return !expectedFormat || value.every(upstream => (
+    (upstream._format === undefined || upstream._format === expectedFormat)
+    && (upstream.format === undefined || upstream.format === expectedFormat)
+  ));
 }
 
 function invalidUpstreamResponseError() {

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -14,6 +14,7 @@ const {
   SUPPORTED_UPSTREAM_FORMATS,
 } = require("./upstreamFormats");
 const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
+const { formatUpstreamError } = require("./upstreamPresentation");
 
 const UPSTREAM_CACHE_SCHEMA_VERSION = 3;
 const UPSTREAM_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -760,11 +761,17 @@ class UpstreamChecker {
     const account = this._captureAccount(options);
     if (!account) return null;
     const sharedOptions = { ...options, account };
-    const [localPkg, upstreams] = await Promise.all([
+    const [localResult, upstreamResult] = await Promise.allSettled([
       this.existsLocally(workspace, repo, name, format, sharedOptions),
       this.getUpstreamsForFormat(workspace, repo, format, sharedOptions),
     ]);
     if (!isAccountCurrent(this.connectionManager, account)) return null;
+    const localPkg = localResult.status === "fulfilled"
+      ? localResult.value
+      : { data: null, error: localResult.reason, complete: false };
+    const upstreams = upstreamResult.status === "fulfilled"
+      ? upstreamResult.value
+      : { data: [], error: upstreamResult.reason, complete: false };
     const configs = Array.isArray(upstreams.data) ? upstreams.data : [];
     const active = configs.filter(upstream => upstream.is_active !== false);
     return {
@@ -772,10 +779,14 @@ class UpstreamChecker {
       format,
       workspace,
       repo,
-      local: localPkg,
+      local: {
+        data: localPkg.data || null,
+        errorMessage: localPkg.error ? formatUpstreamError(localPkg.error, "local") : null,
+        complete: localPkg.complete === true,
+      },
       upstreams: {
         data: { total: configs.length, active: active.length, configs },
-        error: upstreams.error,
+        errorMessage: upstreams.error ? formatUpstreamError(upstreams.error, "upstream") : null,
         complete: upstreams.complete === true,
       },
       canResolveViaUpstream: active.length > 0,

--- a/util/upstreamGapAnalyzer.js
+++ b/util/upstreamGapAnalyzer.js
@@ -2,8 +2,9 @@
 const { canonicalFormat, normalizePackageName } = require("./packageNameNormalizer");
 const { normalizeUpstreamFormat } = require("./upstreamFormats");
 const { UpstreamChecker } = require("./upstreamChecker");
+const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
 
-const UPSTREAM_REPO_CONCURRENCY = 5;
+const UPSTREAM_REPO_CONCURRENCY = 4;
 
 function getUncoveredDependencyKey(dependency) {
   const format = canonicalFormat(dependency && (dependency.format || dependency.ecosystem));
@@ -48,7 +49,7 @@ function buildReachableDetail(snapshot, upstream, format) {
   return `${buildProxyLabel(upstream, format)} on ${snapshot.repo}`;
 }
 
-function classifyDependency(dependency, snapshots) {
+function classifyDependency(dependency, snapshots, options = {}) {
   const key = getUncoveredDependencyKey(dependency);
   const format = canonicalFormat(dependency && (dependency.format || dependency.ecosystem));
   if (!key || !format) {
@@ -81,13 +82,32 @@ function classifyDependency(dependency, snapshots) {
     };
   }
 
+  const incompleteRepositoryState = snapshots.some(snapshot => (
+    (
+      snapshot.complete === false
+      && (!Array.isArray(snapshot.failedFormats) || snapshot.failedFormats.length === 0)
+      && (!Array.isArray(snapshot.uninspectedFormats) || snapshot.uninspectedFormats.length === 0)
+    )
+    || (Array.isArray(snapshot.failedFormats) && snapshot.failedFormats.includes(upstreamFormat))
+    || (
+      Array.isArray(snapshot.uninspectedFormats)
+      && snapshot.uninspectedFormats.includes(upstreamFormat)
+    )
+  ));
+  if (options.repositoriesComplete === false || incompleteRepositoryState) {
+    return {
+      upstreamStatus: "unknown",
+      upstreamDetail: `Upstream coverage for ${upstreamFormat} could not be inspected completely`,
+    };
+  }
+
   return {
     upstreamStatus: "no_proxy",
     upstreamDetail: `No upstream proxy configured for ${upstreamFormat}`,
   };
 }
 
-function buildGapPatch(uncoveredDependencies, snapshots) {
+function buildGapPatch(uncoveredDependencies, snapshots, options = {}) {
   const patchMap = new Map();
 
   for (const dependency of Array.isArray(uncoveredDependencies) ? uncoveredDependencies : []) {
@@ -100,7 +120,7 @@ function buildGapPatch(uncoveredDependencies, snapshots) {
       continue;
     }
 
-    patchMap.set(key, classifyDependency(dependency, snapshots));
+    patchMap.set(key, classifyDependency(dependency, snapshots, options));
   }
 
   return patchMap;
@@ -127,13 +147,20 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
   const cancellationToken = options.cancellationToken || null;
   const upstreamChecker = options.upstreamChecker || new UpstreamChecker(options.context);
   const repositoriesToInspect = Array.isArray(repositories)
-    ? repositories.map((repo) => String(repo || "").trim()).filter(Boolean)
+    ? [...new Set(repositories.map((repo) => String(repo || "").trim()).filter(Boolean))]
     : [];
+  const repositoriesComplete = options.repositoriesComplete !== false;
+  const scheduler = options.scheduler || new UpstreamOperationScheduler();
+  const formatsToInspect = [...new Set((Array.isArray(uncoveredDependencies)
+    ? uncoveredDependencies
+    : []).map(dependency => normalizeUpstreamFormat(canonicalFormat(
+      dependency && (dependency.format || dependency.ecosystem)
+    ))).filter(Boolean))];
 
-  if (repositoriesToInspect.length === 0) {
-    const emptyPatch = buildGapPatch(uncoveredDependencies, []);
+  if (repositoriesToInspect.length === 0 || formatsToInspect.length === 0) {
+    const emptyPatch = buildGapPatch(uncoveredDependencies, [], { repositoriesComplete });
     if (onProgress && emptyPatch.size > 0) {
-      onProgress(new Map(emptyPatch), {
+      publishProgress(onProgress, new Map(emptyPatch), {
         completed: 0,
         total: 0,
         workspace,
@@ -147,41 +174,60 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
   let completed = 0;
 
   await runPromisePool(repositoriesToInspect, UPSTREAM_REPO_CONCURRENCY, async (repo) => {
-    if (cancellationToken && cancellationToken.isCancellationRequested) {
-      return;
-    }
+    if (isCancelled(cancellationToken) || scheduler.stopped) return false;
 
-    const state = await upstreamChecker.getRepositoryUpstreamState(workspace, repo, {
-      cancellationToken,
-    });
+    let state;
+    try {
+      const requestOptions = { cancellationToken, scheduler };
+      state = typeof upstreamChecker.getRepositoryUpstreamStateForFormats === "function"
+        ? await upstreamChecker.getRepositoryUpstreamStateForFormats(
+          workspace,
+          repo,
+          formatsToInspect,
+          requestOptions
+        )
+        : await upstreamChecker.getRepositoryUpstreamState(workspace, repo, requestOptions);
+    } catch {
+      state = null;
+    }
     if (cancellationToken && cancellationToken.isCancellationRequested) {
-      return;
+      return false;
     }
     repoUpstreamStates.set(repo, {
       repo,
       groupedUpstreams: state && state.groupedUpstreams instanceof Map
         ? state.groupedUpstreams
         : new Map(),
+      complete: state?.complete === true,
+      failedFormats: Array.isArray(state?.failedFormats) ? state.failedFormats : [],
+      uninspectedFormats: Array.isArray(state?.uninspectedFormats)
+        ? state.uninspectedFormats
+        : [],
     });
 
     completed += 1;
     if (onProgress) {
-      onProgress(new Map(), {
+      publishProgress(onProgress, new Map(), {
         completed,
         total: repositoriesToInspect.length,
         workspace,
         stage: "upstream",
       });
     }
+    return true;
   });
 
   const snapshots = repositoriesToInspect
     .filter((repo) => repoUpstreamStates.has(repo))
     .map((repo) => repoUpstreamStates.get(repo));
 
-  const patchMap = buildGapPatch(uncoveredDependencies, snapshots);
+  const patchMap = buildGapPatch(uncoveredDependencies, snapshots, {
+    repositoriesComplete: repositoriesComplete
+      && snapshots.length === repositoriesToInspect.length
+      && !isCancelled(cancellationToken),
+  });
   if (onProgress && patchMap.size > 0) {
-    onProgress(new Map(patchMap), {
+    publishProgress(onProgress, new Map(patchMap), {
       completed,
       total: repositoriesToInspect.length,
       workspace,
@@ -189,6 +235,18 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
     });
   }
   return applyGapPatch(uncoveredDependencies, patchMap);
+}
+
+function isCancelled(cancellationToken) {
+  return Boolean(cancellationToken && cancellationToken.isCancellationRequested);
+}
+
+function publishProgress(onProgress, patchMap, metadata) {
+  try {
+    onProgress(patchMap, metadata);
+  } catch {
+    // Progress callbacks are observers and cannot abort or outlive the bounded work pool.
+  }
 }
 
 async function runPromisePool(items, concurrency, worker) {
@@ -204,12 +262,12 @@ async function runPromisePool(items, concurrency, worker) {
         if (item === undefined) {
           break;
         }
-        await worker(item);
+        if (await worker(item) === false) break;
       }
     })());
   }
 
-  await Promise.all(workers);
+  await Promise.allSettled(workers);
 }
 
 module.exports = {

--- a/util/upstreamOperationScheduler.js
+++ b/util/upstreamOperationScheduler.js
@@ -1,0 +1,150 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const DEFAULT_UPSTREAM_CONCURRENCY = 4;
+const DEFAULT_UPSTREAM_REQUEST_BUDGET = 1000;
+
+class UpstreamOperationScheduler {
+  constructor(options = {}) {
+    this.concurrency = boundedPositiveInteger(
+      options.concurrency,
+      DEFAULT_UPSTREAM_CONCURRENCY,
+      DEFAULT_UPSTREAM_CONCURRENCY
+    );
+    this.maxRequests = boundedPositiveInteger(
+      options.maxRequests,
+      DEFAULT_UPSTREAM_REQUEST_BUDGET,
+      DEFAULT_UPSTREAM_REQUEST_BUDGET
+    );
+    this.requestCount = 0;
+    this.acceptedCount = 0;
+    this.activeCount = 0;
+    this.maxActiveCount = 0;
+    this._queue = [];
+    this._circuitError = null;
+    this._cancelled = false;
+  }
+
+  run(task, options = {}) {
+    if (typeof task !== "function") {
+      return Promise.reject(schedulerError("invalid_task", "The upstream request was invalid."));
+    }
+    if (this._cancelled || isCancelled(options)) {
+      return Promise.reject(schedulerError("cancelled", "The upstream operation was cancelled."));
+    }
+    if (this._circuitError) {
+      return Promise.reject(this._circuitError);
+    }
+    // Reserve budget when accepting work. This bounds both dispatched requests and the queue.
+    if (this.acceptedCount >= this.maxRequests) {
+      return Promise.reject(schedulerError(
+        "request_limit",
+        "The upstream operation reached its request budget."
+      ));
+    }
+    this.acceptedCount += 1;
+
+    return new Promise((resolve, reject) => {
+      this._queue.push({ task, options, resolve, reject });
+      this._drain();
+    });
+  }
+
+  cancel() {
+    if (this._cancelled) return;
+    this._cancelled = true;
+    this._rejectQueued(schedulerError("cancelled", "The upstream operation was cancelled."));
+  }
+
+  get queuedCount() {
+    return this._queue.length;
+  }
+
+  get stopped() {
+    return this._cancelled || Boolean(this._circuitError) || this.acceptedCount >= this.maxRequests;
+  }
+
+  _drain() {
+    while (
+      !this._cancelled
+      && !this._circuitError
+      && this.activeCount < this.concurrency
+      && this._queue.length > 0
+    ) {
+      const entry = this._queue.shift();
+      if (isCancelled(entry.options)) {
+        entry.reject(schedulerError("cancelled", "The upstream operation was cancelled."));
+        continue;
+      }
+      this._dispatch(entry);
+    }
+  }
+
+  async _dispatch(entry) {
+    this.activeCount += 1;
+    this.requestCount += 1;
+    this.maxActiveCount = Math.max(this.maxActiveCount, this.activeCount);
+    try {
+      if (this._cancelled || isCancelled(entry.options)) {
+        throw schedulerError("cancelled", "The upstream operation was cancelled.");
+      }
+      const value = await entry.task();
+      if (isRateLimited(value)) this._openRateLimitCircuit(value.error);
+      entry.resolve(value);
+    } catch (error) {
+      if (isRateLimited(error)) this._openRateLimitCircuit(error);
+      entry.reject(error);
+    } finally {
+      this.activeCount -= 1;
+      this._drain();
+    }
+  }
+
+  _openRateLimitCircuit(cause) {
+    if (this._circuitError) return;
+    this._circuitError = schedulerError(
+      "rate_limit_circuit",
+      "The upstream operation stopped after Cloudsmith rate limiting.",
+      cause
+    );
+    this._rejectQueued(this._circuitError);
+  }
+
+  _rejectQueued(error) {
+    const queued = this._queue.splice(0);
+    for (const entry of queued) entry.reject(error);
+  }
+}
+
+function isCancelled(options) {
+  return Boolean(options.signal?.aborted || options.cancellationToken?.isCancellationRequested);
+}
+
+function isRateLimited(value) {
+  const candidate = value && value.ok === false && value.error ? value.error : value;
+  return Boolean(candidate) && (
+    candidate.status === 429
+    || candidate.kind === "rate_limited"
+    || candidate.code === "rate_limited"
+  );
+}
+
+function schedulerError(kind, message, cause = null) {
+  const error = new Error(message);
+  error.name = "UpstreamSchedulerError";
+  error.kind = kind;
+  error.status = kind === "rate_limit_circuit" ? 429 : null;
+  error.cause = cause;
+  return error;
+}
+
+function boundedPositiveInteger(value, fallback, maximum) {
+  return Number.isSafeInteger(value) && value > 0
+    ? Math.min(value, maximum)
+    : fallback;
+}
+
+module.exports = {
+  DEFAULT_UPSTREAM_CONCURRENCY,
+  DEFAULT_UPSTREAM_REQUEST_BUDGET,
+  UpstreamOperationScheduler,
+};

--- a/util/upstreamPresentation.js
+++ b/util/upstreamPresentation.js
@@ -1,0 +1,178 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const MAX_UPSTREAM_URL_LENGTH = 8192;
+const MAX_DISPLAY_TEXT_LENGTH = 500;
+const MAX_ERROR_MESSAGE_LENGTH = 256;
+const CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u;
+const DISPLAY_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/gu;
+const DOT_PATH_SEGMENTS = new Set([".", "..", "%2e", ".%2e", "%2e.", "%2e%2e"]);
+
+const ERROR_COPY = Object.freeze({
+  local: "The local package collection could not be verified.",
+  upstream: "Upstream availability could not be determined.",
+});
+
+const PUBLIC_ERROR_MESSAGES = new Set([
+  "Request failed",
+  "Upstream request failed",
+  "Upstream availability could not be determined.",
+  "The local package collection could not be verified.",
+  "The upstream request was cancelled.",
+  "Cloudsmith could not authorize the upstream request.",
+  "Cloudsmith returned invalid upstream data.",
+  "Cloudsmith upstream data could not be reached.",
+  "Cloudsmith rate limited the upstream request. Try again later.",
+  "The upstream request timed out.",
+]);
+
+const ERROR_KIND_COPY = Object.freeze({
+  cancelled: "The upstream request was cancelled.",
+  forbidden: "Cloudsmith could not authorize the upstream request.",
+  invalid_response: "Cloudsmith returned invalid upstream data.",
+  network: "Cloudsmith upstream data could not be reached.",
+  rate_limited: "Cloudsmith rate limited the upstream request. Try again later.",
+  timeout: "The upstream request timed out.",
+  unauthorized: "Cloudsmith could not authorize the upstream request.",
+});
+
+/**
+ * Converts an upstream-domain failure to bounded public copy. This intentionally
+ * does not serialize unknown objects or expose arbitrary exception messages.
+ */
+function formatUpstreamError(error, context = "upstream") {
+  const fallback = typeof context === "string"
+    && context.length <= 16
+    && Object.prototype.hasOwnProperty.call(ERROR_COPY, context)
+    ? ERROR_COPY[context]
+    : ERROR_COPY.upstream;
+  if (error == null) return fallback;
+
+  try {
+    const kind = typeof error === "object" && typeof error.kind === "string"
+      ? error.kind
+      : null;
+    if (
+      kind
+      && kind.length <= 64
+      && Object.prototype.hasOwnProperty.call(ERROR_KIND_COPY, kind)
+    ) {
+      return ERROR_KIND_COPY[kind];
+    }
+
+    const status = typeof error === "object" ? error.status : null;
+    if (status === 401 || status === 403) return ERROR_KIND_COPY.unauthorized;
+    if (status === 429) return ERROR_KIND_COPY.rate_limited;
+
+    const message = typeof error === "string"
+      ? error
+      : (typeof error === "object" && Object.prototype.hasOwnProperty.call(error, "message")
+          && typeof error.message === "string" ? error.message : null);
+    return message
+      && message.length <= MAX_ERROR_MESSAGE_LENGTH
+      && PUBLIC_ERROR_MESSAGES.has(message)
+      ? message
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Returns an origin-only display string. This is presentation logic, not an
+ * outbound URL validator, and must never be used to authorize network access.
+ */
+function formatUpstreamOrigin(rawUrl) {
+  const parsed = parseDisplayUrl(rawUrl);
+  return parsed ? `${parsed.protocol}//${parsed.host}` : "Origin unavailable";
+}
+
+function formatUpstreamText(value, fallback = "") {
+  if (typeof value !== "string") return fallback;
+  return value.slice(0, MAX_DISPLAY_TEXT_LENGTH)
+    .replace(DISPLAY_CONTROL_OR_BIDI, " ")
+    .replace(/\s+/gu, " ")
+    .trim()
+    || fallback;
+}
+
+function parseDisplayUrl(rawUrl) {
+  if (
+    typeof rawUrl !== "string"
+    || rawUrl.length === 0
+    || rawUrl.length > MAX_UPSTREAM_URL_LENGTH
+    || rawUrl !== rawUrl.trim()
+    || CONTROL_OR_BIDI.test(rawUrl)
+    || rawUrl.includes("\\")
+    || !hasExactHttpAuthority(rawUrl)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Preserves operational path semantics for Terraform only when the raw URL has
+ * no credential, query, fragment, slash-normalization, or control ambiguity.
+ */
+function getTerraformUpstreamUrl(rawUrl) {
+  if (
+    typeof rawUrl !== "string"
+    || rawUrl.length === 0
+    || rawUrl.length > MAX_UPSTREAM_URL_LENGTH
+    || rawUrl !== rawUrl.trim()
+    || CONTROL_OR_BIDI.test(rawUrl)
+    || !(rawUrl.startsWith("https://") || rawUrl.startsWith("http://"))
+    || rawUrl.includes("?")
+    || rawUrl.includes("#")
+    || rawUrl.includes("\\")
+    || authorityContainsUserinfo(rawUrl)
+    || hasDotPathSegment(rawUrl)
+  ) {
+    return null;
+  }
+  const parsed = parseDisplayUrl(rawUrl);
+  if (!parsed || parsed.username || parsed.password || parsed.search || parsed.hash) return null;
+  const pathStart = rawUrl.indexOf("/", rawUrl.indexOf("://") + 3);
+  return pathStart === rawUrl.length - 1 ? rawUrl.slice(0, -1) : rawUrl;
+}
+
+function authorityContainsUserinfo(rawUrl) {
+  const schemeEnd = rawUrl.indexOf("://");
+  if (schemeEnd < 0) return false;
+  const authorityStart = schemeEnd + 3;
+  const pathStart = rawUrl.indexOf("/", authorityStart);
+  const authorityEnd = pathStart < 0 ? rawUrl.length : pathStart;
+  const authority = rawUrl.slice(authorityStart, authorityEnd);
+  return authority.length === 0 || authority.includes("@");
+}
+
+function hasExactHttpAuthority(rawUrl) {
+  if (!(rawUrl.startsWith("https://") || rawUrl.startsWith("http://"))) return false;
+  const authorityStart = rawUrl.indexOf("://") + 3;
+  const pathStart = rawUrl.indexOf("/", authorityStart);
+  const authorityEnd = pathStart < 0 ? rawUrl.length : pathStart;
+  return authorityEnd > authorityStart;
+}
+
+function hasDotPathSegment(rawUrl) {
+  const authorityStart = rawUrl.indexOf("://") + 3;
+  const pathStart = rawUrl.indexOf("/", authorityStart);
+  if (pathStart < 0) return false;
+  return rawUrl.slice(pathStart).split("/").some(segment => (
+    DOT_PATH_SEGMENTS.has(segment.toLowerCase())
+  ));
+}
+
+module.exports = {
+  formatUpstreamError,
+  formatUpstreamOrigin,
+  formatUpstreamText,
+  getTerraformUpstreamUrl,
+};

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -1,10 +1,8 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
-const { apiEndpoint } = require("./apiEndpoint");
 const { CredentialManager } = require("./credentialManager");
-const { formatApiError } = require("./errorFormatter");
-const { PaginatedFetch } = require("./paginatedFetch");
+const { fetchWorkspaceRepositories } = require("./workspaceRepositoryFetcher");
 const {
   buildRegistryTriggerPlan,
   findPythonDistributionUrl,
@@ -17,14 +15,19 @@ const {
 } = require("./registryEndpoints");
 const { canonicalFormat, normalizePackageName } = require("./packageNameNormalizer");
 const { UpstreamChecker } = require("./upstreamChecker");
+const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
 const { normalizeUpstreamFormat } = require("./upstreamFormats");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("./accountOperation");
 
 const MAX_CONCURRENT_PULLS = 5;
 const INITIAL_AUTH_PROBE_CONCURRENCY = 3;
 const MAX_REGISTRY_REDIRECTS = 5;
 const REQUEST_TIMEOUT_MS = 30 * 1000;
 const MAX_REGISTRY_METADATA_BYTES = 1024 * 1024;
-const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
 const SAFE_REGISTRY_ERROR_MESSAGES = new Set([
   "Refused to send Cloudsmith credentials to an untrusted registry host.",
   "Registry metadata response exceeded the size limit.",
@@ -64,6 +67,7 @@ class UpstreamPullService {
     this._showInformationMessage = options.showInformationMessage || vscode.window.showInformationMessage.bind(vscode.window);
     this._showWarningMessage = options.showWarningMessage || vscode.window.showWarningMessage.bind(vscode.window);
     this._upstreamChecker = options.upstreamChecker || new UpstreamChecker(context);
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
   }
 
   async run(options) {
@@ -87,7 +91,12 @@ class UpstreamPullService {
     workspace,
     repositoryHint,
     dependencies,
+    token = null,
+    cancellationToken = null,
+    signal = null,
   }) {
+    const operation = this._createPreparationOperation(cancellationToken || token, signal);
+    if (!this._isPreparationCurrent(operation)) return null;
     const uncoveredDependencies = dedupePullDependencies(
       (Array.isArray(dependencies) ? dependencies : [])
         .filter((dependency) => dependency && isConclusiveCloudsmithAbsence(dependency.cloudsmithStatus))
@@ -116,24 +125,40 @@ class UpstreamPullService {
       return null;
     }
 
-    let repositories;
+    let repositoryCollection;
     try {
-      repositories = await this._fetchRepositories(workspace);
-    } catch (error) {
-      const message = error && error.message ? error.message : "Could not fetch workspace repositories.";
-      await this._showErrorMessage(message);
-      return null;
-    }
-
-    const repositoryMatches = await this._findMatchingRepositories(workspace, repositories, projectFormats);
-    if (repositoryMatches.length === 0) {
-      await this._showInformationMessage(
-        `No repositories have upstream proxies configured for the dependency formats in this project (${formatListLabel(projectFormats)}). Configure an upstream proxy in Cloudsmith to enable pull-through caching.`
+      repositoryCollection = normalizeRepositoryCollection(
+        await this._fetchRepositories(workspace, operation)
       );
+    } catch (error) {
+      if (!this._isPreparationCurrent(operation)) return null;
+      await this._showErrorMessage(repositoryCollectionFailureMessage(error));
+      return null;
+    }
+    if (!this._isPreparationCurrent(operation)) return null;
+
+    const repositorySearch = await this._findMatchingRepositories(
+      workspace,
+      repositoryCollection.items,
+      projectFormats,
+      operation
+    );
+    if (!this._isPreparationCurrent(operation)) return null;
+    if (repositorySearch.matches.length === 0) {
+      const incomplete = !repositoryCollection.complete || !repositorySearch.complete;
+      const message = incomplete
+        ? `Repository upstream inspection was incomplete for ${formatListLabel(projectFormats)}. No matching proxy was found in the repositories that could be inspected.`
+        : `No repositories have upstream proxies configured for the dependency formats in this project (${formatListLabel(projectFormats)}). Configure an upstream proxy in Cloudsmith to enable pull-through caching.`;
+      await (incomplete ? this._showWarningMessage(message) : this._showInformationMessage(message));
       return null;
     }
 
-    const orderedMatches = sortRepositoryMatches(repositoryMatches, repositoryHint);
+    if (!repositoryCollection.complete || !repositorySearch.complete) {
+      await this._showWarningMessage(
+        "Repository upstream inspection was incomplete. Verified matching repositories are shown, but additional matches may exist."
+      );
+    }
+    const orderedMatches = sortRepositoryMatches(repositorySearch.matches, repositoryHint);
     const selected = await this._showQuickPick(
       orderedMatches.map((match) => ({
         label: match.repo.slug || match.repo.name,
@@ -148,7 +173,7 @@ class UpstreamPullService {
       }
     );
 
-    if (!selected || !selected._match) {
+    if (!this._isPreparationCurrent(operation) || !selected || !selected._match) {
       return null;
     }
 
@@ -171,7 +196,7 @@ class UpstreamPullService {
       "Pull dependencies"
     );
 
-    if (confirmation !== "Pull dependencies") {
+    if (!this._isPreparationCurrent(operation) || confirmation !== "Pull dependencies") {
       return null;
     }
 
@@ -179,6 +204,8 @@ class UpstreamPullService {
       workspace,
       repository,
       plan,
+      account: operation.account,
+      repositorySearchComplete: repositoryCollection.complete && repositorySearch.complete,
     };
   }
 
@@ -186,7 +213,12 @@ class UpstreamPullService {
     workspace,
     repositoryHint,
     dependency,
+    token = null,
+    cancellationToken = null,
+    signal = null,
   }) {
+    const operation = this._createPreparationOperation(cancellationToken || token, signal);
+    if (!this._isPreparationCurrent(operation)) return null;
     const normalizedDependency = normalizeSingleDependency(dependency);
     if (!workspace) {
       await this._showErrorMessage("Run a dependency scan against a Cloudsmith workspace first.");
@@ -213,24 +245,40 @@ class UpstreamPullService {
       return null;
     }
 
-    let repositories;
+    let repositoryCollection;
     try {
-      repositories = await this._fetchRepositories(workspace);
-    } catch (error) {
-      const message = error && error.message ? error.message : "Could not fetch workspace repositories.";
-      await this._showErrorMessage(message);
-      return null;
-    }
-
-    const repositoryMatches = await this._findMatchingRepositories(workspace, repositories, [dependencyFormat]);
-    if (repositoryMatches.length === 0) {
-      await this._showInformationMessage(
-        `No repositories have a ${formatDisplayName(dependencyFormat)} upstream configured. Add one in Cloudsmith to pull this dependency.`
+      repositoryCollection = normalizeRepositoryCollection(
+        await this._fetchRepositories(workspace, operation)
       );
+    } catch (error) {
+      if (!this._isPreparationCurrent(operation)) return null;
+      await this._showErrorMessage(repositoryCollectionFailureMessage(error));
+      return null;
+    }
+    if (!this._isPreparationCurrent(operation)) return null;
+
+    const repositorySearch = await this._findMatchingRepositories(
+      workspace,
+      repositoryCollection.items,
+      [dependencyFormat],
+      operation
+    );
+    if (!this._isPreparationCurrent(operation)) return null;
+    if (repositorySearch.matches.length === 0) {
+      const incomplete = !repositoryCollection.complete || !repositorySearch.complete;
+      const message = incomplete
+        ? `Repository upstream inspection was incomplete. No ${formatDisplayName(dependencyFormat)} proxy was found in the repositories that could be inspected.`
+        : `No repositories have a ${formatDisplayName(dependencyFormat)} upstream configured. Add one in Cloudsmith to pull this dependency.`;
+      await (incomplete ? this._showWarningMessage(message) : this._showInformationMessage(message));
       return null;
     }
 
-    const orderedMatches = sortRepositoryMatches(repositoryMatches, repositoryHint);
+    if (!repositoryCollection.complete || !repositorySearch.complete) {
+      await this._showWarningMessage(
+        "Repository upstream inspection was incomplete. Verified matching repositories are shown, but additional matches may exist."
+      );
+    }
+    const orderedMatches = sortRepositoryMatches(repositorySearch.matches, repositoryHint);
     const selected = await this._showQuickPick(
       orderedMatches.map((match) => ({
         label: match.repo.slug || match.repo.name,
@@ -245,7 +293,7 @@ class UpstreamPullService {
       }
     );
 
-    if (!selected || !selected._match) {
+    if (!this._isPreparationCurrent(operation) || !selected || !selected._match) {
       return null;
     }
 
@@ -267,11 +315,28 @@ class UpstreamPullService {
       repository,
       plan,
       dependency: normalizedDependency,
+      account: operation.account,
+      repositorySearchComplete: repositoryCollection.complete && repositorySearch.complete,
     };
   }
 
   async execute(prepared, options = {}) {
-    const apiKey = await this._credentialManager.getApiKey();
+    if (!this._isPreparedAccountCurrent(prepared)) {
+      return { canceled: true, stale: true };
+    }
+    let apiKey;
+    try {
+      apiKey = await this._credentialManager.getApiKey();
+    } catch {
+      if (!this._isPreparedAccountCurrent(prepared)) {
+        return { canceled: true, stale: true };
+      }
+      await this._showErrorMessage("Authentication failed. Check your API key in Cloudsmith settings.");
+      return null;
+    }
+    if (!this._isPreparedAccountCurrent(prepared)) {
+      return { canceled: true, stale: true };
+    }
     if (!apiKey) {
       await this._showErrorMessage("Authentication failed. Check your API key in Cloudsmith settings.");
       return null;
@@ -294,8 +359,10 @@ class UpstreamPullService {
         INITIAL_AUTH_PROBE_CONCURRENCY
       ),
       expandedConcurrency: false,
+      stale: false,
     };
     const pending = new Set();
+    const launchedTasks = [];
     let activeCount = 0;
     let launchedCount = 0;
 
@@ -310,6 +377,11 @@ class UpstreamPullService {
     };
 
     const processNext = async () => {
+      if (!this._isPreparedAccountCurrent(prepared)) {
+        state.canceled = true;
+        state.stale = true;
+        return;
+      }
       if (token && token.isCancellationRequested) {
         state.canceled = true;
         return;
@@ -333,20 +405,40 @@ class UpstreamPullService {
           errorMessage: null,
           requestUrl: buildPullRequestUrl(prepared.workspace, prepared.repository.slug, dependency),
         };
-        if (onStatus) {
-          await onStatus(pullingDetail);
+        await publishStatus(onStatus, pullingDetail);
+        if (!this._isPreparedAccountCurrent(prepared)) {
+          state.canceled = true;
+          state.stale = true;
+          return;
         }
 
-        const result = await this._pullDependency(
-          prepared.workspace,
-          prepared.repository.slug,
-          dependency,
-          apiKey,
-          token
-        );
+        let result;
+        try {
+          result = await this._pullDependency(
+            prepared.workspace,
+            prepared.repository.slug,
+            dependency,
+            apiKey,
+            token,
+            () => this._isPreparedAccountCurrent(prepared)
+          );
+        } catch {
+          result = createPullFailure(
+            dependency,
+            pullingDetail.requestUrl,
+            "The upstream pull failed unexpectedly."
+          );
+        }
+
+        if (!this._isPreparedAccountCurrent(prepared)) {
+          state.canceled = true;
+          state.stale = true;
+          return;
+        }
 
         if (result.canceled) {
           state.canceled = true;
+          state.stale = result.stale === true;
           return;
         }
 
@@ -376,16 +468,20 @@ class UpstreamPullService {
           state.expandedConcurrency = true;
         }
 
-        if (progress) {
-          progress.report({
-            message: buildProgressMessage(counts),
-            increment: counts.total > 0 ? 100 / counts.total : 100,
-          });
-        }
+        publishProgress(progress, {
+          message: buildProgressMessage(counts),
+          increment: counts.total > 0 ? 100 / counts.total : 100,
+        });
 
-        if (onStatus) {
-          await onStatus(result);
-        }
+        await publishStatus(onStatus, result);
+      } catch {
+        const failure = createPullFailure(
+          dependency,
+          buildPullRequestUrl(prepared.workspace, prepared.repository.slug, dependency),
+          "The upstream pull failed unexpectedly."
+        );
+        details.push(failure);
+        updateResultCounts(counts, failure);
       } finally {
         activeCount -= 1;
         fillConcurrency();
@@ -398,12 +494,21 @@ class UpstreamPullService {
         && (state.expandedConcurrency || launchedCount < INITIAL_AUTH_PROBE_CONCURRENCY)
         && nextDependencyIndex < queue.length
         && !(token && token.isCancellationRequested)
+        && this._isPreparedAccountCurrent(prepared)
         && !state.stopForAuthFailure
       ) {
         launchedCount += 1;
         const promise = processNext();
         pending.add(promise);
-        promise.finally(() => pending.delete(promise));
+        launchedTasks.push(promise);
+        promise.then(
+          () => pending.delete(promise),
+          () => pending.delete(promise)
+        );
+      }
+      if (!this._isPreparedAccountCurrent(prepared)) {
+        state.canceled = true;
+        state.stale = true;
       }
     };
 
@@ -411,6 +516,11 @@ class UpstreamPullService {
 
     while (pending.size > 0) {
       await Promise.race([...pending]);
+    }
+    await Promise.allSettled(launchedTasks);
+
+    if (state.stale || !this._isPreparedAccountCurrent(prepared)) {
+      return { canceled: true, stale: true };
     }
 
     if (state.stopForAuthFailure) {
@@ -456,82 +566,138 @@ class UpstreamPullService {
     };
   }
 
-  async _findMatchingRepositories(workspace, repositories, projectFormats) {
+  async _findMatchingRepositories(
+    workspace,
+    repositories,
+    projectFormats,
+    operation
+  ) {
     const matches = [];
+    let complete = true;
+    const scheduler = new UpstreamOperationScheduler();
+    const cancellationToken = operation && operation.cancellationToken;
+    const signal = operation && operation.signal;
+    const cancellationDisposable = cancellationToken
+      && typeof cancellationToken.onCancellationRequested === "function"
+      ? cancellationToken.onCancellationRequested(() => scheduler.cancel())
+      : null;
+    const abortListener = () => scheduler.cancel();
+    if (signal && typeof signal.addEventListener === "function") {
+      signal.addEventListener("abort", abortListener, { once: true });
+    }
 
-    await runPromisePool(repositories, 5, async (repo) => {
-      const repoSlug = repo && repo.slug ? repo.slug : null;
-      if (!repoSlug) {
-        return;
-      }
-
-      const state = await this._upstreamChecker.getRepositoryUpstreamState(workspace, repoSlug);
-      const activeUpstreamsByFormat = new Map();
-      const activeFormats = projectFormats.filter((format) => {
-        const upstreams = state && state.groupedUpstreams instanceof Map
-          ? state.groupedUpstreams.get(format)
-          : [];
-        const activeUpstreams = Array.isArray(upstreams)
-          ? upstreams.filter((upstream) => upstream && upstream.is_active !== false)
-          : [];
-        if (activeUpstreams.length > 0) {
-          activeUpstreamsByFormat.set(format, activeUpstreams);
+    try {
+      await runPromisePool(repositories, 4, async (repo) => {
+        if (!this._isPreparationCurrent(operation) || scheduler.stopped) {
+          complete = false;
+          return false;
+        }
+        const repoSlug = repo && repo.slug ? repo.slug : null;
+        if (!repoSlug) {
+          complete = false;
           return true;
         }
-        return false;
-      });
 
-      if (activeFormats.length === 0) {
-        return;
+        let state;
+        try {
+          const requestOptions = {
+            scheduler,
+            cancellationToken,
+            signal,
+            account: operation.account,
+          };
+          state = typeof this._upstreamChecker.getRepositoryUpstreamStateForFormats === "function"
+            ? await this._upstreamChecker.getRepositoryUpstreamStateForFormats(
+              workspace,
+              repoSlug,
+              projectFormats,
+              requestOptions
+            )
+            : await this._upstreamChecker.getRepositoryUpstreamState(
+              workspace,
+              repoSlug,
+              requestOptions
+            );
+        } catch {
+          complete = false;
+          return this._isPreparationCurrent(operation) && !scheduler.stopped;
+        }
+        if (!isRepositoryInspectionCompleteForFormats(state, projectFormats)) complete = false;
+        const activeUpstreamsByFormat = new Map();
+        const activeFormats = projectFormats.filter((format) => {
+          const upstreams = state && state.groupedUpstreams instanceof Map
+            ? state.groupedUpstreams.get(format)
+            : [];
+          const activeUpstreams = Array.isArray(upstreams)
+            ? upstreams.filter((upstream) => upstream && upstream.is_active !== false)
+            : [];
+          if (activeUpstreams.length > 0) {
+            activeUpstreamsByFormat.set(format, activeUpstreams);
+            return true;
+          }
+          return false;
+        });
+
+        if (activeFormats.length === 0) {
+          return true;
+        }
+
+        matches.push({
+          repo,
+          activeFormats,
+          activeUpstreamsByFormat,
+        });
+        return true;
+      });
+    } finally {
+      if (!this._isPreparationCurrent(operation)) scheduler.cancel();
+      if (cancellationDisposable) cancellationDisposable.dispose();
+      if (signal && typeof signal.removeEventListener === "function") {
+        signal.removeEventListener("abort", abortListener);
       }
+    }
+    if (!this._isPreparationCurrent(operation)) complete = false;
 
-      matches.push({
-        repo,
-        activeFormats,
-        activeUpstreamsByFormat,
-      });
-    });
-
-    return matches.sort((left, right) => {
+    const sortedMatches = matches.sort((left, right) => {
       const leftSlug = String(left.repo.slug || left.repo.name || "");
       const rightSlug = String(right.repo.slug || right.repo.name || "");
       return leftSlug.localeCompare(rightSlug, undefined, { sensitivity: "base" });
     });
+    return { matches: sortedMatches, complete };
   }
 
-  async _fetchWorkspaceRepositories(workspace) {
-    const paginatedFetch = new PaginatedFetch(this._api);
-    const endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
-    const repositories = [];
-    let page = 1;
-
-    while (true) {
-      const result = await paginatedFetch.fetchPage(
-        endpoint,
-        page,
-        WORKSPACE_REPOSITORY_PAGE_SIZE,
-        null,
-        { validate: isRepositoryArray, retry: "never" }
-      );
-      if (result.error) {
-        throw new Error(`Could not fetch workspace repositories. ${formatApiError(result.error)}`);
-      }
-
-      repositories.push(...(Array.isArray(result.data) ? result.data : []));
-
-      const pageTotal = result.pagination && result.pagination.pageTotal
-        ? result.pagination.pageTotal
-        : 1;
-      if (page >= pageTotal) {
-        break;
-      }
-      page += 1;
-    }
-
-    return repositories;
+  async _fetchWorkspaceRepositories(workspace, operation = {}) {
+    return fetchWorkspaceRepositories(this.context, workspace, {
+      cloudsmithAPI: this._api,
+      connectionManager: this._connectionManager,
+      retry: "never",
+      cancellationToken: operation.cancellationToken,
+      signal: operation.signal,
+      account: operation.account,
+    });
   }
 
-  async _pullDependency(workspace, repo, dependency, apiKey, token) {
+  _createPreparationOperation(cancellationToken, signal) {
+    const account = this._connectionManager ? captureAccount(this._connectionManager) : null;
+    return { cancellationToken, signal, account };
+  }
+
+  _isPreparationCurrent(operation) {
+    if (
+      !operation
+      || isCancellationRequested(operation.cancellationToken)
+      || operation.signal?.aborted
+    ) return false;
+    return !this._connectionManager
+      || Boolean(operation.account && isAccountCurrent(this._connectionManager, operation.account));
+  }
+
+  _isPreparedAccountCurrent(prepared) {
+    return !this._connectionManager
+      || Boolean(prepared?.account && isAccountCurrent(this._connectionManager, prepared.account));
+  }
+
+  async _pullDependency(workspace, repo, dependency, apiKey, token, isCurrent = null) {
     const plan = buildRegistryTriggerPlan(workspace, repo, dependency);
     const format = formatForDependency(dependency);
 
@@ -553,7 +719,7 @@ class UpstreamPullService {
       plan.request,
       apiKey,
       token,
-      { captureBody: plan.strategy !== "direct" }
+      { captureBody: plan.strategy !== "direct", isCurrent }
     );
     if (metadataAttempt.canceled) {
       return metadataAttempt;
@@ -599,6 +765,10 @@ class UpstreamPullService {
       };
     }
 
+    if (isCurrent && !isCurrent()) {
+      return { canceled: true, stale: true };
+    }
+
     const artifactAttempt = await this._requestRegistry(
       {
         method: "GET",
@@ -607,7 +777,7 @@ class UpstreamPullService {
       },
       apiKey,
       token,
-      { captureBody: false }
+      { captureBody: false, isCurrent }
     );
 
     if (artifactAttempt.canceled) {
@@ -618,6 +788,10 @@ class UpstreamPullService {
   }
 
   async _requestRegistry(request, apiKey, token, options = {}) {
+    const isCurrent = typeof options.isCurrent === "function" ? options.isCurrent : null;
+    if (isCurrent && !isCurrent()) {
+      return { canceled: true, stale: true };
+    }
     const controller = new AbortController();
     let abortCause = null;
     const abort = (cause) => {
@@ -646,7 +820,8 @@ class UpstreamPullService {
         request,
         apiKey,
         controller.signal,
-        0
+        0,
+        isCurrent
       );
 
       const body = options.captureBody === false
@@ -665,6 +840,9 @@ class UpstreamPullService {
         body,
       };
     } catch (error) {
+      if (isCurrent && !isCurrent()) {
+        return { canceled: true, stale: true };
+      }
       if (abortCause === "cancelled" || (token && token.isCancellationRequested)) {
         return { canceled: true };
       }
@@ -685,9 +863,12 @@ class UpstreamPullService {
     }
   }
 
-  async _fetchRegistryResponse(request, apiKey, signal, redirectCount) {
+  async _fetchRegistryResponse(request, apiKey, signal, redirectCount, isCurrent = null) {
     if (!request || !isTrustedRegistryUrl(request.url)) {
       throw new Error("Refused to send Cloudsmith credentials to an untrusted registry host.");
+    }
+    if (isCurrent && !isCurrent()) {
+      throw new Error("The Cloudsmith account changed during the registry request.");
     }
 
     const fetchResult = await this._awaitRegistryAbortable(this._fetchImpl(request.url, {
@@ -729,6 +910,10 @@ class UpstreamPullService {
 
     await cancelRegistryBody(response);
 
+    if (isCurrent && !isCurrent()) {
+      throw new Error("The Cloudsmith account changed during the registry request.");
+    }
+
     return this._fetchRegistryResponse(
       {
         ...request,
@@ -736,7 +921,8 @@ class UpstreamPullService {
       },
       apiKey,
       signal,
-      redirectCount + 1
+      redirectCount + 1,
+      isCurrent
     );
   }
 
@@ -774,16 +960,24 @@ class UpstreamPullService {
   }
 }
 
-function isRepositoryArray(value) {
-  return Array.isArray(value) && value.every(repository => (
-    repository
-    && typeof repository === "object"
-    && !Array.isArray(repository)
-    && typeof repository.slug === "string"
-    && repository.slug.length > 0
-    && typeof repository.name === "string"
-    && repository.name.length > 0
-  ));
+function normalizeRepositoryCollection(value) {
+  if (!value || typeof value !== "object") return { items: [], complete: false };
+  const items = Array.isArray(value.items) ? value.items : [];
+  return {
+    items,
+    complete: value.complete === true && value.stale !== true,
+  };
+}
+
+function isRepositoryInspectionCompleteForFormats(state, formats) {
+  if (!state || typeof state !== "object") return false;
+  if (state.complete === true) return true;
+  const unavailable = [
+    ...(Array.isArray(state.failedFormats) ? state.failedFormats : []),
+    ...(Array.isArray(state.uninspectedFormats) ? state.uninspectedFormats : []),
+  ];
+  if (unavailable.length === 0) return false;
+  return !(Array.isArray(formats) ? formats : []).some(format => unavailable.includes(format));
 }
 
 function buildRegistryRequestHeaders(headers) {
@@ -1512,12 +1706,57 @@ async function runPromisePool(items, concurrency, worker) {
         if (item === undefined) {
           break;
         }
-        await worker(item);
+        if (await worker(item) === false) break;
       }
     })());
   }
 
-  await Promise.all(workers);
+  await Promise.allSettled(workers);
+}
+
+function isCancellationRequested(token) {
+  return Boolean(token && token.isCancellationRequested);
+}
+
+async function publishStatus(onStatus, detail) {
+  if (!onStatus) return true;
+  try {
+    await onStatus(detail);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function publishProgress(progress, update) {
+  if (!progress || typeof progress.report !== "function") return;
+  try {
+    progress.report(update);
+  } catch {
+    // Progress is observational; a disposed or faulty reporter must not alter pull outcomes.
+  }
+}
+
+function createPullFailure(dependency, requestUrl, errorMessage) {
+  return {
+    dependency,
+    status: PULL_STATUS.ERROR,
+    errorMessage,
+    requestUrl,
+    networkError: false,
+  };
+}
+
+function repositoryCollectionFailureMessage(error) {
+  switch (error && error.kind) {
+    case "rate_limited":
+      return "Cloudsmith rate limited the repository lookup. Try again later.";
+    case "unauthorized":
+    case "forbidden":
+      return "Cloudsmith repository access could not be authorized.";
+    default:
+      return "Could not fetch workspace repositories.";
+  }
 }
 
 module.exports = {

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -403,7 +403,6 @@ class UpstreamPullService {
           dependency,
           status: PULL_STATUS.PULLING,
           errorMessage: null,
-          requestUrl: buildPullRequestUrl(prepared.workspace, prepared.repository.slug, dependency),
         };
         await publishStatus(onStatus, pullingDetail);
         if (!this._isPreparedAccountCurrent(prepared)) {
@@ -425,7 +424,6 @@ class UpstreamPullService {
         } catch {
           result = createPullFailure(
             dependency,
-            pullingDetail.requestUrl,
             "The upstream pull failed unexpectedly."
           );
         }
@@ -442,6 +440,7 @@ class UpstreamPullService {
           return;
         }
 
+        result = toPublicPullDetail(result);
         details.push(result);
         updateResultCounts(counts, result);
 
@@ -477,7 +476,6 @@ class UpstreamPullService {
       } catch {
         const failure = createPullFailure(
           dependency,
-          buildPullRequestUrl(prepared.workspace, prepared.repository.slug, dependency),
           "The upstream pull failed unexpectedly."
         );
         details.push(failure);
@@ -531,7 +529,6 @@ class UpstreamPullService {
           dependency,
           status: PULL_STATUS.AUTH_FAILED,
           errorMessage: "Skipped after repeated authentication failures.",
-          requestUrl: buildPullRequestUrl(prepared.workspace, prepared.repository.slug, dependency),
           networkError: false,
         });
       }
@@ -710,7 +707,6 @@ class UpstreamPullService {
         dependency,
         status: PULL_STATUS.FORMAT_MISMATCH,
         errorMessage,
-        requestUrl: null,
         networkError: false,
       };
     }
@@ -726,19 +722,19 @@ class UpstreamPullService {
     }
 
     if (plan.strategy === "direct") {
-      return mapRegistryAttempt(dependency, metadataAttempt, plan.request.url, format);
+      return mapRegistryAttempt(dependency, metadataAttempt, format);
     }
 
     if (metadataAttempt.statusCode === 401 || metadataAttempt.statusCode === 403) {
-      return mapRegistryAttempt(dependency, metadataAttempt, plan.request.url, format);
+      return mapRegistryAttempt(dependency, metadataAttempt, format);
     }
 
     if (metadataAttempt.statusCode === 404) {
-      return mapRegistryAttempt(dependency, metadataAttempt, plan.request.url, format);
+      return mapRegistryAttempt(dependency, metadataAttempt, format);
     }
 
     if (metadataAttempt.statusCode < 200 || metadataAttempt.statusCode >= 300) {
-      return mapRegistryAttempt(dependency, metadataAttempt, plan.request.url, format);
+      return mapRegistryAttempt(dependency, metadataAttempt, format);
     }
 
     let artifactUrl = null;
@@ -760,7 +756,6 @@ class UpstreamPullService {
         dependency,
         status: PULL_STATUS.NOT_FOUND,
         errorMessage: missingArtifactMessage(plan.strategy, dependency.version),
-        requestUrl: plan.request.url,
         networkError: false,
       };
     }
@@ -784,7 +779,7 @@ class UpstreamPullService {
       return artifactAttempt;
     }
 
-    return mapRegistryAttempt(dependency, artifactAttempt, artifactUrl, format);
+    return mapRegistryAttempt(dependency, artifactAttempt, format);
   }
 
   async _requestRegistry(request, apiKey, token, options = {}) {
@@ -1343,13 +1338,12 @@ function recomputeResultCounts(counts, results) {
   Object.assign(counts, next);
 }
 
-function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
+function mapRegistryAttempt(dependency, attempt, format) {
   if (attempt.statusCode >= 200 && attempt.statusCode < 300) {
     return {
       dependency,
       status: PULL_STATUS.CACHED,
       errorMessage: null,
-      requestUrl,
       networkError: false,
     };
   }
@@ -1359,7 +1353,6 @@ function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
       dependency,
       status: PULL_STATUS.ALREADY_EXISTS,
       errorMessage: null,
-      requestUrl,
       networkError: false,
     };
   }
@@ -1369,7 +1362,6 @@ function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
       dependency,
       status: PULL_STATUS.AUTH_FAILED,
       errorMessage: "Authentication failed.",
-      requestUrl,
       networkError: false,
     };
   }
@@ -1379,7 +1371,6 @@ function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
       dependency,
       status: PULL_STATUS.NOT_FOUND,
       errorMessage: defaultNotFoundMessage(format),
-      requestUrl,
       networkError: false,
     };
   }
@@ -1389,7 +1380,6 @@ function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
       dependency,
       status: PULL_STATUS.ERROR,
       errorMessage: attempt.errorMessage || "Registry request failed.",
-      requestUrl,
       networkError: Boolean(attempt.networkError),
     };
   }
@@ -1398,7 +1388,6 @@ function mapRegistryAttempt(dependency, attempt, requestUrl, format) {
     dependency,
     status: PULL_STATUS.ERROR,
     errorMessage: `Registry request returned HTTP ${attempt.statusCode}.`,
-    requestUrl,
     networkError: false,
   };
 }
@@ -1476,11 +1465,6 @@ function safeHost(url) {
   } catch {
     return "";
   }
-}
-
-function buildPullRequestUrl(workspace, repo, dependency) {
-  const plan = buildRegistryTriggerPlan(workspace, repo, dependency);
-  return plan && plan.request ? plan.request.url : null;
 }
 
 function dedupePullDependencies(dependencies) {
@@ -1737,13 +1721,21 @@ function publishProgress(progress, update) {
   }
 }
 
-function createPullFailure(dependency, requestUrl, errorMessage) {
+function createPullFailure(dependency, errorMessage) {
   return {
     dependency,
     status: PULL_STATUS.ERROR,
     errorMessage,
-    requestUrl,
     networkError: false,
+  };
+}
+
+function toPublicPullDetail(result) {
+  return {
+    dependency: result.dependency,
+    status: result.status,
+    errorMessage: result.errorMessage || null,
+    networkError: result.networkError === true,
   };
 }
 

--- a/util/workspaceFetcher.js
+++ b/util/workspaceFetcher.js
@@ -1,0 +1,107 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const { CloudsmithAPI } = require("./cloudsmithAPI");
+const { apiEndpoint } = require("./apiEndpoint");
+const {
+  PaginatedFetch,
+  collectionFailureResult,
+  replaceCollectionItems,
+} = require("./paginatedFetch");
+const { workspaceCollectionIdentity } = require("./collectionIdentity");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("./accountOperation");
+
+const WORKSPACE_PAGE_SIZE = 500;
+const MAX_WORKSPACE_PAGES = 20;
+const MAX_WORKSPACES = 10000;
+const STALE_WORKSPACE_ACCOUNT_ERROR = Object.freeze({
+  kind: "stale_account",
+  message: "The active Cloudsmith account changed while workspaces were loading.",
+});
+
+function staleResult() {
+  return Object.freeze({
+    ...collectionFailureResult(STALE_WORKSPACE_ACCOUNT_ERROR, { termination: "stale_account" }),
+    stale: true,
+  });
+}
+
+async function fetchWorkspaces(context, options = {}) {
+  const {
+    account: suppliedAccount,
+    cloudsmithAPI: suppliedApi,
+    connectionManager: suppliedManager,
+    paginatedFetch: suppliedPagination,
+    ...requestOptions
+  } = options;
+  const connectionManager = resolveConnectionManager(context, suppliedManager);
+  const account = suppliedAccount || captureAccount(connectionManager);
+  if (!account || !isAccountCurrent(connectionManager, account)) return staleResult();
+
+  const cloudsmithAPI = suppliedApi || new CloudsmithAPI(context);
+  const paginatedFetch = suppliedPagination || new PaginatedFetch(cloudsmithAPI);
+  const endpoint = apiEndpoint(["namespaces"], { query: { sort: "slug" } });
+  const result = await paginatedFetch.fetchCollection(endpoint, {
+    ...requestOptions,
+    pageSize: WORKSPACE_PAGE_SIZE,
+    maxPages: MAX_WORKSPACE_PAGES,
+    maxRequests: MAX_WORKSPACE_PAGES,
+    maxItems: MAX_WORKSPACES,
+    canonicalIdentity: workspaceCollectionIdentity,
+    descriptor: `workspaces:${account.activationId}:${account.accountEpoch}`,
+    validate: isWorkspaceArray,
+  });
+  if (!isAccountCurrent(connectionManager, account)) return staleResult();
+  return Object.freeze({
+    ...replaceCollectionItems(result, sortWorkspaces(result.items)),
+    stale: false,
+  });
+}
+
+function sortWorkspaces(workspaces) {
+  return [...workspaces].sort((left, right) => {
+    const leftName = normalizedWorkspaceName(left);
+    const rightName = normalizedWorkspaceName(right);
+    const byName = leftName.localeCompare(rightName, undefined, { sensitivity: "base" });
+    if (byName !== 0) return byName;
+    return left.slug.localeCompare(right.slug);
+  });
+}
+
+function normalizedWorkspaceName(workspace) {
+  return typeof workspace.name === "string" && workspace.name.length > 0
+    ? workspace.name
+    : workspace.slug;
+}
+
+function isWorkspaceArray(value) {
+  return Array.isArray(value) && value.every(workspace => (
+    workspace
+    && typeof workspace === "object"
+    && !Array.isArray(workspace)
+    && typeof workspace.slug === "string"
+    && workspace.slug.length > 0
+    && workspace.slug.length <= 512
+    && workspace.slug.trim() === workspace.slug
+    && (
+      workspace.name === undefined
+      || (
+        typeof workspace.name === "string"
+        && workspace.name.length <= 512
+      )
+    )
+  ));
+}
+
+module.exports = {
+  MAX_WORKSPACES,
+  MAX_WORKSPACE_PAGES,
+  STALE_WORKSPACE_ACCOUNT_ERROR,
+  WORKSPACE_PAGE_SIZE,
+  fetchWorkspaces,
+  isWorkspaceArray,
+  normalizedWorkspaceName,
+};

--- a/util/workspaceRepositoryFetcher.js
+++ b/util/workspaceRepositoryFetcher.js
@@ -1,8 +1,15 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { formatApiError } = require("./errorFormatter");
-const { PaginatedFetch } = require("./paginatedFetch");
+const {
+  PaginatedFetch,
+  collectionFailureResult,
+  replaceCollectionItems,
+} = require("./paginatedFetch");
+const { repositoryCollectionIdentity } = require("./collectionIdentity");
 const {
   captureAccount,
   isAccountCurrent,
@@ -11,30 +18,26 @@ const {
 
 const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
 const MAX_WORKSPACE_REPOSITORY_PAGES = 20;
-const UNEXPECTED_RESPONSE_FORMAT_ERROR = "Unexpected repository response format";
+const MAX_WORKSPACE_REPOSITORIES = 10000;
 const STALE_ACCOUNT_ERROR = Object.freeze({
   kind: "stale_account",
   message: "The active Cloudsmith account changed while repositories were loading.",
 });
 
 function staleResult() {
-  return {
-    repositories: [],
-    error: STALE_ACCOUNT_ERROR,
-    warning: null,
-    partial: false,
+  return Object.freeze({
+    ...collectionFailureResult(STALE_ACCOUNT_ERROR, { termination: "stale_account" }),
     stale: true,
-  };
+  });
 }
 
 function sortRepositories(repositories) {
   return [...repositories].sort((left, right) => {
     const leftName = typeof left.name === "string" ? left.name : "";
     const rightName = typeof right.name === "string" ? right.name : "";
-
-    return leftName.localeCompare(rightName, undefined, {
-      sensitivity: "base",
-    });
+    const byName = leftName.localeCompare(rightName, undefined, { sensitivity: "base" });
+    if (byName !== 0) return byName;
+    return left.slug.localeCompare(right.slug);
   });
 }
 
@@ -50,143 +53,51 @@ async function fetchWorkspaceRepositories(context, workspace, options = {}) {
   const connectionManager = resolveConnectionManager(context, suppliedManager);
   const account = suppliedAccount || captureAccount(connectionManager);
   if (!account || !isAccountCurrent(connectionManager, account)) return staleResult();
-  const cloudsmithAPI = suppliedApi || new CloudsmithAPI(context);
-  const paginatedFetch = suppliedPagination || new PaginatedFetch(cloudsmithAPI);
+
   let endpoint;
   try {
     endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
   } catch {
-    return {
-      repositories: [],
-      error: Object.freeze({ kind: "invalid_request", message: "The workspace identifier is invalid." }),
-      warning: null,
-      partial: false,
+    return Object.freeze({
+      ...collectionFailureResult(
+        Object.freeze({ kind: "invalid_request", message: "The workspace identifier is invalid." }),
+        { termination: "invalid_request" }
+      ),
       stale: false,
-    };
+    });
   }
 
+  const cloudsmithAPI = suppliedApi || new CloudsmithAPI(context);
+  const paginatedFetch = suppliedPagination || new PaginatedFetch(cloudsmithAPI);
   return withProgress(
     {
       location: vscode.ProgressLocation.Window,
       title: `Loading repositories for ${workspace}...`,
+      cancellable: true,
     },
-    async progress => {
+    async (_progress, progressToken) => {
       if (!isAccountCurrent(connectionManager, account)) return staleResult();
-      const repositories = [];
-      let page = 1;
-      let knownPageTotal = null;
-
-      while (true) {
-        if (!isAccountCurrent(connectionManager, account)) return staleResult();
-        progress.report({
-          message: knownPageTotal ? `Page ${page} of ${knownPageTotal}` : `Page ${page}`,
-        });
-
-        const result = await paginatedFetch.fetchPage(
-          endpoint,
-          page,
-          WORKSPACE_REPOSITORY_PAGE_SIZE,
-          null,
-          { ...requestOptions, validate: isRepositoryArray }
+      const result = await paginatedFetch.fetchCollection(endpoint, {
+        ...requestOptions,
+        pageSize: WORKSPACE_REPOSITORY_PAGE_SIZE,
+        maxPages: MAX_WORKSPACE_REPOSITORY_PAGES,
+        maxRequests: MAX_WORKSPACE_REPOSITORY_PAGES,
+        maxItems: MAX_WORKSPACE_REPOSITORIES,
+        canonicalIdentity: repository => repositoryCollectionIdentity(workspace, repository),
+        descriptor: `workspace-repositories:${account.activationId}:${account.accountEpoch}:${workspace}`,
+        validate: isRepositoryArray,
+        cancellationToken: requestOptions.cancellationToken || progressToken,
+      });
+      if (!isAccountCurrent(connectionManager, account)) return staleResult();
+      if (result.partial && result.failures.length > 0) {
+        console.warn(
+          `[WorkspaceRepositories] Repository enumeration is incomplete: ${formatApiError(result.failures[0].error)}`
         );
-        if (!isAccountCurrent(connectionManager, account)) return staleResult();
-
-        if (result.error) {
-          if (page === 1) {
-            return {
-              repositories: [],
-              error: result.error,
-              warning: null,
-              partial: false,
-              stale: false,
-            };
-          }
-
-          console.warn(
-            `[WorkspaceRepositories] Failed to load an additional repository page: ${formatApiError(result.error)}`
-          );
-
-          return {
-            repositories: sortRepositories(repositories),
-            error: null,
-            warning: result.error,
-            partial: true,
-            stale: false,
-          };
-        }
-
-        if (!Array.isArray(result.data)) {
-          if (page === 1) {
-            return {
-              repositories: [],
-              error: UNEXPECTED_RESPONSE_FORMAT_ERROR,
-              warning: null,
-              partial: false,
-              stale: false,
-            };
-          }
-
-          console.warn(
-            `[WorkspaceRepositories] Failed to load additional repositories for ${workspace} on page ${page}: ${UNEXPECTED_RESPONSE_FORMAT_ERROR}`
-          );
-
-          return {
-            repositories: sortRepositories(repositories),
-            error: null,
-            warning: UNEXPECTED_RESPONSE_FORMAT_ERROR,
-            partial: true,
-            stale: false,
-          };
-        }
-
-        const pageData = result.data;
-        const currentPage = result.pagination?.page || page;
-        const pageTotal = result.pagination?.pageTotal || currentPage;
-        const actualPageSize = result.pagination?.pageSize || WORKSPACE_REPOSITORY_PAGE_SIZE;
-
-        knownPageTotal = pageTotal;
-        repositories.push(...pageData);
-
-        if (currentPage >= pageTotal) {
-          break;
-        }
-
-        if (pageData.length < actualPageSize) {
-          return {
-            repositories: sortRepositories(repositories),
-            error: null,
-            warning: Object.freeze({
-              kind: "pagination_incomplete",
-              message: "Repository pagination ended before the authoritative final page.",
-            }),
-            partial: true,
-            stale: false,
-          };
-        }
-
-        if (page >= MAX_WORKSPACE_REPOSITORY_PAGES) {
-          return {
-            repositories: sortRepositories(repositories),
-            error: null,
-            warning: Object.freeze({
-              kind: "pagination_limit",
-              message: "Repository enumeration exceeded the safe page limit.",
-            }),
-            partial: true,
-            stale: false,
-          };
-        }
-
-        page += 1;
       }
-
-      return {
-        repositories: sortRepositories(repositories),
-        error: null,
-        warning: null,
-        partial: false,
+      return Object.freeze({
+        ...replaceCollectionItems(result, sortRepositories(result.items)),
         stale: false,
-      };
+      });
     }
   );
 }
@@ -198,15 +109,18 @@ function isRepositoryArray(value) {
     && !Array.isArray(repository)
     && typeof repository.slug === "string"
     && repository.slug.length > 0
+    && repository.slug.length <= 512
+    && repository.slug.trim() === repository.slug
     && typeof repository.name === "string"
     && repository.name.length > 0
+    && repository.name.length <= 512
   ));
 }
 
 module.exports = {
-  UNEXPECTED_RESPONSE_FORMAT_ERROR,
-  STALE_ACCOUNT_ERROR,
+  MAX_WORKSPACE_REPOSITORIES,
   MAX_WORKSPACE_REPOSITORY_PAGES,
+  STALE_ACCOUNT_ERROR,
   WORKSPACE_REPOSITORY_PAGE_SIZE,
   fetchWorkspaceRepositories,
 };

--- a/views/cloudsmithProvider.js
+++ b/views/cloudsmithProvider.js
@@ -14,6 +14,7 @@ const InfoNode = require("../models/infoNode");
 const { WorkspaceInfoNode } = require("../models/workspaceInfoNode");
 const WorkspaceNode = require("../models/workspaceNode");
 const RepositoryNode = require("../models/repositoryNode");
+const workspaceFetcher = require("../util/workspaceFetcher");
 const workspaceRepositoryFetcher = require("../util/workspaceRepositoryFetcher");
 const { getWorkspaceContextProjector } = require("../util/workspaceContextProjector");
 
@@ -27,8 +28,14 @@ class CloudsmithProvider {
       || (() => new CloudsmithAPI(this.context));
     this._fetchWorkspaceRepositories = options.fetchWorkspaceRepositories
       || workspaceRepositoryFetcher.fetchWorkspaceRepositories;
+    this._fetchWorkspaces = options.fetchWorkspaces || workspaceFetcher.fetchWorkspaces;
     this._workspaceContextProjector = options.workspaceContextProjector
       || getWorkspaceContextProjector(context);
+    this._repositoryNodeOptions = Object.freeze({
+      createPaginatedFetch: options.createPaginatedFetch,
+      upstreamChecker: options.upstreamChecker,
+      withProgress: options.withProgress,
+    });
     this._onDidChangeTreeData = new vscode.EventEmitter();
     this.onDidChangeTreeData = this._onDidChangeTreeData.event;
     this._defaultWorkspaceFallbackHandler = null;
@@ -36,6 +43,8 @@ class CloudsmithProvider {
     this._suppressMissingCredentialsWarningOnce = false;
     this._operationId = 0;
     this._loadingOperationId = null;
+    this._operationController = null;
+    this._repositoryNodes = new Set();
   }
 
   getTreeItem(element) {
@@ -60,12 +69,18 @@ class CloudsmithProvider {
     if (options.suppressMissingCredentialsWarning) {
       this._suppressMissingCredentialsWarningOnce = true;
     }
+    this._invalidateRepositoryNodes();
+    this._abortActiveOperation();
     this._operationId += 1;
-    void this._projectMultipleWorkspaces(false).catch(() => {});
+    void this._projectMultipleWorkspaces(
+      Boolean(captureAccount(this._connectionManager))
+    ).catch(() => {});
     this._onDidChangeTreeData.fire();
   }
 
   dispose() {
+    this._invalidateRepositoryNodes();
+    this._abortActiveOperation();
     this._operationId += 1;
     this._workspaceCache.clear();
     this._onDidChangeTreeData.dispose();
@@ -78,11 +93,17 @@ class CloudsmithProvider {
   }
 
   _beginOperation() {
+    this._invalidateRepositoryNodes();
+    this._abortActiveOperation();
     const account = captureAccount(this._connectionManager);
     if (!account) return null;
+    const controller = new AbortController();
+    this._operationController = controller;
     const operation = {
       id: ++this._operationId,
       account,
+      controller,
+      signal: controller.signal,
     };
     operation.projection = this._workspaceContextProjector.begin({
       isCurrent: () => this._isOperationCurrent(operation),
@@ -94,8 +115,14 @@ class CloudsmithProvider {
     return Boolean(
       operation
       && operation.id === this._operationId
+      && operation.signal.aborted === false
       && isAccountCurrent(this._connectionManager, operation.account)
     );
+  }
+
+  _abortActiveOperation() {
+    this._operationController?.abort();
+    this._operationController = null;
   }
 
   _signedOutNode() {
@@ -135,12 +162,40 @@ class CloudsmithProvider {
     });
   }
 
-  _createWorkspaceNodes(workspaces) {
+  _createWorkspaceNodes(workspaces, signal = null) {
     return workspaces.map(workspace => new WorkspaceNode(workspace, this.context, {
       connectionManager: this._connectionManager,
       createCloudsmithAPI: this._createCloudsmithAPI,
       fetchWorkspaceRepositories: this._fetchWorkspaceRepositories,
+      signal,
+      createRepositoryNode: (repository, workspaceSlug) => (
+        this._createRepositoryNode(repository, workspaceSlug)
+      ),
     }));
+  }
+
+  _createRepositoryNode(repository, workspaceSlug) {
+    const node = new RepositoryNode(repository, workspaceSlug, this.context, {
+      connectionManager: this._connectionManager,
+      createCloudsmithAPI: this._createCloudsmithAPI,
+      requestRefresh: element => this.refreshNode(element),
+      ...this._repositoryNodeOptions,
+    });
+    this._repositoryNodes.add(node);
+    return node;
+  }
+
+  _invalidateRepositoryNodes() {
+    for (const node of this._repositoryNodes) {
+      node.invalidate();
+    }
+    this._repositoryNodes.clear();
+  }
+
+  refreshNode(element) {
+    if (element && this._repositoryNodes.has(element)) {
+      this._onDidChangeTreeData.fire(element);
+    }
   }
 
   setDefaultWorkspaceFallbackHandler(handler) {
@@ -167,45 +222,36 @@ class CloudsmithProvider {
         if (!this._isOperationCurrent(operation)) return [];
         await this._projectMultipleWorkspaces(cached.length > 1, operation);
         if (!this._isOperationCurrent(operation)) return [];
-        return this._createWorkspaceNodes(cached);
+        return this._createWorkspaceNodes(cached, operation.signal);
       }
 
-      const result = await this._createCloudsmithAPI().get("namespaces/?sort=slug", {
-        responseType: "array",
-        validate: value => Array.isArray(value) && value.every(workspace => (
-          workspace
-          && typeof workspace === "object"
-          && !Array.isArray(workspace)
-          && typeof workspace.slug === "string"
-          && workspace.slug.length > 0
-        )),
-        retry: "safe-read",
+      await this._projectMultipleWorkspaces(true, operation);
+      if (!this._isOperationCurrent(operation)) return [];
+
+      const result = await this._fetchWorkspaces(this.context, {
+        account: operation.account,
+        connectionManager: this._connectionManager,
+        cloudsmithAPI: this._createCloudsmithAPI(),
+        signal: operation.signal,
       });
+      if (!this._isOperationCurrent(operation) || result.stale) return [];
+      if (!Array.isArray(result.items)) throw new TypeError("Invalid workspace collection.");
+      const workspaces = result.items.map(workspace => ({
+        slug: workspace.slug,
+        name: workspaceFetcher.normalizedWorkspaceName(workspace),
+      }));
+      const incomplete = result.complete !== true;
+      await this._projectMultipleWorkspaces(incomplete || workspaces.length > 1, operation);
       if (!this._isOperationCurrent(operation)) return [];
+      if (result.complete) this._workspaceCache.set(workspaces, operation.account);
 
-      const workspaces = result.ok
-        ? result.data.map(workspace => ({
-          slug: workspace.slug,
-          name: typeof workspace.name === "string" && workspace.name.length > 0
-            ? workspace.name
-            : workspace.slug,
-        }))
-        : null;
-
-      if (!workspaces) {
-        await this._projectMultipleWorkspaces(false, operation);
-        if (!this._isOperationCurrent(operation)) return [];
-        return [this._loadFailureNode("workspaces")];
-      }
-      await this._projectMultipleWorkspaces(workspaces.length > 1, operation);
-      if (!this._isOperationCurrent(operation)) return [];
-      this._workspaceCache.set(workspaces, operation.account);
-
-      return this._createWorkspaceNodes(workspaces);
+      const nodes = this._createWorkspaceNodes(workspaces, operation.signal);
+      if (incomplete) nodes.push(this._incompleteCollectionNode("workspaces", result));
+      return nodes;
     } catch {
       if (!this._isOperationCurrent(operation)) return [];
       try {
-        await this._projectMultipleWorkspaces(false, operation);
+        await this._projectMultipleWorkspaces(true, operation);
       } catch {
         // Loading cleanup and the fixed failure node remain authoritative.
       }
@@ -237,27 +283,48 @@ class CloudsmithProvider {
       const result = await this._fetchWorkspaceRepositories(this.context, workspaceSlug, {
         account: operation.account,
         connectionManager: this._connectionManager,
+        signal: operation.signal,
       });
       if (!this._isOperationCurrent(operation) || result.stale) return [];
 
-      if (result.error) {
+      if (!Array.isArray(result.items)) {
+        return [this._loadFailureNode("repositories")];
+      }
+      if (result.cancelled === true) {
+        if (result.items.length === 0) {
+          return [new InfoNode(
+            "Repository loading cancelled",
+            "No workspace fallback or quota request was started",
+            "Refresh the view to try loading the repository collection again.",
+            "warning"
+          )];
+        }
+        const cancelledNodes = [new WorkspaceInfoNode(workspaceSlug, null)];
+        for (const repo of result.items) {
+          cancelledNodes.push(this._createRepositoryNode(repo, workspaceSlug));
+        }
+        cancelledNodes.push(this._incompleteCollectionNode("repositories", result));
+        return cancelledNodes;
+      }
+      if (result.complete !== true && result.items.length === 0) {
         if (this._defaultWorkspaceFallbackHandler) {
           this._defaultWorkspaceFallbackHandler(workspaceSlug);
         } else {
           vscode.window.showWarningMessage(
-            `Could not access workspace "${workspaceSlug}". Showing all workspaces.`
+            `Could not verify the repository list for workspace "${workspaceSlug}". Showing all workspaces.`
           );
         }
         // Fall back to full workspace tree
         return this.getWorkspaces();
       }
 
-      const repos = result.repositories;
+      const repos = result.items;
       let quotaData = null;
       try {
         const quotaResult = await this._createCloudsmithAPI().get(apiEndpoint(["quota", workspaceSlug]), {
           responseType: "object",
           retry: "safe-read",
+          signal: operation.signal,
         });
         if (quotaResult.ok && quotaResult.data.usage && typeof quotaResult.data.usage === "object") {
           quotaData = quotaResult.data;
@@ -272,10 +339,10 @@ class CloudsmithProvider {
       ];
       for (const repo of repos) {
         // Pass workspaceSlug as the workspace parameter so downstream calls work
-        RepositoryNodes.push(new RepositoryNode(repo, workspaceSlug, this.context, {
-          connectionManager: this._connectionManager,
-          createCloudsmithAPI: this._createCloudsmithAPI,
-        }));
+        RepositoryNodes.push(this._createRepositoryNode(repo, workspaceSlug));
+      }
+      if (result.complete !== true) {
+        RepositoryNodes.push(this._incompleteCollectionNode("repositories", result));
       }
       return RepositoryNodes;
     } catch {
@@ -285,6 +352,19 @@ class CloudsmithProvider {
     } finally {
       this._finishLoading(operation);
     }
+  }
+
+  _incompleteCollectionNode(kind, result) {
+    const loaded = Array.isArray(result?.items) ? result.items.length : 0;
+    const failure = result?.failures?.[0]?.error;
+    return new InfoNode(
+      loaded > 0
+        ? `${kind[0].toUpperCase()}${kind.slice(1)} are incomplete`
+        : `Could not load ${kind}`,
+      loaded > 0 ? `${loaded.toLocaleString()} loaded` : "Check the connection and credentials",
+      failure?.message || "A safe collection limit was reached before completeness was proven.",
+      "warning"
+    );
   }
 }
 

--- a/views/complianceReportProvider.js
+++ b/views/complianceReportProvider.js
@@ -66,8 +66,24 @@ class ComplianceReportProvider {
       sections.push(renderUncoveredSection(reportData.uncoveredDeps || []));
     }
 
+    const incompleteCount = [
+      summary.unresolved,
+      summary.lookupFailed,
+      summary.lookupIncomplete,
+      summary.rateLimited,
+      summary.checking,
+    ].reduce((total, value) => (
+      Number.isSafeInteger(value) && value > 0 ? total + value : total
+    ), 0);
     const emptyState = sections.length === 0
-      ? `
+      ? incompleteCount > 0
+        ? `
+        <div class="card empty-card">
+          <h2>Compliance status incomplete</h2>
+          <p>${escapeHtml(String(incompleteCount))} dependency lookups were unresolved, failed, incomplete, rate limited, or still in progress. No clean compliance conclusion can be made.</p>
+        </div>
+      `
+        : `
         <div class="card empty-card">
           <h2>No compliance issues detected</h2>
           <p>All scanned dependencies were covered by Cloudsmith and no report sections were triggered for this scan.</p>
@@ -434,19 +450,23 @@ function renderEcosystemSection(ecosystemBreakdown) {
 function renderVulnerabilitySection(vulnerableDeps) {
   const rows = vulnerableDeps.map((dependency) => {
     const severityClass = severityClassName(dependency.maxSeverity);
+    const vulnerabilityEvidence = Number.isSafeInteger(dependency.cveCount)
+      && dependency.cveCount >= 0
+      ? String(dependency.cveCount)
+      : boundedVulnerabilityStatus(dependency.vulnerabilityStatus);
     return `
       <tr>
         <td>${escapeHtml(dependency.name)}</td>
         <td>${escapeHtml(displayValue(dependency.version))}</td>
         <td>${escapeHtml(dependency.isDirect ? "Direct" : "Transitive")}</td>
         <td><span class="badge ${severityClass}">${escapeHtml(dependency.maxSeverity || "Unknown")}</span></td>
-        <td>${escapeHtml(String(dependency.cveCount || 0))}</td>
+        <td>${escapeHtml(vulnerabilityEvidence)}</td>
         <td>${escapeHtml(dependency.hasFixAvailable ? "Yes" : "No")}</td>
       </tr>
     `;
   }).join("");
 
-  return renderSection("Vulnerable Dependencies", `
+  return renderSection("Vulnerability Findings", `
     <table>
       <thead>
         <tr>
@@ -454,13 +474,17 @@ function renderVulnerabilitySection(vulnerableDeps) {
           <th>Version</th>
           <th>Type</th>
           <th>Severity</th>
-          <th>CVE Count</th>
+          <th>CVE Count / Status</th>
           <th>Fix Available</th>
         </tr>
       </thead>
       <tbody>${rows}</tbody>
     </table>
   `);
+}
+
+function boundedVulnerabilityStatus(value) {
+  return value === "Detected" ? "Detected" : "Unknown";
 }
 
 function renderLicenseSection(restrictiveLicenseDeps) {
@@ -515,7 +539,14 @@ function renderPolicySection(policyViolationDeps) {
 
 function renderUncoveredSection(uncoveredDeps) {
   const reachable = uncoveredDeps.filter((dependency) => dependency.upstreamStatus === "reachable");
-  const notReachable = uncoveredDeps.filter((dependency) => dependency.upstreamStatus !== "reachable");
+  const notReachable = uncoveredDeps.filter((dependency) => (
+    dependency.upstreamStatus === "no_proxy" || dependency.upstreamStatus === "unreachable"
+  ));
+  const unknown = uncoveredDeps.filter((dependency) => (
+    dependency.upstreamStatus !== "reachable"
+    && dependency.upstreamStatus !== "no_proxy"
+    && dependency.upstreamStatus !== "unreachable"
+  ));
   const groups = [];
 
   if (reachable.length > 0) {
@@ -574,6 +605,34 @@ function renderUncoveredSection(uncoveredDeps) {
     `);
   }
 
+  if (unknown.length > 0) {
+    groups.push(`
+      <div class="section-group">
+        <h3>Reachability unknown</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Package</th>
+              <th>Version</th>
+              <th>Ecosystem</th>
+              <th>Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${unknown.map((dependency) => `
+              <tr>
+                <td>${escapeHtml(dependency.name)}</td>
+                <td>${escapeHtml(displayValue(dependency.version))}</td>
+                <td>${escapeHtml(displayValue(dependency.ecosystem))}</td>
+                <td>${escapeHtml(displayValue(dependency.upstreamDetail))}</td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      </div>
+    `);
+  }
+
   return renderSection("Uncovered Dependencies", groups.join(""));
 }
 
@@ -602,6 +661,9 @@ function formatSeverityBreakdown(summary) {
   }
   if (summary.lowCount) {
     parts.push(`${summary.lowCount} Low`);
+  }
+  if (summary.vulnUnknownCount) {
+    parts.push(`${summary.vulnUnknownCount} Unknown`);
   }
   return parts.length > 0 ? parts.join(", ") : "No known vulnerabilities";
 }

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -15,7 +15,7 @@ const {
   MAX_DIAGNOSTIC_OCCURRENCES,
   createDiagnosticCandidate,
 } = require("../util/diagnosticsPublisher");
-const { PaginatedFetch } = require("../util/paginatedFetch");
+const { fetchWorkspaceRepositories } = require("../util/workspaceRepositoryFetcher");
 const { SearchQueryBuilder } = require("../util/searchQueryBuilder");
 const { LicenseClassifier } = require("../util/licenseClassifier");
 const {
@@ -28,6 +28,10 @@ const {
 const {
   enrichVulnerabilities,
 } = require("../util/dependencyVulnEnricher");
+const {
+  getPackagePolicyFlags,
+  getPackageVulnerabilityState,
+} = require("../util/packageVulnerabilities");
 const { enrichLicenses } = require("../util/dependencyLicenseEnricher");
 const { getFoundDependencyKey } = require("../util/foundDependencyKey");
 const { enrichPolicies } = require("../util/dependencyPolicyEnricher");
@@ -45,13 +49,16 @@ const DependencySourceGroupNode = require("../models/dependencySourceGroupNode")
 const DependencySummaryNode = require("../models/dependencySummaryNode");
 const InfoNode = require("../models/infoNode");
 const { getConnectionManager } = require("../util/connectionManager");
+const { packageCollectionIdentity } = require("../util/collectionIdentity");
 
 const DEFAULT_MAX_DEPENDENCIES_TO_SCAN = 10000;
 const LOOKUP_PAGE_SIZE = 100;
 const LOOKUP_MAX_PAGES = 100;
 const LOOKUP_CONCURRENCY = 8;
 const LOOKUP_MAX_REQUESTS_PER_RESOLUTION = 2000;
-const WORKSPACE_REPOSITORY_PAGE_SIZE = 500;
+const LOOKUP_MAX_PACKAGE_NAME_LENGTH = 2048;
+const LOOKUP_MAX_PACKAGE_FORMAT_LENGTH = 100;
+const LOOKUP_MAX_PACKAGE_VERSION_LENGTH = 2048;
 const COVERAGE_MATCH_BATCH_SIZE = 50;
 const ENRICHMENT_PROGRESS_DEBOUNCE_MS = 500;
 
@@ -1060,14 +1067,23 @@ class DependencyHealthProvider {
           return;
         }
 
-        const result = await lookupExactDependency({
-          api,
-          cloudsmithWorkspace,
-          cloudsmithRepo,
-          dependency,
-          token,
-          requestBudget,
-        });
+        let result;
+        try {
+          result = await lookupExactDependency({
+            api,
+            cloudsmithWorkspace,
+            cloudsmithRepo,
+            dependency,
+            token,
+            requestBudget,
+          });
+        } catch {
+          result = createCoverageLookupResult(
+            CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
+            null,
+            "The Cloudsmith lookup failed unexpectedly without proving package absence."
+          );
+        }
         statusCounts.set(result.status, (statusCounts.get(result.status) || 0) + 1);
         pendingMatches.push({ dependency, result });
       });
@@ -1108,10 +1124,10 @@ class DependencyHealthProvider {
         continue;
       }
 
-      const message = result.reason && result.reason.message
-        ? result.reason.message
-        : String(result.reason || "An enrichment step failed.");
-      this._warnings.push(message);
+      appendUniqueWarning(
+        this._warnings,
+        boundedFailureMessage(result.reason, "An enrichment step failed.")
+      );
     }
   }
 
@@ -1194,11 +1210,18 @@ class DependencyHealthProvider {
   }
 
   async _runUpstreamGapAnalysis(uncoveredDependencies, workspace, repo, progress, token) {
-    const repositories = repo
-      ? [repo]
+    const repositoryCollection = repo
+      ? { items: [repo], complete: true, incomplete: false, partial: false }
       : await (this._services.fetchRepositories
         ? this._services.fetchRepositories(workspace, token)
         : this._fetchWorkspaceRepositories(workspace, token));
+    const normalizedRepositories = normalizeRepositoryCollection(repositoryCollection);
+    if (!normalizedRepositories.complete) {
+      appendUniqueWarning(
+        this._warnings,
+        "Repository enumeration for upstream analysis was incomplete. Positive proxy matches are retained, but missing proxy coverage is shown as unknown."
+      );
+    }
 
     const handler = this._createDebouncedEnrichmentHandler((patchMap) => {
       this._fullTrees = applyUncoveredOverlayPatch(this._fullTrees, patchMap, (dependency, gap) => ({
@@ -1218,9 +1241,14 @@ class DependencyHealthProvider {
         ...dependency,
         cloudsmithStatus: "NOT_FOUND",
       }));
-      await this._services.analyzeUpstreamGaps(legacyCompatibleDependencies, workspace, repositories, {
+      await this._services.analyzeUpstreamGaps(
+        legacyCompatibleDependencies,
+        workspace,
+        normalizedRepositories.items,
+        {
         context: this.context,
         cancellationToken: token,
+        repositoriesComplete: normalizedRepositories.complete,
         onProgress: (patchMap, meta = {}) => {
           if (meta.total > 0) {
             progress.report({
@@ -1229,54 +1257,27 @@ class DependencyHealthProvider {
           }
           handler.onProgress(patchMap);
         },
-      });
+        }
+      );
     } finally {
       handler.flush();
     }
   }
 
   async _fetchWorkspaceRepositories(workspace, token) {
-    const api = new CloudsmithAPI(this.context);
-    const paginatedFetch = new PaginatedFetch(api);
-    let endpoint;
-    try {
-      endpoint = apiEndpoint(["repos", workspace], { query: { sort: "name" } });
-    } catch {
-      this._warnings.push("Could not load repositories for upstream analysis. The workspace identifier was invalid.");
-      return [];
-    }
-    const repositories = [];
-    let page = 1;
-
-    while (!token || !token.isCancellationRequested) {
-      const result = await paginatedFetch.fetchPage(
-        endpoint,
-        page,
-        WORKSPACE_REPOSITORY_PAGE_SIZE,
-        null,
-        { cancellationToken: token, retry: "never", validate: isRepositoryPageArray }
-      );
-      if (result.error) {
-        this._warnings.push(`Could not load repositories for upstream analysis. ${result.error.message}`);
-        break;
-      }
-
-      for (const repository of Array.isArray(result.data) ? result.data : []) {
-        if (repository && repository.slug) {
-          repositories.push(repository.slug);
-        }
-      }
-
-      const pageTotal = result.pagination && result.pagination.pageTotal
-        ? result.pagination.pageTotal
-        : 1;
-      if (page >= pageTotal) {
-        break;
-      }
-      page += 1;
-    }
-
-    return [...new Set(repositories)];
+    const result = await fetchWorkspaceRepositories(this.context, workspace, {
+      connectionManager: this._connectionManager,
+      cloudsmithAPI: this._services.createCloudsmithAPI(),
+      cancellationToken: token,
+      retry: "never",
+      withProgress: async (_options, task) => task({ report() {} }),
+    });
+    const items = Array.isArray(result?.items) ? result.items : [];
+    return {
+      ...result,
+      items: [...new Set(items.map(repository => repository?.slug).filter(Boolean))],
+      complete: result?.complete === true,
+    };
   }
 
   async _publishDiagnostics(cancellationToken) {
@@ -1487,30 +1488,38 @@ class DependencyHealthProvider {
     }
 
     this._dependencyOperationRunning = true;
-    let cancellationSource = null;
+    const cancellationSource = new vscode.CancellationTokenSource();
+    this._activeDependencyCancellation = cancellationSource;
+    let prepared = null;
 
     try {
       await this._updateContexts();
-      const prepared = await this._services.upstreamPullService.prepareSingle({
-        workspace: this.lastWorkspace,
-        repositoryHint: this.lastRepo,
-        dependency,
-      });
-      if (!prepared || !this._isAccountCurrent(accountEpoch)) {
-        return;
-      }
-
-      cancellationSource = new vscode.CancellationTokenSource();
-      this._activeDependencyCancellation = cancellationSource;
       const result = await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: `Pulling ${formatSingleDependencyLabel(prepared.dependency)} through ${prepared.repository.slug}...`,
+          title: `Preparing upstream pull for ${formatSingleDependencyLabel(dependency)}...`,
           cancellable: true,
         },
         async (progress, token) => {
           const subscription = token.onCancellationRequested(() => cancellationSource.cancel());
           try {
+            progress.report({ message: "Inspecting repository upstreams..." });
+            prepared = await this._services.upstreamPullService.prepareSingle({
+              workspace: this.lastWorkspace,
+              repositoryHint: this.lastRepo,
+              dependency,
+              cancellationToken: cancellationSource.token,
+            });
+            if (
+              !prepared
+              || cancellationSource.token.isCancellationRequested
+              || !this._isAccountCurrent(accountEpoch)
+            ) {
+              return cancellationSource.token.isCancellationRequested
+                ? { canceled: true }
+                : null;
+            }
+
             progress.report({ message: "Triggering upstream pull..." });
             const execution = await this._services.upstreamPullService.execute(prepared, {
               progress,
@@ -1574,11 +1583,9 @@ class DependencyHealthProvider {
         vscode.window.showInformationMessage(notification.message);
       }
     } finally {
-      if (cancellationSource) {
-        cancellationSource.dispose();
-        if (this._activeDependencyCancellation === cancellationSource) {
-          this._activeDependencyCancellation = null;
-        }
+      cancellationSource.dispose();
+      if (this._activeDependencyCancellation === cancellationSource) {
+        this._activeDependencyCancellation = null;
       }
       this._dependencyOperationRunning = false;
       await this._updateContexts();
@@ -1680,11 +1687,19 @@ class DependencyHealthProvider {
           ? "Enriching pulled dependency..."
           : "Enriching newly covered dependencies...",
       });
-      await Promise.all([
+      const enrichmentResults = await Promise.allSettled([
         this._runVulnerabilityEnrichment(newlyFoundDependencies, cloudsmithWorkspace, progress, token),
         this._runLicenseEnrichment(newlyFoundDependencies, token),
         this._runPolicyEnrichment(newlyFoundDependencies, token),
       ]);
+      for (const result of enrichmentResults) {
+        if (result.status === "rejected") {
+          appendUniqueWarning(
+            this._warnings,
+            boundedFailureMessage(result.reason, "A dependency refresh enrichment step failed.")
+          );
+        }
+      }
     }
 
     if (options.refreshRemainingUpstream) {
@@ -1868,16 +1883,18 @@ class DependencyHealthProvider {
   }
 }
 
-function isRepositoryPageArray(value) {
-  return Array.isArray(value) && value.every(repository => (
-    repository
-    && typeof repository === "object"
-    && !Array.isArray(repository)
-    && typeof repository.slug === "string"
-    && repository.slug.length > 0
-    && typeof repository.name === "string"
-    && repository.name.length > 0
-  ));
+function normalizeRepositoryCollection(value) {
+  const collection = value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : { items: [], complete: false };
+  const rawItems = Array.isArray(collection.items) ? collection.items : [];
+  const items = [...new Set(rawItems.map(repository => (
+    typeof repository === "string" ? repository.trim() : repository?.slug
+  )).filter(Boolean))];
+  return {
+    items,
+    complete: collection.complete === true && collection.stale !== true,
+  };
 }
 
 function createScanOperation(status, id, values = {}) {
@@ -1898,6 +1915,16 @@ function appendUniqueWarning(warnings, warning) {
     return;
   }
   warnings.push(warning);
+}
+
+function boundedFailureMessage(error, fallback) {
+  const raw = error && typeof error.message === "string"
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : fallback;
+  const normalized = String(raw || fallback).replace(/[\r\n\t]+/g, " ").trim();
+  return normalized.length <= 512 ? normalized : `${normalized.slice(0, 511)}…`;
 }
 
 function getConcreteDependencyVersion(dependency) {
@@ -2016,6 +2043,8 @@ async function lookupExactDependency({
       .version(concreteVersion)
       .build();
     let page = 1;
+    let paginationAnchor = null;
+    const seenPackageIdentities = new Set();
 
     while (true) {
       if (token && token.isCancellationRequested) {
@@ -2062,7 +2091,11 @@ async function lookupExactDependency({
       }
       const response = await api.get(requestEndpoint, {
         responseType: "array",
-        validate: isPackageCandidateArray,
+        validate: value => isPackageCandidateArray(
+          value,
+          cloudsmithWorkspace,
+          cloudsmithRepo
+        ),
         retry: "never",
         cancellationToken: token,
       });
@@ -2089,6 +2122,29 @@ async function lookupExactDependency({
           pagesFetched
         );
       }
+      if (!isPackageCandidateArray(response.data, cloudsmithWorkspace, cloudsmithRepo)) {
+        return createCoverageLookupResult(
+          pagesFetched > 0
+            ? CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
+            : CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
+          null,
+          "Cloudsmith returned package records outside the requested lookup scope.",
+          pagesFetched
+        );
+      }
+      const pageIdentities = response.data.map(packageCandidateIdentity);
+      if (
+        new Set(pageIdentities).size !== pageIdentities.length
+        || pageIdentities.some(identity => seenPackageIdentities.has(identity))
+      ) {
+        return createCoverageLookupResult(
+          CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE,
+          null,
+          "Cloudsmith repeated package records before the lookup completed.",
+          pagesFetched
+        );
+      }
+      for (const identity of pageIdentities) seenPackageIdentities.add(identity);
       pagesFetched += 1;
       const match = matchCoverageCandidates(response.data, dependency, concreteVersion);
       if (match) {
@@ -2100,12 +2156,15 @@ async function lookupExactDependency({
         );
       }
 
-      const pagination = getLookupPaginationDirective(
+      const paginationState = getLookupPaginationState(
         normalizeLookupHeaders(response.headers),
         page,
         response.data.length,
-        LOOKUP_PAGE_SIZE
+        LOOKUP_PAGE_SIZE,
+        paginationAnchor
       );
+      const pagination = paginationState.directive;
+      paginationAnchor = paginationState.anchor;
       if (pagination === "incomplete") {
         return createCoverageLookupResult(
           CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE,
@@ -2213,43 +2272,75 @@ function getCaseAwareCloudsmithPackageLookupKeys(candidate, ecosystemOrFormat) {
   return getCloudsmithPackageLookupKeys(candidate, format);
 }
 
-function getLookupPaginationDirective(headers, requestedPage, itemCount, requestedPageSize) {
+function getLookupPaginationState(
+  headers,
+  requestedPage,
+  itemCount,
+  requestedPageSize,
+  anchor = null
+) {
   const metadata = headers && typeof headers === "object" ? headers : {};
   const currentPage = parseOptionalNonNegativeInteger(metadata.page);
   if (currentPage.present && (!currentPage.valid || currentPage.value !== requestedPage)) {
-    return "incomplete";
+    return { directive: "incomplete", anchor };
   }
 
   const pageTotal = parseOptionalNonNegativeInteger(metadata.pageTotal);
   const count = parseOptionalNonNegativeInteger(metadata.count);
   const responsePageSize = parseOptionalNonNegativeInteger(metadata.pageSize);
   if (count.present && (!count.valid || count.value < itemCount)) {
-    return "incomplete";
+    return { directive: "incomplete", anchor };
   }
   if (responsePageSize.present && (!responsePageSize.valid || responsePageSize.value < 1)) {
-    return "incomplete";
+    return { directive: "incomplete", anchor };
   }
   const effectivePageSize = responsePageSize.present
     ? responsePageSize.value
     : requestedPageSize;
   if (itemCount > effectivePageSize) {
-    return "incomplete";
+    return { directive: "incomplete", anchor };
   }
+  const nextAnchor = {
+    pageTotal: pageTotal.present && pageTotal.valid ? pageTotal.value : null,
+    pageTotalAuthoritative: pageTotal.present,
+    count: count.present && count.valid ? count.value : null,
+    countAuthoritative: count.present,
+    pageSize: effectivePageSize,
+    pageSizeAuthoritative: responsePageSize.present,
+  };
+  if (
+    (pageTotal.present && !pageTotal.valid)
+    || (count.present && !count.valid)
+    || (
+      anchor
+      && (
+        anchor.pageTotal !== nextAnchor.pageTotal
+        || anchor.pageTotalAuthoritative !== nextAnchor.pageTotalAuthoritative
+        || anchor.count !== nextAnchor.count
+        || anchor.countAuthoritative !== nextAnchor.countAuthoritative
+        || anchor.pageSize !== nextAnchor.pageSize
+        || anchor.pageSizeAuthoritative !== nextAnchor.pageSizeAuthoritative
+      )
+    )
+  ) {
+    return { directive: "incomplete", anchor };
+  }
+  const stableAnchor = anchor || nextAnchor;
   if (count.present) {
     const expectedItemCount = Math.min(
       effectivePageSize,
       Math.max(0, count.value - ((requestedPage - 1) * effectivePageSize))
     );
     if (itemCount !== expectedItemCount) {
-      return "incomplete";
+      return { directive: "incomplete", anchor: stableAnchor };
     }
   }
 
   if (pageTotal.present) {
     if (!pageTotal.valid || pageTotal.value < requestedPage) {
       return pageTotal.valid && pageTotal.value === 0 && itemCount === 0
-        ? "exhausted"
-        : "incomplete";
+        ? { directive: "exhausted", anchor: stableAnchor }
+        : { directive: "incomplete", anchor: stableAnchor };
     }
     if (count.present) {
       const calculatedTotal = count.value === 0
@@ -2260,33 +2351,55 @@ function getLookupPaginationDirective(headers, requestedPage, itemCount, request
         || (count.value === 0 && pageTotal.value > 1)
         || (count.value > 0 && calculatedTotal !== pageTotal.value)
       ) {
-        return "incomplete";
+        return { directive: "incomplete", anchor: stableAnchor };
       }
     }
-    return requestedPage >= pageTotal.value ? "exhausted" : "next";
+    if (requestedPage < pageTotal.value && itemCount !== effectivePageSize) {
+      return { directive: "incomplete", anchor: stableAnchor };
+    }
+    return {
+      directive: requestedPage >= pageTotal.value ? "exhausted" : "next",
+      anchor: stableAnchor,
+    };
   }
 
   if (count.present) {
     const calculatedTotal = Math.ceil(count.value / effectivePageSize);
     if (calculatedTotal < requestedPage) {
       return count.value === 0 && itemCount === 0 && requestedPage === 1
-        ? "exhausted"
-        : "incomplete";
+        ? { directive: "exhausted", anchor: stableAnchor }
+        : { directive: "incomplete", anchor: stableAnchor };
     }
-    return requestedPage >= calculatedTotal ? "exhausted" : "next";
+    return {
+      directive: requestedPage >= calculatedTotal ? "exhausted" : "next",
+      anchor: stableAnchor,
+    };
   }
 
-  return "incomplete";
+  return { directive: "incomplete", anchor: stableAnchor };
+}
+
+function getLookupPaginationDirective(headers, requestedPage, itemCount, requestedPageSize) {
+  return getLookupPaginationState(
+    headers,
+    requestedPage,
+    itemCount,
+    requestedPageSize
+  ).directive;
 }
 
 function parseOptionalNonNegativeInteger(value) {
   if (value == null || value === "") {
     return { present: false, valid: false, value: null };
   }
-  const normalized = typeof value === "number" ? value : Number(String(value).trim());
+  const normalized = typeof value === "number"
+    ? value
+    : typeof value === "string" && /^(0|[1-9]\d*)$/.test(value)
+      ? Number(value)
+      : NaN;
   return {
     present: true,
-    valid: Number.isInteger(normalized) && normalized >= 0,
+    valid: Number.isSafeInteger(normalized) && normalized >= 0,
     value: normalized,
   };
 }
@@ -2300,15 +2413,36 @@ function normalizeLookupHeaders(headers) {
   };
 }
 
-function isPackageCandidateArray(value) {
-  return Array.isArray(value) && value.every(candidate => (
-    candidate
-    && typeof candidate === "object"
-    && !Array.isArray(candidate)
-    && nonEmptyString(candidate.name)
-    && nonEmptyString(candidate.format)
-    && nonEmptyString(candidate.version)
-  ));
+function isPackageCandidateArray(value, expectedWorkspace, expectedRepository) {
+  return Array.isArray(value)
+    && value.length <= LOOKUP_PAGE_SIZE
+    && value.every(candidate => (
+      candidate
+      && typeof candidate === "object"
+      && !Array.isArray(candidate)
+      && boundedExactLookupString(candidate.name, LOOKUP_MAX_PACKAGE_NAME_LENGTH)
+      && boundedExactLookupString(candidate.format, LOOKUP_MAX_PACKAGE_FORMAT_LENGTH)
+      && boundedExactLookupString(candidate.version, LOOKUP_MAX_PACKAGE_VERSION_LENGTH)
+      && candidate.namespace === expectedWorkspace
+      && (!expectedRepository || candidate.repository === expectedRepository)
+      && Boolean(getPackagePolicyFlags(candidate))
+      && Boolean(packageCandidateIdentity(candidate))
+    ));
+}
+
+function packageCandidateIdentity(candidate) {
+  try {
+    return packageCollectionIdentity(candidate);
+  } catch {
+    return null;
+  }
+}
+
+function boundedExactLookupString(value, maxLength) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= maxLength
+    && value.trim() === value;
 }
 
 function isAbsentCoverageStatus(status) {
@@ -2751,7 +2885,7 @@ function dependencySeveritySortGroup(dependency) {
     return 0;
   }
 
-  if (vulnerabilities && vulnerabilities.count > 0) {
+  if (hasDetectedVulnerabilities(vulnerabilities)) {
     if (vulnerabilities.maxSeverity === "Critical") {
       return 1;
     }
@@ -2847,7 +2981,7 @@ function matchesFilter(dependency, filterMode) {
 
   switch (filterMode) {
     case FILTER_MODES.VULNERABLE:
-      return Boolean(vulnerabilities && vulnerabilities.count > 0);
+      return hasDetectedVulnerabilities(vulnerabilities);
     case FILTER_MODES.UNCOVERED:
       return isAbsentCoverageStatus(dependency.cloudsmithStatus);
     case FILTER_MODES.RESTRICTIVE_LICENSE:
@@ -2904,12 +3038,17 @@ function buildDependencySummary(fullTrees, displayTrees, options = {}) {
   )).length;
   const vulnerable = summaryDependencies.filter((dependency) => {
     const vulnerabilities = getDependencyVulnerabilityData(dependency);
-    return dependency.cloudsmithStatus === "FOUND" && vulnerabilities && vulnerabilities.count > 0;
+    return dependency.cloudsmithStatus === "FOUND" && hasDetectedVulnerabilities(vulnerabilities);
   }).length;
   const severityCounts = {};
   for (const dependency of summaryDependencies) {
     const vulnerabilities = getDependencyVulnerabilityData(dependency);
-    if (dependency.cloudsmithStatus === "FOUND" && vulnerabilities && vulnerabilities.count > 0 && vulnerabilities.maxSeverity) {
+    if (
+      dependency.cloudsmithStatus === "FOUND"
+      && hasDetectedVulnerabilities(vulnerabilities)
+      && vulnerabilities.maxSeverity
+      && vulnerabilities.maxSeverity !== "Unknown"
+    ) {
       severityCounts[vulnerabilities.maxSeverity] = (severityCounts[vulnerabilities.maxSeverity] || 0) + 1;
     }
   }
@@ -3024,7 +3163,7 @@ async function runPromisePool(items, concurrency, worker) {
     })());
   }
 
-  await Promise.all(workers);
+  await Promise.allSettled(workers);
 }
 
 function mergePatchMaps(patchMaps) {
@@ -3159,7 +3298,7 @@ function buildComplianceReportData(projectName, dependencies, options = {}) {
     .filter((dependency) => dependency.cloudsmithStatus === "FOUND")
     .map((dependency) => {
       const vulnerabilities = getDependencyVulnerabilityData(dependency);
-      if (!vulnerabilities || vulnerabilities.count <= 0) {
+      if (!vulnerabilities || (!hasDetectedVulnerabilities(vulnerabilities) && !vulnerabilities.unknown)) {
         return null;
       }
 
@@ -3172,15 +3311,19 @@ function buildComplianceReportData(projectName, dependencies, options = {}) {
         version: dependency.version || "",
         isDirect: Boolean(dependency.isDirect),
         maxSeverity: vulnerabilities.maxSeverity || null,
-        cveCount: vulnerabilities.count || 0,
+        cveCount: vulnerabilities.countKnown === true ? vulnerabilities.count : null,
+        vulnerabilityStatus: hasDetectedVulnerabilities(vulnerabilities) ? "Detected" : "Unknown",
         hasFixAvailable: Boolean(fixEntry || vulnerabilities.hasFixAvailable),
       };
     })
     .filter(Boolean)
     .sort(compareComplianceVulnerabilityRows);
 
+  const detectedVulnerableDeps = vulnerableDeps.filter((dependency) => (
+    dependency.vulnerabilityStatus === "Detected"
+  ));
   const severityCounts = {};
-  for (const dependency of vulnerableDeps) {
+  for (const dependency of detectedVulnerableDeps) {
     const severity = dependency.maxSeverity || "Unknown";
     severityCounts[severity] = (severityCounts[severity] || 0) + 1;
   }
@@ -3269,7 +3412,8 @@ function buildComplianceReportData(projectName, dependencies, options = {}) {
       lookupFailed,
       lookupIncomplete,
       coveragePct: total === 0 ? 0 : Math.round((found / total) * 100),
-      vulnCount: vulnerableDeps.length,
+      vulnCount: detectedVulnerableDeps.length,
+      vulnUnknownCount: vulnerableDeps.length - detectedVulnerableDeps.length,
       criticalCount: severityCounts.Critical || 0,
       highCount: severityCounts.High || 0,
       mediumCount: severityCounts.Medium || 0,
@@ -3525,7 +3669,10 @@ function defaultUpstreamDetail(status) {
 
 function buildDependencyHealthReport(projectName, dependencies, summary, generatedDate) {
   const vulnerableDependencies = dependencies
-    .filter((dependency) => dependency.vulnerabilities && dependency.vulnerabilities.count > 0)
+    .filter((dependency) => {
+      const vulnerabilities = getDependencyVulnerabilityData(dependency);
+      return hasDetectedVulnerabilities(vulnerabilities) || vulnerabilities?.unknown === true;
+    })
     .sort((left, right) => compareDependencies(left, right, SORT_MODES.SEVERITY, false));
   const uncoveredDependencies = dependencies
     .filter((dependency) => isAbsentCoverageStatus(dependency.cloudsmithStatus))
@@ -3551,24 +3698,33 @@ function buildDependencyHealthReport(projectName, dependencies, summary, generat
     const severityParts = ["Critical", "High", "Medium", "Low"]
       .filter((severity) => summary.severityCounts[severity] > 0)
       .map((severity) => `${summary.severityCounts[severity]} ${severity}`);
-    lines.push(`- ${summary.vulnerable} with known vulnerabilities (${severityParts.join(", ")})`);
+    lines.push(
+      `- ${summary.vulnerable} with detected vulnerabilities${severityParts.length > 0 ? ` (${severityParts.join(", ")})` : ""}`
+    );
   }
 
   lines.push("");
-  lines.push("## Vulnerable Dependencies");
+  lines.push("## Dependency Vulnerability Status");
   if (vulnerableDependencies.length === 0) {
     lines.push("None");
   } else {
     lines.push("| Package | Version | Type | Severity | CVEs | Fix Available |");
     lines.push("|---------|---------|------|----------|------|---------------|");
     for (const dependency of vulnerableDependencies) {
-      const fixEntry = (dependency.vulnerabilities.entries || []).find((entry) => entry.fixVersion);
+      const vulnerabilities = getDependencyVulnerabilityData(dependency);
+      const fixEntry = (vulnerabilities.entries || []).find((entry) => entry.fixVersion);
       const fixCell = fixEntry
         ? `Yes (${fixEntry.fixVersion})`
-        : dependency.vulnerabilities.hasFixAvailable
+        : vulnerabilities.hasFixAvailable
           ? "Yes"
           : "No";
-      lines.push(`| ${dependency.name} | ${dependency.version || "—"} | ${dependency.isDirect ? "Direct" : "Transitive"} | ${dependency.vulnerabilities.maxSeverity || "Unknown"} | ${(dependency.vulnerabilities.cveIds || []).join(", ") || "—"} | ${fixCell} |`);
+      const status = vulnerabilities.unknown && !hasDetectedVulnerabilities(vulnerabilities)
+        ? "Unknown"
+        : "Detected";
+      const cves = vulnerabilities.countKnown === true
+        ? (vulnerabilities.cveIds || []).join(", ") || String(vulnerabilities.count)
+        : status;
+      lines.push(`| ${dependency.name} | ${dependency.version || "—"} | ${dependency.isDirect ? "Direct" : "Transitive"} | ${vulnerabilities.maxSeverity || "Unknown"} | ${cves} | ${fixCell} |`);
     }
   }
 
@@ -3627,19 +3783,25 @@ function getDependencyVulnerabilityData(dependency) {
     return null;
   }
 
-  const count = Number(
-    cloudsmithPackage.vulnerability_scan_results_count
-    || cloudsmithPackage.num_vulnerabilities
-    || 0
-  );
-  if (!Number.isFinite(count) || count <= 0) {
+  const state = getPackageVulnerabilityState(cloudsmithPackage);
+  if (state.count === 0 && !state.detected && !state.unknown) {
     return null;
   }
 
   return {
-    count,
+    count: state.count !== null ? state.count : (state.candidateCount || 0),
+    countKnown: state.count !== null,
+    detected: state.detected,
+    unknown: state.unknown,
     maxSeverity: cloudsmithPackage.max_severity || null,
   };
+}
+
+function hasDetectedVulnerabilities(vulnerabilities) {
+  return Boolean(vulnerabilities && (
+    vulnerabilities.detected === true
+    || (vulnerabilities.countKnown !== false && vulnerabilities.count > 0)
+  ));
 }
 
 function getDependencyPolicyData(dependency) {

--- a/views/promotionProvider.js
+++ b/views/promotionProvider.js
@@ -4,8 +4,13 @@ const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiEndpoint } = require("../util/apiEndpoint");
 const { CredentialManager } = require("../util/credentialManager");
-const { PaginatedFetch } = require("../util/paginatedFetch");
+const {
+  PaginatedFetch,
+  collectionFailureResult,
+  replaceCollectionItems,
+} = require("../util/paginatedFetch");
 const { fetchWorkspaceRepositories } = require("../util/workspaceRepositoryFetcher");
+const { packageCollectionIdentity } = require("../util/collectionIdentity");
 const { buildExactPackageQuery, packageMatchesExactIdentity } = require("../util/packageQuery");
 const { captureAccount, isAccountCurrent, resolveConnectionManager } = require("../util/accountOperation");
 const {
@@ -69,7 +74,84 @@ class PromotionProvider {
     return config.get("promotionTags");
   }
 
-  async getPromotionStatus(workspace, name, version, format) {
+  async getPackageLocations(workspace, name, version, format, options = {}) {
+    const account = options.account || captureAccount(this._connectionManager);
+    if (!account || !isAccountCurrent(this._connectionManager, account)) {
+      return packageLocationFailure("stale_account", "The active Cloudsmith account is unavailable.");
+    }
+    let apiKey;
+    try {
+      apiKey = Object.prototype.hasOwnProperty.call(options, "apiKey")
+        ? options.apiKey
+        : await this._credentialManager.getApiKey();
+    } catch {
+      return packageLocationFailure(
+        "authentication_unavailable",
+        "Cloudsmith authentication is unavailable."
+      );
+    }
+    if (!apiKey || !isAccountCurrent(this._connectionManager, account)) {
+      return packageLocationFailure(
+        "authentication_unavailable",
+        "Cloudsmith authentication is unavailable."
+      );
+    }
+    let endpoint;
+    let identity;
+    try {
+      identity = normalizePackageQueryIdentity(workspace, name, version, format);
+      endpoint = apiEndpoint(["packages", identity.workspace]);
+    } catch {
+      const error = Object.freeze({
+        kind: "invalid_request",
+        message: "The exact package location identity was invalid.",
+      });
+      return Object.freeze({
+        ...collectionFailureResult(error, { termination: "invalid_request" }),
+        error,
+      });
+    }
+
+    // Reuse an injected/shared adapter. If lifecycle code replaces the API, avoid retaining
+    // the adapter bound to the superseded transport.
+    const paginatedFetch = this._paginatedFetch.api === undefined
+      || this._paginatedFetch.api === this.api
+      ? this._paginatedFetch
+      : new PaginatedFetch(this.api);
+    const collection = await paginatedFetch.fetchCollection(endpoint, {
+      pageSize: EXACT_PACKAGE_PAGE_SIZE,
+      maxPages: MAX_EXACT_PACKAGE_PAGES,
+      maxRequests: MAX_EXACT_PACKAGE_PAGES,
+      maxItems: MAX_EXACT_PACKAGE_ITEMS,
+      query: buildExactPackageQuery(identity.name, identity.version, identity.format),
+      canonicalIdentity: packageCollectionIdentity,
+      descriptor: `exact-package-locations:${identity.workspace}:${identity.format}`,
+      responseType: "array",
+      validate: isPackageLocationArray,
+      retry: "never",
+      apiKey,
+      signal: options.signal,
+      cancellationToken: options.cancellationToken,
+    });
+    if (!isAccountCurrent(this._connectionManager, account)) {
+      return packageLocationFailure(
+        "stale_account",
+        "The active Cloudsmith account changed while package locations were loading."
+      );
+    }
+    const exactCollection = replaceCollectionItems(
+      collection,
+      collection.items.filter(candidate => packageMatchesExactIdentity(candidate, identity))
+    );
+    const error = exactCollection.items.length === 0
+      && exactCollection.failureCount > 0
+      && exactCollection.pageCount === 0
+      ? exactCollection.failures[0].error
+      : null;
+    return Object.freeze({ ...exactCollection, error });
+  }
+
+  async getPromotionStatus(workspace, name, version, format, options = {}) {
     let pipeline;
     try {
       pipeline = normalizePipeline(this.getPipeline());
@@ -78,38 +160,42 @@ class PromotionProvider {
     }
     if (pipeline.length === 0) return { items: [], error: null };
 
-    let endpoint;
-    let identity;
-    try {
-      identity = normalizePackageQueryIdentity(workspace, name, version, format);
-      const query = buildExactPackageQuery(identity.name, identity.version, identity.format);
-      endpoint = apiEndpoint(["packages", identity.workspace], { query: { query, page_size: 100 } });
-    } catch (error) {
-      return { items: [], error };
-    }
-    const results = await this.api.get(endpoint, {
-      responseType: "array",
-      validate: isPackageLocationArray,
-      retry: "never",
-    });
-    if (!results.ok) return { items: [], error: results.error };
+    const collection = await this.getPackageLocations(
+      workspace,
+      name,
+      version,
+      format,
+      options
+    );
+    if (collection.error) return collection;
 
     const repoMap = new Map();
-    for (const pkg of results.data.filter(candidate => (
-      packageMatchesExactIdentity(candidate, identity)
-    ))) {
-      repoMap.set(pkg.repository, pkg);
+    for (const pkg of collection.items) {
+      const matches = repoMap.get(pkg.repository) || [];
+      matches.push(pkg);
+      repoMap.set(pkg.repository, matches);
     }
     return {
+      ...collection,
       items: pipeline.map(repo => {
-        const pkg = repoMap.get(repo) || null;
+        const matches = repoMap.get(repo) || [];
+        const pkg = matches.length === 1 ? matches[0] : null;
+        const ambiguous = matches.length > 1;
+        const absentProven = collection.complete && matches.length === 0;
         return {
           repo,
-          found: Boolean(pkg),
-          status: pkg ? (pkg.status_str || "Unknown") : "Not present",
+          found: pkg ? true : (absentProven ? false : null),
+          status: pkg
+            ? (pkg.status_str || "Unknown")
+            : ambiguous
+              ? "Unknown — multiple exact package locations were returned"
+              : absentProven
+                ? "Not present"
+                : "Unknown — package location search is incomplete",
           quarantined: pkg ? pkg.status_str === "Quarantined" : false,
           policyViolated: pkg ? pkg.policy_violated === true : false,
           pkg,
+          ambiguous,
         };
       }),
       error: null,
@@ -839,7 +925,7 @@ class PromotionProvider {
     }
   }
 
-  async _findTargetPackages(source, target, apiKey, cancellationToken, account, options) {
+  async _findTargetPackages(source, target, apiKey, cancellationToken, account, options = {}) {
     let endpoint;
     let query;
     try {
@@ -849,41 +935,38 @@ class PromotionProvider {
       return { ok: false, complete: false, packages: [], errorCode: "invalid_package_query" };
     }
     const packages = [];
-    let itemCount = 0;
-    for (let page = 1; page <= MAX_EXACT_PACKAGE_PAGES; page += 1) {
-      if (!this._isAccountCurrent(account)) {
-        return { ok: false, complete: false, packages: [], errorCode: "account_changed" };
-      }
-      let result;
+    const knownIdentities = new Set();
+    let resume = null;
+    while (true) {
+      let collection;
       try {
-        result = await this._paginatedFetch.fetchPage(
-          endpoint,
-          page,
-          EXACT_PACKAGE_PAGE_SIZE,
+        collection = await this._paginatedFetch.fetchCollection(endpoint, {
+          pageSize: EXACT_PACKAGE_PAGE_SIZE,
+          maxPages: MAX_EXACT_PACKAGE_PAGES,
+          maxRequests: MAX_EXACT_PACKAGE_PAGES,
+          maxItems: MAX_EXACT_PACKAGE_ITEMS,
+          pageBatchLimit: 1,
           query,
-          {
-            apiKey,
-            validate: isPackageLocationArray,
-            retry: "never",
-            cancellationToken,
-          }
-        );
+          descriptor: `promotion-target:${target.workspace}:${target.repository}:${source.format}`,
+          canonicalIdentity: packageCollectionIdentity,
+          validate: value => isPackageLocationArray(value) && value.every(candidate => (
+            candidate.namespace === target.workspace
+            && candidate.repository === target.repository
+          )),
+          retry: "never",
+          apiKey,
+          cancellationToken,
+          resume,
+          ...(resume ? { knownIdentities } : {}),
+        });
       } catch {
         return { ok: false, complete: false, packages: [], errorCode: "target_state_unverified" };
       }
-      if (result.error) {
-        return {
-          ok: false,
-          complete: false,
-          packages: [],
-          errorCode: readErrorCode(result.error, "target_state"),
-        };
+      if (!this._isAccountCurrent(account)) {
+        return { ok: false, complete: false, packages: [], errorCode: "account_changed" };
       }
-      itemCount += result.data.length;
-      if (itemCount > MAX_EXACT_PACKAGE_ITEMS) {
-        return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
-      }
-      for (const candidate of result.data) {
+      for (const candidate of collection.items) {
+        knownIdentities.add(packageCollectionIdentity(candidate));
         if (!packageMatchesExactIdentity(candidate, source)) continue;
         try {
           packages.push(normalizeTargetPackage(candidate, source, target));
@@ -895,21 +978,29 @@ class PromotionProvider {
             errorCode: errorCode(error, "malformed_target_package"),
           };
         }
-        if (options.stopOnPresence) {
-          return { ok: true, complete: true, packages: Object.freeze(packages) };
-        }
-        if (packages.length > 1) {
-          return { ok: true, complete: true, packages: Object.freeze(packages) };
-        }
       }
-      if (page >= result.pagination.pageTotal) {
+      if ((options.stopOnPresence && packages.length > 0) || packages.length > 1) {
         return { ok: true, complete: true, packages: Object.freeze(packages) };
       }
-      if (result.pagination.pageTotal > MAX_EXACT_PACKAGE_PAGES) {
+      if (collection.complete) {
+        return { ok: true, complete: true, packages: Object.freeze(packages) };
+      }
+      if (collection.termination !== "page_batch" || !collection.continuation) {
+        const failure = collection.failures[0]?.error;
+        return {
+          ok: false,
+          complete: false,
+          packages: [],
+          errorCode: failure
+            ? readErrorCode(failure, "target_state")
+            : "target_state_unknown",
+        };
+      }
+      resume = collection.continuation;
+      if (knownIdentities.size !== resume.cumulative.itemCount) {
         return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
       }
     }
-    return { ok: false, complete: false, packages: [], errorCode: "target_state_unknown" };
   }
 
   async _loadPresenceHints(source, apiKey, account) {
@@ -921,28 +1012,31 @@ class PromotionProvider {
     } catch {
       return null;
     }
-    const repositories = new Set();
-    for (let page = 1; page <= MAX_EXACT_PACKAGE_PAGES; page += 1) {
-      if (!this._isAccountCurrent(account)) return null;
-      let result;
-      try {
-        result = await this._paginatedFetch.fetchPage(
-          endpoint,
-          page,
-          EXACT_PACKAGE_PAGE_SIZE,
-          query,
-          { apiKey, validate: isPackageLocationArray, retry: "never" }
-        );
-      } catch {
-        return null;
-      }
-      if (result.error || result.pagination.pageTotal > MAX_EXACT_PACKAGE_PAGES) return null;
-      for (const pkg of result.data) {
-        if (packageMatchesExactIdentity(pkg, source)) repositories.add(pkg.repository);
-      }
-      if (page >= result.pagination.pageTotal) return repositories;
+    let collection;
+    try {
+      collection = await this._paginatedFetch.fetchCollection(endpoint, {
+        pageSize: EXACT_PACKAGE_PAGE_SIZE,
+        maxPages: MAX_EXACT_PACKAGE_PAGES,
+        maxRequests: MAX_EXACT_PACKAGE_PAGES,
+        maxItems: MAX_EXACT_PACKAGE_ITEMS,
+        query,
+        descriptor: `promotion-presence-hints:${source.workspace}:${source.format}`,
+        canonicalIdentity: packageCollectionIdentity,
+        validate: value => isPackageLocationArray(value) && value.every(candidate => (
+          candidate.namespace === source.workspace
+        )),
+        retry: "never",
+        apiKey,
+      });
+    } catch {
+      return null;
     }
-    return null;
+    if (!this._isAccountCurrent(account) || !collection.complete) return null;
+    const repositories = new Set();
+    for (const pkg of collection.items) {
+      if (packageMatchesExactIdentity(pkg, source)) repositories.add(pkg.repository);
+    }
+    return repositories;
   }
 
   async _loadTargetCandidates(source, pipeline, account, apiKey) {
@@ -961,12 +1055,12 @@ class PromotionProvider {
       return { ok: false, errorCode: "repository_list_incomplete" };
     }
     if (result.stale) return { ok: false, errorCode: "account_changed" };
-    if (result.error || result.warning || result.partial) {
+    if (result.complete !== true || result.failureCount > 0 || !Array.isArray(result.items)) {
       return { ok: false, errorCode: "repository_list_incomplete" };
     }
     const repositories = new Map();
     try {
-      for (const record of result.repositories) {
+      for (const record of result.items) {
         const target = normalizeTargetRepository(record, source.workspace, record.slug);
         if (repositories.has(target.repository)) {
           return { ok: false, errorCode: "repository_list_incomplete" };
@@ -1310,6 +1404,14 @@ function failureOutcome(code, options = {}) {
     overall: "failed",
     errorCode: code,
     remoteState: "unchanged",
+  });
+}
+
+function packageLocationFailure(kind, message) {
+  const error = Object.freeze({ kind, message });
+  return Object.freeze({
+    ...collectionFailureResult(error, { termination: kind }),
+    error,
   });
 }
 

--- a/views/quarantineExplainProvider.js
+++ b/views/quarantineExplainProvider.js
@@ -8,11 +8,24 @@ const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiEndpoint } = require("../util/apiEndpoint");
 const { formatApiError } = require("../util/errorFormatter");
 const { buildPackageUrl } = require("../util/webAppUrls");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
+const {
+  fetchPackageDecisionLogs,
+  normalizePolicyStatusReason,
+  parsePolicyStatusReason,
+} = require("../util/policyDecisionLogs");
 
 class QuarantineExplainProvider {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
     this._panel = null;
+    this._operation = null;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._cloudsmithAPI = options.cloudsmithAPI || null;
   }
 
   /**
@@ -45,13 +58,16 @@ class QuarantineExplainProvider {
       version = typeof version.value === "object" ? version.value.value : version.value;
     }
 
-    const statusReason = item.status_reason || null;
+    const statusReason = normalizePolicyStatusReason(item.status_reason);
     const packageUrl = buildPackageUrl(workspace, repo, format, name, version, slugPerm);
 
     if (!workspace || !slugPerm) {
       vscode.window.showWarningMessage("Could not determine package details for quarantine explanation.");
       return;
     }
+
+    const account = captureAccount(this._connectionManager);
+    if (!account || !isAccountCurrent(this._connectionManager, account)) return;
 
     // Create or reveal the WebView panel
     if (this._panel) {
@@ -66,6 +82,8 @@ class QuarantineExplainProvider {
     );
     this._panel = panel;
     const requestController = new AbortController();
+    const operation = { account, controller: requestController, panel };
+    this._operation = operation;
     const nonce = this._getNonce();
 
     panel.onDidDispose(() => {
@@ -73,13 +91,14 @@ class QuarantineExplainProvider {
       if (this._panel === panel) {
         this._panel = null;
       }
+      if (this._operation === operation) this._operation = null;
     });
 
     // Show loading state
     panel.webview.html = this._getLoadingHtml(name, version);
 
     // Fetch policy decision trace
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
+    const cloudsmithAPI = this._cloudsmithAPI || new CloudsmithAPI(this.context);
     const policyTrace = await this._fetchPolicyDecisionTrace(
       cloudsmithAPI,
       workspace,
@@ -88,7 +107,7 @@ class QuarantineExplainProvider {
       requestController.signal
     );
 
-    if (this._panel !== panel) {
+    if (!this._isOperationCurrent(operation)) {
       return;
     }
 
@@ -100,16 +119,19 @@ class QuarantineExplainProvider {
 
     // Handle messages from the WebView
     panel.webview.onDidReceiveMessage(async (message) => {
+      if (!this._isOperationCurrent(operation)) return;
       if (message.command === "findSafeVersion") {
-        vscode.commands.executeCommand("cloudsmith-vsc.findSafeVersion", item);
+        await vscode.commands.executeCommand("cloudsmith-vsc.findSafeVersion", item);
       } else if (message.command === "showVulnerabilities") {
-        vscode.commands.executeCommand("cloudsmith-vsc.showVulnerabilities", item);
+        await vscode.commands.executeCommand("cloudsmith-vsc.showVulnerabilities", item);
       } else if (message.command === "openInCloudsmith" && packageUrl) {
         await vscode.env.openExternal(vscode.Uri.parse(packageUrl));
       } else if (message.command === "copyReport") {
         const report = this._buildPlainTextReport(name, version, statusReason, policyTrace);
         await vscode.env.clipboard.writeText(report);
-        vscode.window.showInformationMessage("Quarantine report copied.");
+        if (this._isOperationCurrent(operation)) {
+          vscode.window.showInformationMessage("Quarantine report copied.");
+        }
       }
     });
   }
@@ -124,55 +146,36 @@ class QuarantineExplainProvider {
     const trace = {
       parsedReason: null,
       decisionLogs: [],
+      decisionLogsComplete: false,
+      decisionLogsPartial: false,
+      decisionLogsIncomplete: true,
+      decisionLogsFailureCount: 0,
       policyDetail: null,
     };
 
     // Parse the status_reason field if present
-    if (statusReason) {
-      const policyMatch = statusReason.match(/Quarantined by (.+?)\.(.+?)(?:\(Policy:\s*(.+?)\))?$/);
-      if (policyMatch) {
-        trace.parsedReason = {
-          policyName: policyMatch[1].trim(),
-          description: policyMatch[2].trim(),
-          policySlug: policyMatch[3] ? policyMatch[3].trim() : null,
-        };
-      } else {
-        trace.parsedReason = { raw: statusReason };
-      }
-    }
+    trace.parsedReason = parsePolicyStatusReason(statusReason);
 
     // Fetch decision logs from v2 API
     try {
-      const logsEndpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"], {
-        query: { page_size: 100 },
-      });
-      const logsResult = await cloudsmithAPI.getV2(logsEndpoint, {
-        responseType: "json",
-        validate: isArrayOrResultsEnvelope,
-        retry: "never",
+      const logsResult = await fetchPackageDecisionLogs(cloudsmithAPI, workspace, slugPerm, {
         signal,
       });
-
-      if (logsResult.ok) {
-        const logs = Array.isArray(logsResult.data) ? logsResult.data : logsResult.data.results;
-        trace.decisionLogs = logs.filter(entry => {
-          if (entry.package && entry.package.identifier === slugPerm) {
-            return true;
-          }
-          if (entry.package_slug_perm === slugPerm) {
-            return true;
-          }
-          return false;
-        });
-      } else if (logsResult.error.kind !== "cancelled") {
-        console.warn(`[Quarantine] Policy decision logs unavailable: ${formatApiError(logsResult.error)}`);
-      }
-    } catch (error) { // eslint-disable-line no-unused-vars
-      // v2 policy decision log endpoint may not be available
+      if (signal && signal.aborted) return trace;
+      trace.decisionLogs = [...logsResult.items];
+      trace.decisionLogsComplete = logsResult.complete;
+      trace.decisionLogsPartial = logsResult.partial;
+      trace.decisionLogsIncomplete = logsResult.incomplete;
+      trace.decisionLogsFailureCount = logsResult.failureCount;
+    } catch {
+      trace.decisionLogsComplete = false;
+      trace.decisionLogsPartial = false;
+      trace.decisionLogsIncomplete = true;
+      trace.decisionLogsFailureCount = 1;
     }
 
     // If we have a policy slug, fetch the policy detail for the description
-    if (trace.parsedReason && trace.parsedReason.policySlug) {
+    if (trace.parsedReason && trace.parsedReason.policySlug && !(signal && signal.aborted)) {
       try {
         const policyEndpoint = apiEndpoint([
           "workspaces",
@@ -186,6 +189,7 @@ class QuarantineExplainProvider {
           retry: "never",
           signal,
         });
+        if (signal && signal.aborted) return trace;
         if (policyResult.ok) {
           trace.policyDetail = policyResult.data;
         } else if (policyResult.error.kind !== "cancelled") {
@@ -250,7 +254,7 @@ class QuarantineExplainProvider {
       for (const entry of policyTrace.decisionLogs) {
         decisionLogsHtml += `<tr>
           <td>${this._esc(entry.policy_name || entry.name || "Unknown")}</td>
-          <td>${this._esc(entry.matched ? "Yes" : "No")}</td>
+          <td>${this._esc(entry.matched === true ? "Yes" : entry.matched === false ? "No" : "Unknown")}</td>
           <td>${this._esc(entry.action || entry.actions_taken || "\u2014")}</td>
           <td>${this._esc(entry.reason || "\u2014")}</td>
         </tr>`;
@@ -259,7 +263,10 @@ class QuarantineExplainProvider {
     }
 
     // Non-vulnerability notice
-    const nonVulnNotice = !hasCVEs
+    const decisionLogsWarning = policyTrace.decisionLogsComplete === false
+      ? `<div class="warning-banner">Policy decision log history is incomplete. Loaded entries are shown, but additional policy or vulnerability decisions may exist.</div>`
+      : "";
+    const nonVulnNotice = !hasCVEs && policyTrace.decisionLogsComplete === true
       ? `<div class="info-banner">This quarantine was triggered by policy rules, not a specific vulnerability.</div>`
       : "";
 
@@ -340,6 +347,13 @@ class QuarantineExplainProvider {
     margin: 16px 0;
     color: var(--vscode-descriptionForeground);
   }
+  .warning-banner {
+    background: var(--vscode-inputValidation-warningBackground, rgba(255,200,0,0.08));
+    border: 1px solid var(--vscode-inputValidation-warningBorder, #c8a000);
+    border-radius: 4px;
+    padding: 10px 14px;
+    margin: 16px 0;
+  }
 </style>
 </head>
 <body>
@@ -350,6 +364,7 @@ class QuarantineExplainProvider {
   <span class="quarantine-badge">\u26D4 Quarantined</span>
 
   ${policyInfoHtml}
+  ${decisionLogsWarning}
   ${nonVulnNotice}
   ${decisionLogsHtml}
 
@@ -398,6 +413,9 @@ class QuarantineExplainProvider {
         lines.push(`  - ${entry.policy_name || entry.name || "Unknown"}: ${entry.reason || entry.action || "\u2014"}`);
       }
     }
+    if (policyTrace.decisionLogsComplete === false) {
+      lines.push("Policy decision log history is incomplete; additional entries may exist.");
+    }
     return lines.join("\n");
   }
 
@@ -414,23 +432,32 @@ class QuarantineExplainProvider {
     return crypto.randomBytes(16).toString("hex");
   }
 
+  _isOperationCurrent(operation) {
+    return Boolean(
+      operation
+      && this._operation === operation
+      && this._panel === operation.panel
+      && !operation.controller.signal.aborted
+      && isAccountCurrent(this._connectionManager, operation.account)
+    );
+  }
+
+  resetForAccountChange() {
+    const operation = this._operation;
+    this._operation = null;
+    if (operation) operation.controller.abort();
+    const panel = this._panel;
+    this._panel = null;
+    if (panel) panel.dispose();
+  }
+
   dispose() {
-    if (this._panel) {
-      this._panel.dispose();
-      this._panel = null;
-    }
+    this.resetForAccountChange();
   }
 }
 
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function isArrayOrResultsEnvelope(value) {
-  if (Array.isArray(value)) {
-    return value.every(isRecord);
-  }
-  return isRecord(value) && Array.isArray(value.results) && value.results.every(isRecord);
 }
 
 module.exports = { QuarantineExplainProvider };

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -8,21 +8,33 @@ const SearchResultNode = require("../models/searchResultNode");
 const LoadMoreNode = require("../models/loadMoreNode");
 const InfoNode = require("../models/infoNode");
 const { formatApiError } = require("../util/errorFormatter");
+const {
+    getPackagePolicyFlags,
+    getPackageVulnerabilityState,
+} = require("../util/packageVulnerabilities");
+const {
+    MAX_COLLECTION_IDENTITY_PART_LENGTH,
+    packageCollectionIdentity,
+} = require("../util/collectionIdentity");
 
 const MAX_RESULTS = 5000;
-const MAX_REPOSITORIES = 100;
+const MAX_REPOSITORIES = 1000;
 const MAX_WORKSPACE_LENGTH = 200;
 const MAX_REPOSITORY_LENGTH = 200;
 const MAX_QUERY_LENGTH = 2048;
 const MAX_PACKAGE_NAME_LENGTH = 2048;
 const MAX_PACKAGE_FORMAT_LENGTH = 100;
 const MAX_PACKAGE_VERSION_LENGTH = 2048;
-const MAX_PACKAGE_IDENTITY_LENGTH = 2048;
+const MAX_PACKAGE_IDENTITY_LENGTH = MAX_COLLECTION_IDENTITY_PART_LENGTH;
 const MAX_PACKAGE_OPTIONAL_STRING_LENGTH = 4096;
 const MAX_PACKAGE_URL_LENGTH = 8192;
 const MAX_PACKAGE_TAGS = 100;
 const MAX_PACKAGE_TAG_LENGTH = 500;
 const MULTI_REPO_CONCURRENCY = 4;
+const MAX_MULTI_REPO_REQUESTS = 2000;
+const MAX_MULTI_REPO_PAGES = 20;
+const MAX_SINGLE_SEARCH_PAGES = 20;
+const MAX_SINGLE_SEARCH_REQUESTS = 24;
 const MAX_FAILURE_DETAILS = 20;
 
 class SearchProvider {
@@ -270,14 +282,14 @@ class SearchProvider {
             return;
         }
 
-        let nodes;
+        let builtRoot;
         try {
-            nodes = buildUniqueNodes(
+            builtRoot = buildUniqueNodes(
                 result.data,
                 this.context,
                 new Set(),
                 this.connectionManager
-            ).nodes;
+            );
         } catch (error) {
             this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
             return;
@@ -285,12 +297,27 @@ class SearchProvider {
         if (!this._isCurrentRoot(operation)) {
             return;
         }
+        if (builtRoot.duplicateCount > 0) {
+            this._failRoot(
+                operation,
+                "Could not search packages. Cloudsmith returned duplicate package identities.",
+                null,
+                "invalid_response"
+            );
+            return;
+        }
 
-        const keptNodes = nodes.slice(0, MAX_RESULTS);
-        const droppedResultCount = nodes.length - keptNodes.length;
+        const keptNodes = builtRoot.nodes.slice(0, MAX_RESULTS);
+        const droppedResultCount = builtRoot.nodes.length - keptNodes.length;
         const pagination = freezePagination(result.pagination);
-        const capReached = keptNodes.length >= MAX_RESULTS
+        const resultLimitReached = keptNodes.length >= MAX_RESULTS
             && pagination.page < pagination.pageTotal;
+        // This is a per-search session bound, independent of the API page at
+        // which an explicitly requested root search began.
+        const successfulPageCount = 1;
+        const pageLimitReached = successfulPageCount >= MAX_SINGLE_SEARCH_PAGES
+            && pagination.page < pagination.pageTotal;
+        const capReached = resultLimitReached || pageLimitReached;
         this._commitRoot(operation, {
             descriptor,
             results: keptNodes,
@@ -303,6 +330,10 @@ class SearchProvider {
                 unsearchedRepositoryCount: 0,
                 droppedResultCount,
                 capReached,
+                partial: capReached || droppedResultCount > 0,
+                requestCount: 1,
+                pageCount: successfulPageCount,
+                pageLimitReached,
             },
         });
         if (keptNodes.length === 0) {
@@ -313,93 +344,38 @@ class SearchProvider {
     async _executeRepositorySearch(operation) {
         const { descriptor } = operation;
         const pageSize = clampPageSize(this._getPageSize());
-        const searchableCount = Math.min(
-            descriptor.repositories.length,
-            Math.floor(MAX_RESULTS / pageSize)
-        );
-        const searchedRepositories = descriptor.repositories.slice(0, searchableCount);
-        const unsearchedRepositoryCount = descriptor.repositories.length - searchedRepositories.length;
         const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
         if (!this._isCurrentRoot(operation)) {
             this._discardRoot(operation);
             return;
         }
 
-        let repositoryResults;
+        let collection;
         try {
             const outcome = await this._withProgress(progressOptions(), async (_progress, token) => {
-                const results = await mapWithConcurrency(
-                    searchedRepositories,
-                    MULTI_REPO_CONCURRENCY,
-                    async repository => {
-                        if (!this._isCurrentRoot(operation)) {
-                            return staleRepositoryResult(repository);
-                        }
-                        let endpoint;
-                        try {
-                            endpoint = apiEndpoint(["packages", descriptor.workspace, repository]);
-                        } catch {
-                            return failedRepositoryResult(repository, localSearchError(
-                                "invalid_request",
-                                "The repository identifier was invalid."
-                            ));
-                        }
-                        let result;
-                        try {
-                            result = await paginatedFetch.fetchPage(
-                                endpoint,
-                                1,
-                                pageSize,
-                                descriptor.query,
-                                {
-                                    cancellationToken: token,
-                                    retry: "never",
-                                    signal: operation.controller.signal,
-                                    validate: isPackageSearchArray,
-                                }
-                            );
-                        } catch (error) {
-                            return failedRepositoryResult(repository, localSearchError(
-                                "unexpected",
-                                safeErrorMessage(error)
-                            ));
-                        }
-                        if (!this._isCurrentRoot(operation)) {
-                            return staleRepositoryResult(repository);
-                        }
-                        if (result.error) {
-                            return failedRepositoryResult(repository, result.error);
-                        }
-                        if (!isValidFetchedPage(result, 1, pageSize)) {
-                            return failedRepositoryResult(repository, localSearchError(
-                                "invalid_response",
-                                "Cloudsmith returned an invalid result page."
-                            ));
-                        }
-                        if (!hasExactPackageScope(result.data, {
-                            kind: "repository",
-                            workspace: descriptor.workspace,
-                            repository,
-                        })) {
-                            return failedRepositoryResult(repository, localSearchError(
-                                "invalid_response",
-                                "Cloudsmith returned packages outside the requested scope."
-                            ));
-                        }
-                        return Object.freeze({ repository, result, stale: false });
-                    },
-                    () => this._isCurrentRoot(operation) && !token?.isCancellationRequested
-                );
-                return { results, cancelled: Boolean(token?.isCancellationRequested) };
+                const run = createRepositorySearchRun(descriptor);
+                await runRepositorySearchWorkers({
+                    run,
+                    operation,
+                    pageSize,
+                    paginatedFetch,
+                    token,
+                    isCurrent: () => this._isCurrentRoot(operation),
+                });
+                return {
+                    run,
+                    cancelled: Boolean(token?.isCancellationRequested || run.cancelled),
+                    stale: run.stale,
+                };
             });
             if (!this._isCurrentRoot(operation)) {
                 return;
             }
-            if (outcome.cancelled) {
+            if (outcome.cancelled || outcome.stale) {
                 this._cancelRoot(operation);
                 return;
             }
-            repositoryResults = outcome.results;
+            collection = finalizeRepositorySearchRun(outcome.run);
         } catch (error) {
             if (!this._isCurrentRoot(operation)) {
                 return;
@@ -411,39 +387,31 @@ class SearchProvider {
         if (!this._isCurrentRoot(operation)) {
             return;
         }
-        const completedResults = repositoryResults.filter(result => result && !result.stale);
-        const failures = completedResults.filter(result => result.error);
-        const successes = completedResults.filter(result => !result.error);
-        if (successes.length === 0) {
-            const detail = failures.length > 0
-                ? ` ${formatApiError(failures[0].error)}`
+        if (collection.successfulPageCount === 0) {
+            const detail = collection.failureDetails.length > 0
+                ? ` ${collection.failureDetails[0].message}`
                 : " No repository search completed.";
             this._failRoot(
                 operation,
                 `Could not search the selected repositories.${detail}`,
-                failures[0]?.error || null,
-                failures[0]?.error?.kind || "search_failed"
+                null,
+                collection.firstFailureKind || "search_failed"
             );
             return;
         }
 
         let built;
         try {
-            const seen = new Set();
-            const nodes = [];
-            for (const success of successes) {
-                const next = buildUniqueNodes(
-                    success.result.data,
-                    this.context,
-                    seen,
-                    this.connectionManager
-                );
-                nodes.push(...next.nodes);
-            }
+            const nodes = buildUniqueNodes(
+                collection.packages,
+                this.context,
+                new Set(),
+                this.connectionManager
+            ).nodes;
             const keptNodes = nodes.slice(0, MAX_RESULTS);
             built = {
                 nodes: keptNodes,
-                droppedResultCount: nodes.length - keptNodes.length,
+                droppedResultCount: collection.droppedResultCount + nodes.length - keptNodes.length,
             };
         } catch (error) {
             this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
@@ -453,62 +421,42 @@ class SearchProvider {
             return;
         }
 
-        const failureDetails = failures.slice(0, MAX_FAILURE_DETAILS).map(({ repository, error }) => ({
-            repository,
-            message: formatApiError(error),
-        }));
-        const truncatedRepositories = successes.filter(({ result }) => (
-            result.pagination.page < result.pagination.pageTotal
-            || result.pagination.count > result.data.length
-        ));
-        const truncationDetails = truncatedRepositories
-            .slice(0, MAX_FAILURE_DETAILS)
-            .map(({ repository, result }) => ({
-                repository,
-                loadedCount: result.data.length,
-                totalCount: result.pagination.count,
-                page: result.pagination.page,
-                pageTotal: result.pagination.pageTotal,
-            }));
-        const matchedResultCount = boundedCountSum(
-            successes.map(({ result }) => result.pagination.count)
-        );
-        const truncatedResultCount = boundedCountSum(
-            truncatedRepositories.map(({ result }) => (
-                Math.max(0, result.pagination.count - result.data.length)
-            ))
-        );
-        const partial = failures.length > 0
-            || unsearchedRepositoryCount > 0
-            || truncatedRepositories.length > 0
-            || built.droppedResultCount > 0;
+        const partial = !collection.complete || built.droppedResultCount > 0;
         this._commitRoot(operation, {
             descriptor,
             results: built.nodes,
             pagination: null,
             pageable: false,
-            totalCount: matchedResultCount,
+            totalCount: collection.totalCount,
             diagnostics: {
-                failedRepositoryCount: failures.length,
-                failureDetails,
-                unsearchedRepositoryCount,
-                truncatedRepositoryCount: truncatedRepositories.length,
-                truncationDetails,
-                truncatedResultCount,
+                failedRepositoryCount: collection.failedRepositoryCount,
+                failureDetails: collection.failureDetails,
+                unsearchedRepositoryCount: collection.unsearchedRepositoryCount,
+                truncatedRepositoryCount: collection.truncatedRepositoryCount,
+                truncationDetails: collection.truncationDetails,
+                truncatedResultCount: collection.truncatedResultCount,
                 droppedResultCount: built.droppedResultCount,
                 partial,
-                capReached: built.nodes.length >= MAX_RESULTS
-                    || unsearchedRepositoryCount > 0
-                    || truncatedRepositories.length > 0,
+                capReached: built.droppedResultCount > 0
+                    || collection.requestLimitReached
+                    || collection.pageLimitReached
+                    || collection.resultLimitReached,
+                requestCount: collection.requestCount,
+                pageCount: collection.pageCount,
+                rateLimited: collection.rateLimited,
+                requestLimitReached: collection.requestLimitReached,
+                pageLimitReached: collection.pageLimitReached,
             },
         });
 
-        if (failures.length > 0) {
-            const names = failures.slice(0, MAX_FAILURE_DETAILS).map(result => result.repository);
-            const suffix = failures.length > names.length ? `, and ${failures.length - names.length} more` : "";
+        if (collection.failedRepositoryCount > 0) {
+            const names = collection.failureDetails.map(detail => detail.repository);
+            const suffix = collection.failedRepositoryCount > names.length
+                ? `, and ${collection.failedRepositoryCount - names.length} more`
+                : "";
             this._notify("warning", `Could not search some repositories: ${names.join(", ")}${suffix}.`);
         }
-        if (built.nodes.length === 0) {
+        if (built.nodes.length === 0 && !partial) {
             this._notify("information", `No packages found for "${descriptor.query}".`);
         }
     }
@@ -546,6 +494,7 @@ class SearchProvider {
             targetPage,
             account,
             controller: new AbortController(),
+            attemptRequestCount: committed.diagnostics.requestCount + 1,
         });
         const promise = Promise.resolve()
             .then(() => this._executePage(operation))
@@ -585,7 +534,13 @@ class SearchProvider {
                 ? apiEndpoint(["packages", descriptor.workspace, descriptor.repository])
                 : apiEndpoint(["packages", descriptor.workspace]);
         } catch {
-            this._failPage(operation, "Could not load more packages. The search scope was invalid.", null, "invalid_request");
+            this._failPage(
+                operation,
+                "Could not load more packages. The search scope was invalid.",
+                null,
+                "invalid_request",
+                true
+            );
             return;
         }
 
@@ -614,7 +569,13 @@ class SearchProvider {
             if (!this._isCurrentPage(operation)) {
                 return;
             }
-            this._failPage(operation, `Could not load more packages. ${safeErrorMessage(error)}`, null, "unexpected");
+            this._failPage(
+                operation,
+                `Could not load more packages. ${safeErrorMessage(error)}`,
+                null,
+                "unexpected",
+                true
+            );
             return;
         }
 
@@ -631,7 +592,8 @@ class SearchProvider {
                 operation,
                 `Could not load more packages. ${formatApiError(result.error)}`,
                 result.error,
-                result.error.kind
+                result.error.kind,
+                !isRetryablePageFailure(result.error)
             );
             return;
         }
@@ -640,7 +602,18 @@ class SearchProvider {
                 operation,
                 "Could not load more packages. Cloudsmith returned an invalid result page.",
                 null,
-                "invalid_response"
+                "invalid_response",
+                true
+            );
+            return;
+        }
+        if (!samePaginationAnchor(committed.pagination, result.pagination)) {
+            this._failPage(
+                operation,
+                "Could not load more packages. Cloudsmith changed pagination metadata between pages.",
+                null,
+                "invalid_response",
+                true
             );
             return;
         }
@@ -649,7 +622,8 @@ class SearchProvider {
                 operation,
                 "Could not load more packages. Cloudsmith returned an unexpected page or package scope.",
                 null,
-                "invalid_response"
+                "invalid_response",
+                true
             );
             return;
         }
@@ -664,7 +638,23 @@ class SearchProvider {
                 this.connectionManager
             );
         } catch (error) {
-            this._failPage(operation, `Could not display more search results. ${safeErrorMessage(error)}`, null, "invalid_response");
+            this._failPage(
+                operation,
+                `Could not display more search results. ${safeErrorMessage(error)}`,
+                null,
+                "invalid_response",
+                true
+            );
+            return;
+        }
+        if (built.duplicateCount > 0) {
+            this._failPage(
+                operation,
+                "Could not load more packages. Cloudsmith repeated a package identity.",
+                null,
+                "invalid_response",
+                true
+            );
             return;
         }
         if (!this._isCurrentPage(operation)) {
@@ -676,7 +666,15 @@ class SearchProvider {
         const results = [...committed.results, ...appended];
         const pagination = freezePagination(result.pagination);
         const pageDropped = built.nodes.length - appended.length;
-        const capReached = results.length >= MAX_RESULTS && pagination.page < pagination.pageTotal;
+        const requestCount = operation.attemptRequestCount;
+        const pageCount = committed.diagnostics.pageCount + 1;
+        const resultLimitReached = results.length >= MAX_RESULTS
+            && pagination.page < pagination.pageTotal;
+        const pageLimitReached = pageCount >= MAX_SINGLE_SEARCH_PAGES
+            && pagination.page < pagination.pageTotal;
+        const requestLimitReached = requestCount >= MAX_SINGLE_SEARCH_REQUESTS
+            && pagination.page < pagination.pageTotal;
+        const capReached = resultLimitReached || pageLimitReached || requestLimitReached;
         const nextCommitted = freezeCommitted({
             ...committed,
             results,
@@ -688,6 +686,11 @@ class SearchProvider {
                 ...committed.diagnostics,
                 droppedResultCount: committed.diagnostics.droppedResultCount + pageDropped,
                 capReached: committed.diagnostics.capReached || capReached,
+                partial: committed.diagnostics.partial || capReached || pageDropped > 0,
+                requestCount,
+                pageCount,
+                requestLimitReached,
+                pageLimitReached,
             },
         });
         this._state = freezeState({ committed: nextCommitted, pending: null, failure: null });
@@ -746,18 +749,19 @@ class SearchProvider {
         this.refresh();
     }
 
-    _failPage(operation, message, _error, kind) {
+    _failPage(operation, message, _error, kind, terminal = false) {
         if (!this._isCurrentPage(operation)) {
             return;
         }
+        const committed = commitPageAttempt(operation, { terminal, failed: true });
         this._state = freezeState({
-            committed: operation.committed,
+            committed,
             pending: null,
             failure: {
                 operationId: operation.id,
                 activationId: operation.account.activationId,
                 accountEpoch: operation.account.accountEpoch,
-                descriptor: operation.committed.descriptor,
+                descriptor: committed.descriptor,
                 kind: kind || "page_failed",
                 message,
             },
@@ -770,7 +774,11 @@ class SearchProvider {
         if (!this._isCurrentPage(operation)) {
             return;
         }
-        this._state = freezeState({ committed: operation.committed, pending: null, failure: null });
+        this._state = freezeState({
+            committed: commitPageAttempt(operation),
+            pending: null,
+            failure: null,
+        });
         this.refresh();
     }
 
@@ -925,7 +933,8 @@ class SearchProvider {
             children.push(new LoadMoreNode(
                 committed.pagination.page,
                 committed.pagination.pageTotal,
-                committed.pagination.count
+                committed.pagination.count,
+                committed.results.length
             ));
         }
         return children;
@@ -982,13 +991,13 @@ function normalizeDescriptor(value) {
     }
     if (value.kind === "repositories") {
         if (!Array.isArray(value.repositories)) {
-            throw new Error("Select between 1 and 100 repositories to search.");
+            throw new Error("Select between 1 and 1,000 repositories to search.");
         }
         const repositories = [...new Set(value.repositories.map(repository => (
             normalizeRequiredString(repository, "repository", MAX_REPOSITORY_LENGTH)
         )))];
         if (repositories.length < 1 || repositories.length > MAX_REPOSITORIES) {
-            throw new Error("Select between 1 and 100 repositories to search.");
+            throw new Error("Select between 1 and 1,000 repositories to search.");
         }
         return freezeDescriptor({ kind: "repositories", workspace, repositories, query, page: 1 });
     }
@@ -1073,15 +1082,18 @@ function canonicalizeSearchPackage(pkg) {
     const repository = requiredString(pkg.repository, MAX_REPOSITORY_LENGTH);
     const namespace = requiredString(pkg.namespace, MAX_WORKSPACE_LENGTH);
     const slugPerm = requiredString(pkg.slug_perm, MAX_PACKAGE_IDENTITY_LENGTH);
-    if (!name || !format || !version || !repository || !namespace || !slugPerm) return null;
+    const policyFlags = getPackagePolicyFlags(pkg);
+    if (!name || !format || !version || !repository || !namespace || !slugPerm || !policyFlags) {
+        return null;
+    }
 
     const downloads = Number.isSafeInteger(pkg.downloads) && pkg.downloads >= 0
         ? pkg.downloads
         : 0;
-    const numVulnerabilities = Number.isSafeInteger(pkg.num_vulnerabilities)
-        && pkg.num_vulnerabilities >= 0
-        ? pkg.num_vulnerabilities
-        : undefined;
+    const vulnerabilityState = getPackageVulnerabilityState(pkg);
+    const numVulnerabilities = vulnerabilityState.count === null
+        ? undefined
+        : vulnerabilityState.count;
     return {
         name,
         format,
@@ -1103,16 +1115,11 @@ function canonicalizeSearchPackage(pkg) {
         version_digest: optionalString(pkg.version_digest),
         cdn_url: optionalString(pkg.cdn_url, MAX_PACKAGE_URL_LENGTH),
         filename: optionalString(pkg.filename),
-        policy_violated: pkg.policy_violated === true,
-        deny_policy_violated: pkg.deny_policy_violated === true,
-        license_policy_violated: pkg.license_policy_violated === true,
-        vulnerability_policy_violated: pkg.vulnerability_policy_violated === true,
+        ...policyFlags,
         num_vulnerabilities: numVulnerabilities,
-        has_vulnerabilities: pkg.has_vulnerabilities === true
-            ? true
-            : pkg.has_vulnerabilities === false
-                ? false
-                : undefined,
+        // Canonicalize all list-response aliases through the shared indicator contract.
+        // Omitting both fields intentionally remains "unknown" to downstream nodes.
+        has_vulnerabilities: vulnerabilityState.detected ? true : undefined,
         max_severity: optionalString(pkg.max_severity),
         vulnerability_scan_results_url: optionalString(
             pkg.vulnerability_scan_results_url,
@@ -1128,7 +1135,7 @@ function canonicalizeSearchPackage(pkg) {
 }
 
 function isValidFetchedPage(result, requestedPage, requestedPageSize) {
-    return Boolean(
+    if (!(
         result
         && isPackageSearchArray(result.data)
         && result.data.length <= requestedPageSize
@@ -1136,12 +1143,50 @@ function isValidFetchedPage(result, requestedPage, requestedPageSize) {
         && result.pagination.page === requestedPage
         && Number.isSafeInteger(result.pagination.pageTotal)
         && result.pagination.pageTotal >= requestedPage
-        && Number.isSafeInteger(result.pagination.count)
-        && result.pagination.count >= result.data.length
         && Number.isSafeInteger(result.pagination.pageSize)
         && result.pagination.pageSize >= 1
         && result.pagination.pageSize <= 100
-    );
+        && result.pagination.pageSize <= requestedPageSize
+        && result.data.length <= result.pagination.pageSize
+    )) return false;
+    const countAuthoritative = result.pagination.countAuthoritative === true
+        || (
+            result.pagination.countAuthoritative === undefined
+            && Number.isSafeInteger(result.pagination.count)
+        );
+    if (countAuthoritative) {
+        if (!Number.isSafeInteger(result.pagination.count) || result.pagination.count < 0) return false;
+        const calculatedPages = Math.max(
+            1,
+            Math.ceil(result.pagination.count / result.pagination.pageSize)
+        );
+        const expectedItems = Math.min(
+            result.pagination.pageSize,
+            Math.max(
+                0,
+                result.pagination.count - ((requestedPage - 1) * result.pagination.pageSize)
+            )
+        );
+        return calculatedPages === result.pagination.pageTotal
+            && result.data.length === expectedItems;
+    }
+    return (result.pagination.count === null || result.pagination.count === undefined)
+        && (
+            requestedPage >= result.pagination.pageTotal
+            || result.data.length === result.pagination.pageSize
+        );
+}
+
+function samePaginationAnchor(previous, current) {
+    if (!previous || !current || current.page !== previous.page + 1) return false;
+    const previousCountAuthoritative = previous.countAuthoritative === true
+        || (previous.countAuthoritative === undefined && Number.isSafeInteger(previous.count));
+    const currentCountAuthoritative = current.countAuthoritative === true
+        || (current.countAuthoritative === undefined && Number.isSafeInteger(current.count));
+    return previous.pageTotal === current.pageTotal
+        && previous.pageSize === current.pageSize
+        && previousCountAuthoritative === currentCountAuthoritative
+        && previous.count === current.count;
 }
 
 function hasExactPackageScope(packages, descriptor) {
@@ -1152,15 +1197,20 @@ function hasExactPackageScope(packages, descriptor) {
 }
 
 function packageKey(pkg) {
-    return JSON.stringify([pkg.namespace, pkg.repository, pkg.slug_perm]);
+    return packageCollectionIdentity(pkg);
 }
 
 function packageKeyFromNode(node) {
-    return JSON.stringify([node.namespace, node.repository, node.slug_perm_raw]);
+    return packageCollectionIdentity({
+        namespace: node.namespace,
+        repository: node.repository,
+        slug_perm: node.slug_perm_raw,
+    });
 }
 
 function buildUniqueNodes(packages, context, seen, connectionManager) {
     const nodes = [];
+    let duplicateCount = 0;
     for (const pkg of packages) {
         const canonicalPackage = canonicalizeSearchPackage(pkg);
         if (!canonicalPackage) {
@@ -1168,12 +1218,13 @@ function buildUniqueNodes(packages, context, seen, connectionManager) {
         }
         const key = packageKey(canonicalPackage);
         if (seen.has(key)) {
+            duplicateCount += 1;
             continue;
         }
         seen.add(key);
         nodes.push(freezeSearchNode(new SearchResultNode(canonicalPackage, context, { connectionManager })));
     }
-    return { nodes };
+    return { nodes, duplicateCount };
 }
 
 function freezeSearchNode(node) {
@@ -1206,10 +1257,13 @@ function freezeDescriptor(descriptor) {
 }
 
 function freezePagination(pagination) {
+    const countAuthoritative = pagination.countAuthoritative === true
+        || (pagination.countAuthoritative === undefined && Number.isSafeInteger(pagination.count));
     return Object.freeze({
         page: pagination.page,
         pageTotal: pagination.pageTotal,
-        count: pagination.count,
+        count: countAuthoritative ? pagination.count : null,
+        countAuthoritative,
         pageSize: pagination.pageSize,
     });
 }
@@ -1229,7 +1283,9 @@ function freezeCommitted(value) {
         resultKeys: Object.freeze([...value.resultKeys]),
         pagination: value.pagination ? freezePagination(value.pagination) : null,
         pageable: Boolean(value.pageable),
-        totalCount: Number.isFinite(value.totalCount) ? value.totalCount : value.results.length,
+        totalCount: Number.isSafeInteger(value.totalCount) && value.totalCount >= 0
+            ? value.totalCount
+            : null,
         diagnostics: Object.freeze({
             failedRepositoryCount: diagnostics.failedRepositoryCount || 0,
             failureDetails,
@@ -1240,7 +1296,35 @@ function freezeCommitted(value) {
             droppedResultCount: diagnostics.droppedResultCount || 0,
             partial: Boolean(diagnostics.partial),
             capReached: Boolean(diagnostics.capReached),
+            requestCount: diagnostics.requestCount || 0,
+            pageCount: diagnostics.pageCount || 0,
+            rateLimited: Boolean(diagnostics.rateLimited),
+            requestLimitReached: Boolean(diagnostics.requestLimitReached),
+            pageLimitReached: Boolean(diagnostics.pageLimitReached),
         }),
+    });
+}
+
+function commitPageAttempt(operation, { terminal = false } = {}) {
+    const committed = operation.committed;
+    const requestCount = Math.max(
+        committed.diagnostics.requestCount,
+        operation.attemptRequestCount
+    );
+    const requestLimitReached = requestCount >= MAX_SINGLE_SEARCH_REQUESTS;
+    const pageLimitReached = committed.diagnostics.pageCount >= MAX_SINGLE_SEARCH_PAGES;
+    const hardLimitReached = requestLimitReached || pageLimitReached;
+    return freezeCommitted({
+        ...committed,
+        pageable: committed.pageable && !terminal && !hardLimitReached,
+        diagnostics: {
+            ...committed.diagnostics,
+            requestCount,
+            capReached: committed.diagnostics.capReached || hardLimitReached,
+            partial: committed.diagnostics.partial || terminal || hardLimitReached,
+            requestLimitReached,
+            pageLimitReached,
+        },
     });
 }
 
@@ -1302,49 +1386,454 @@ function progressOptions(title = "Searching packages...") {
     };
 }
 
-async function mapWithConcurrency(items, concurrency, worker, shouldContinue) {
-    const results = new Array(items.length);
-    let nextIndex = 0;
-    const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
-        while (shouldContinue()) {
-            const index = nextIndex;
-            nextIndex += 1;
-            if (index >= items.length) {
-                return;
-            }
-            results[index] = await worker(items[index], index);
-            if (!shouldContinue()) {
-                return;
-            }
+function createRepositorySearchRun(descriptor) {
+    const repositories = descriptor.repositories.map((repository, index) => ({
+        repository,
+        index,
+        anchor: null,
+        complete: false,
+        failed: false,
+        pagesFetched: 0,
+        itemCount: 0,
+        uniqueCount: 0,
+    }));
+    return {
+        descriptor,
+        repositories,
+        queue: repositories.map(repository => ({ repositoryIndex: repository.index, page: 1 })),
+        nextQueueIndex: 0,
+        requestCount: 0,
+        successfulPageCount: 0,
+        records: [],
+        identities: new Map(),
+        failureRepositories: new Set(),
+        failureDetails: [],
+        firstFailureKind: null,
+        cancelled: false,
+        stale: false,
+        circuitOpen: false,
+        rateLimited: false,
+        requestLimitReached: false,
+        pageLimitReached: false,
+        resultLimitReached: false,
+        internalFailure: false,
+    };
+}
+
+async function runRepositorySearchWorkers(options) {
+    const workers = Array.from(
+        { length: MULTI_REPO_CONCURRENCY },
+        () => runRepositorySearchWorker(options)
+    );
+    const outcomes = await Promise.allSettled(workers);
+    if (outcomes.some(outcome => outcome.status === "rejected")) {
+        options.run.internalFailure = true;
+        options.run.circuitOpen = true;
+        if (!options.run.firstFailureKind) options.run.firstFailureKind = "unexpected";
+    }
+}
+
+async function runRepositorySearchWorker(options) {
+    const workerState = { repository: null };
+    try {
+        await runRepositorySearchWorkerLoop(options, workerState);
+    } catch {
+        options.run.circuitOpen = true;
+        if (workerState.repository) {
+            recordRepositoryFailure(
+                options.run,
+                workerState.repository,
+                "unexpected",
+                "The repository result could not be processed safely."
+            );
+        } else {
+            options.run.internalFailure = true;
+            if (!options.run.firstFailureKind) options.run.firstFailureKind = "unexpected";
         }
-    });
-    await Promise.all(workers);
-    return results;
+    }
 }
 
-function failedRepositoryResult(repository, error) {
-    return Object.freeze({ repository, error, stale: false });
+async function runRepositorySearchWorkerLoop(options, workerState) {
+    const { run, operation, pageSize, paginatedFetch, token, isCurrent } = options;
+    while (true) {
+        workerState.repository = null;
+        const task = reserveRepositoryTask(run, token, isCurrent);
+        if (!task) return;
+        const repositoryState = run.repositories[task.repositoryIndex];
+        workerState.repository = repositoryState;
+        let endpoint;
+        try {
+            endpoint = apiEndpoint([
+                "packages",
+                run.descriptor.workspace,
+                repositoryState.repository,
+            ]);
+        } catch {
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                "invalid_request",
+                "The repository identifier was invalid."
+            );
+            continue;
+        }
+
+        let result;
+        try {
+            result = await paginatedFetch.fetchPage(
+                endpoint,
+                task.page,
+                pageSize,
+                run.descriptor.query,
+                {
+                    cancellationToken: token,
+                    retry: "never",
+                    signal: operation.controller.signal,
+                    validate: isPackageSearchArray,
+                }
+            );
+        } catch {
+            if (!isCurrent()) {
+                run.stale = true;
+                return;
+            }
+            if (token?.isCancellationRequested) {
+                run.cancelled = true;
+                return;
+            }
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                "unexpected",
+                "The repository request failed unexpectedly."
+            );
+            continue;
+        }
+
+        if (!isCurrent()) {
+            run.stale = true;
+            return;
+        }
+        if (token?.isCancellationRequested) {
+            run.cancelled = true;
+            return;
+        }
+        if (result?.error) {
+            if (result.error.kind === "cancelled") {
+                run.cancelled = true;
+                return;
+            }
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                result.error.kind || "search_failed",
+                formatApiError(result.error)
+            );
+            if (result.error.kind === "rate_limited" || result.error.status === 429) {
+                run.rateLimited = true;
+                run.circuitOpen = true;
+            }
+            continue;
+        }
+
+        const validation = validateRepositoryPage(result, task, repositoryState, pageSize);
+        if (!validation.ok) {
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                "invalid_response",
+                validation.message
+            );
+            continue;
+        }
+        if (!hasExactPackageScope(result.data, {
+            kind: "repository",
+            workspace: run.descriptor.workspace,
+            repository: repositoryState.repository,
+        })) {
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                "invalid_response",
+                "Cloudsmith returned packages outside the requested repository."
+            );
+            continue;
+        }
+
+        let duplicateKind = null;
+        const pageIdentities = new Map();
+        const pageRecords = [];
+        for (let itemIndex = 0; itemIndex < result.data.length; itemIndex += 1) {
+            const canonicalPackage = canonicalizeSearchPackage(result.data[itemIndex]);
+            if (!canonicalPackage) {
+                duplicateKind = "malformed";
+                break;
+            }
+            const key = packageKey(canonicalPackage);
+            const signature = packageIdentitySignature(canonicalPackage);
+            const existing = run.identities.get(key);
+            const pageSignature = pageIdentities.get(key);
+            if (existing || pageSignature) {
+                duplicateKind = (existing ? existing.signature : pageSignature) === signature
+                    ? "duplicate"
+                    : "collision";
+                break;
+            }
+            pageIdentities.set(key, signature);
+            pageRecords.push({
+                repositoryIndex: repositoryState.index,
+                page: task.page,
+                itemIndex,
+                package: canonicalPackage,
+                key,
+                signature,
+            });
+        }
+
+        if (duplicateKind) {
+            const messages = {
+                collision: "Cloudsmith returned conflicting records for one package identity.",
+                duplicate: "Cloudsmith repeated a package identity across result pages.",
+                malformed: "Cloudsmith returned an invalid package record.",
+            };
+            recordRepositoryFailure(
+                run,
+                repositoryState,
+                duplicateKind === "duplicate" ? "pagination_no_progress" : "invalid_response",
+                messages[duplicateKind]
+            );
+            continue;
+        }
+
+        run.successfulPageCount += 1;
+        repositoryState.pagesFetched = task.page;
+        repositoryState.itemCount += result.data.length;
+        repositoryState.uniqueCount += pageRecords.length;
+        if (!repositoryState.anchor) repositoryState.anchor = validation.anchor;
+        for (const record of pageRecords) {
+            run.identities.set(record.key, {
+                signature: record.signature,
+                repositoryIndex: repositoryState.index,
+            });
+            run.records.push({
+                repositoryIndex: record.repositoryIndex,
+                page: record.page,
+                itemIndex: record.itemIndex,
+                package: record.package,
+            });
+        }
+
+        if (run.identities.size >= MAX_RESULTS) {
+            run.resultLimitReached = true;
+        }
+
+        if (task.page >= validation.anchor.pageTotal) {
+            if (
+                validation.anchor.countAuthoritative
+                && repositoryState.itemCount !== validation.anchor.count
+            ) {
+                recordRepositoryFailure(
+                    run,
+                    repositoryState,
+                    "invalid_response",
+                    "Cloudsmith pagination did not match its authoritative result count."
+                );
+                continue;
+            }
+            repositoryState.complete = true;
+            continue;
+        }
+
+        if (task.page >= MAX_MULTI_REPO_PAGES) {
+            run.pageLimitReached = true;
+            continue;
+        }
+        if (!run.circuitOpen && !run.resultLimitReached) {
+            run.queue.push({ repositoryIndex: repositoryState.index, page: task.page + 1 });
+        }
+    }
 }
 
-function staleRepositoryResult(repository) {
-    return Object.freeze({ repository, error: null, stale: true });
+function reserveRepositoryTask(run, token, isCurrent) {
+    if (!isCurrent()) {
+        run.stale = true;
+        return null;
+    }
+    if (token?.isCancellationRequested) {
+        run.cancelled = true;
+        return null;
+    }
+    if (run.circuitOpen || run.resultLimitReached) return null;
+    if (run.requestCount >= MAX_MULTI_REPO_REQUESTS) {
+        if (run.nextQueueIndex < run.queue.length) run.requestLimitReached = true;
+        return null;
+    }
+    if (run.nextQueueIndex >= run.queue.length) return null;
+
+    const task = run.queue[run.nextQueueIndex];
+    run.nextQueueIndex += 1;
+    run.requestCount += 1;
+    return task;
 }
 
-function localSearchError(kind, message) {
-    return Object.freeze({
-        kind,
-        status: null,
-        retryable: false,
-        message,
-        requestId: null,
-        retryAfterMs: null,
-        outcomeUnknown: false,
-        diagnostic: Object.freeze({}),
-    });
+function validateRepositoryPage(result, task, repositoryState, requestedPageSize) {
+    if (!result || !Array.isArray(result.data) || !result.pagination) {
+        return { ok: false, message: "Cloudsmith returned an invalid result page." };
+    }
+    const pagination = result.pagination;
+    const countAuthoritative = pagination.countAuthoritative === true
+        || (pagination.countAuthoritative === undefined && Number.isSafeInteger(pagination.count));
+    if (
+        pagination.page !== task.page
+        || !Number.isSafeInteger(pagination.pageTotal)
+        || pagination.pageTotal < task.page
+        || !Number.isSafeInteger(pagination.pageSize)
+        || pagination.pageSize < 1
+        || pagination.pageSize > requestedPageSize
+        || result.data.length > pagination.pageSize
+        || (countAuthoritative && (!Number.isSafeInteger(pagination.count) || pagination.count < 0))
+        || (!countAuthoritative && pagination.count !== null && pagination.count !== undefined)
+    ) {
+        return { ok: false, message: "Cloudsmith returned invalid pagination metadata." };
+    }
+
+    const anchor = {
+        pageTotal: pagination.pageTotal,
+        pageSize: pagination.pageSize,
+        count: countAuthoritative ? pagination.count : null,
+        countAuthoritative,
+    };
+    if (repositoryState.anchor && (
+        repositoryState.anchor.pageTotal !== anchor.pageTotal
+        || repositoryState.anchor.pageSize !== anchor.pageSize
+        || repositoryState.anchor.count !== anchor.count
+        || repositoryState.anchor.countAuthoritative !== anchor.countAuthoritative
+    )) {
+        return { ok: false, message: "Cloudsmith changed pagination metadata between pages." };
+    }
+    if (task.page !== repositoryState.pagesFetched + 1) {
+        return { ok: false, message: "Cloudsmith repeated or skipped a repository result page." };
+    }
+    if (countAuthoritative) {
+        const calculatedPages = Math.max(1, Math.ceil(anchor.count / anchor.pageSize));
+        if (calculatedPages !== anchor.pageTotal) {
+            return { ok: false, message: "Cloudsmith returned contradictory pagination metadata." };
+        }
+        const expectedItems = task.page < anchor.pageTotal
+            ? anchor.pageSize
+            : anchor.count - ((task.page - 1) * anchor.pageSize);
+        if (expectedItems < 0 || expectedItems > anchor.pageSize || result.data.length !== expectedItems) {
+            return { ok: false, message: "Cloudsmith returned a page with contradictory cardinality." };
+        }
+    } else if (task.page < anchor.pageTotal && result.data.length !== anchor.pageSize) {
+        return { ok: false, message: "Cloudsmith returned a short page before the final page." };
+    }
+    return { ok: true, anchor };
+}
+
+function packageIdentitySignature(pkg) {
+    return JSON.stringify([
+        pkg.namespace,
+        pkg.repository,
+        pkg.slug_perm,
+        pkg.name,
+        pkg.format,
+        pkg.version,
+    ]);
+}
+
+function recordRepositoryFailure(run, repositoryState, kind, message) {
+    repositoryState.failed = true;
+    repositoryState.complete = false;
+    if (!run.failureRepositories.has(repositoryState.index)) {
+        run.failureRepositories.add(repositoryState.index);
+        if (run.failureDetails.length < MAX_FAILURE_DETAILS) {
+            run.failureDetails.push({ repository: repositoryState.repository, message });
+        }
+    }
+    if (!run.firstFailureKind) run.firstFailureKind = kind;
+}
+
+function finalizeRepositorySearchRun(run) {
+    run.records.sort((left, right) => (
+        left.repositoryIndex - right.repositoryIndex
+        || left.page - right.page
+        || left.itemIndex - right.itemIndex
+    ));
+    const packages = run.records.slice(0, MAX_RESULTS).map(record => record.package);
+    const droppedResultCount = Math.max(0, run.records.length - packages.length);
+    const unsearched = run.repositories.filter(repository => (
+        !repository.failed && repository.pagesFetched === 0
+    ));
+    const truncated = run.repositories.filter(repository => (
+        !repository.failed && !repository.complete && repository.pagesFetched > 0
+    ));
+    const truncationDetails = truncated.slice(0, MAX_FAILURE_DETAILS).map(repository => ({
+        repository: repository.repository,
+        loadedCount: repository.uniqueCount,
+        totalCount: repository.anchor?.countAuthoritative
+            ? repository.anchor.count
+            : null,
+        page: repository.pagesFetched,
+        pageTotal: repository.anchor?.pageTotal || repository.pagesFetched,
+    }));
+    const totalCount = boundedCountSum(run.repositories.map(repository => (
+        repository.anchor?.countAuthoritative ? repository.anchor.count : repository.uniqueCount
+    )));
+    const truncatedResultCount = boundedCountSum(truncated.map(repository => (
+        repository.anchor?.countAuthoritative
+            ? Math.max(0, repository.anchor.count - repository.uniqueCount)
+            : 0
+    )));
+    const resultLimitReached = droppedResultCount > 0 || (
+        run.resultLimitReached
+        && run.repositories.some(repository => !repository.complete && !repository.failed)
+    );
+    const complete = run.failureRepositories.size === 0
+        && !run.internalFailure
+        && unsearched.length === 0
+        && truncated.length === 0
+        && !run.requestLimitReached
+        && !run.pageLimitReached
+        && !resultLimitReached;
+    return {
+        packages,
+        droppedResultCount,
+        complete,
+        successfulPageCount: run.successfulPageCount,
+        failedRepositoryCount: run.failureRepositories.size,
+        failureDetails: run.failureDetails,
+        firstFailureKind: run.firstFailureKind,
+        unsearchedRepositoryCount: unsearched.length,
+        truncatedRepositoryCount: truncated.length,
+        truncationDetails,
+        truncatedResultCount,
+        totalCount,
+        requestCount: run.requestCount,
+        pageCount: run.successfulPageCount,
+        rateLimited: run.rateLimited,
+        requestLimitReached: run.requestLimitReached,
+        pageLimitReached: run.pageLimitReached,
+        resultLimitReached,
+    };
 }
 
 function safeErrorMessage() {
     return "The operation failed unexpectedly. Retry the search.";
+}
+
+function isRetryablePageFailure(error) {
+    return Boolean(
+        error
+        && typeof error === "object"
+        && (
+            error.retryable === true
+            || error.kind === "rate_limited"
+            || error.kind === "network_error"
+            || error.kind === "timeout"
+            || error.kind === "server_error"
+        )
+    );
 }
 
 function boundedCountSum(counts) {
@@ -1370,15 +1859,24 @@ function summaryNode(committed) {
     }
     const count = committed.totalCount;
     const loadedCount = committed.results.length;
-    const countDescription = descriptor.kind === "repositories" && committed.diagnostics.partial
-        ? count > loadedCount
-            ? `${loadedCount.toLocaleString()} of ${count.toLocaleString()} matching packages loaded (partial)`
-            : `${loadedCount.toLocaleString()} package${loadedCount !== 1 ? "s" : ""} loaded (partial)`
-        : `${count.toLocaleString()} package${count !== 1 ? "s" : ""}`;
+    let countDescription;
+    if (committed.diagnostics.partial) {
+        countDescription = count !== null && count > loadedCount
+            ? `${loadedCount.toLocaleString()} of ${count.toLocaleString()} known matching packages loaded (incomplete)`
+            : `${loadedCount.toLocaleString()} package${loadedCount !== 1 ? "s" : ""} loaded (incomplete)`;
+    } else if (count !== null && committed.pageable) {
+        countDescription = `${loadedCount.toLocaleString()} of ${count.toLocaleString()} matching packages loaded`;
+    } else if (count !== null) {
+        countDescription = `${count.toLocaleString()} package${count !== 1 ? "s" : ""}`;
+    } else if (committed.pageable) {
+        countDescription = `${loadedCount.toLocaleString()} package${loadedCount !== 1 ? "s" : ""} loaded (more available)`;
+    } else {
+        countDescription = `${loadedCount.toLocaleString()} package${loadedCount !== 1 ? "s" : ""} loaded`;
+    }
     return new InfoNode(
         `Results for: ${descriptor.query}`,
         `${countDescription} in ${scopeLabel}`,
-        `Query: ${descriptor.query}\n${tooltipScope}${committed.diagnostics.partial ? "\nPartial results" : ""}`,
+        `Query: ${descriptor.query}\n${tooltipScope}${committed.diagnostics.partial ? "\nIncomplete results" : ""}`,
         "search",
         "searchSummary"
     );
@@ -1411,26 +1909,36 @@ function diagnosticNodes(committed) {
     if (diagnostics.unsearchedRepositoryCount > 0) {
         nodes.push(new InfoNode(
             `${diagnostics.unsearchedRepositoryCount} repositories were not searched`,
-            `The search stopped before scheduling them to stay within the ${MAX_RESULTS.toLocaleString()}-item work budget.`,
+            "The search stopped before their next request could be scheduled.",
             "Refine the query or select fewer repositories to search every selected repository.",
             "info"
         ));
     }
     if (diagnostics.truncatedRepositoryCount > 0) {
         const details = diagnostics.truncationDetails
-            .map(detail => (
-                `${detail.repository}: loaded ${detail.loadedCount.toLocaleString()} of `
-                + `${detail.totalCount.toLocaleString()} matches `
-                + `(page ${detail.page} of ${detail.pageTotal})`
-            ))
+            .map(detail => {
+                const count = Number.isSafeInteger(detail.totalCount)
+                    ? ` of ${detail.totalCount.toLocaleString()}`
+                    : "";
+                return `${detail.repository}: loaded ${detail.loadedCount.toLocaleString()}${count} matches `
+                    + `(page ${detail.page} of ${detail.pageTotal})`;
+            })
             .join("\n");
         const omitted = diagnostics.truncatedRepositoryCount - diagnostics.truncationDetails.length;
         const suffix = omitted > 0 ? `\n…and ${omitted} more.` : "";
         nodes.push(new InfoNode(
-            `${diagnostics.truncatedRepositoryCount} repositories have additional matching pages`,
+            `${diagnostics.truncatedRepositoryCount} repositories were not fully searched`,
             `${details}${suffix}`,
-            "Multi-repository search loads only the first page from each repository. Refine the query to avoid omitted matches.",
+            "The search stopped at a page, request, result, or rate-limit boundary. Refine the query to avoid omitted matches.",
             "info"
+        ));
+    }
+    if (diagnostics.rateLimited) {
+        nodes.push(new InfoNode(
+            "Search stopped after rate limiting",
+            "No further repository requests were scheduled after Cloudsmith returned HTTP 429.",
+            "Successful repository pages were preserved, but the result is incomplete.",
+            "warning"
         ));
     }
     if (diagnostics.droppedResultCount > 0) {
@@ -1438,6 +1946,16 @@ function diagnosticNodes(committed) {
             `${diagnostics.droppedResultCount} results were omitted`,
             `Only the first ${MAX_RESULTS.toLocaleString()} results are retained.`,
             "Refine the search query to see omitted results.",
+            "info"
+        ));
+    } else if (
+        (diagnostics.pageLimitReached || diagnostics.requestLimitReached)
+        && diagnostics.truncatedRepositoryCount === 0
+    ) {
+        nodes.push(new InfoNode(
+            "Search loading limit reached",
+            `${committed.results.length.toLocaleString()} results were retained; more results may exist.`,
+            "Refine the search query before loading more pages.",
             "info"
         ));
     } else if (diagnostics.capReached && diagnostics.truncatedRepositoryCount === 0) {

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -35,6 +35,15 @@ class UpstreamDetailProvider {
       const fetchState = await this._fetchGroupedUpstreams(workspace, repoSlug, abortController.signal);
 
       if (!fetchState) {
+        if (this._canRender(panel, requestId) && !abortController.signal.aborted) {
+          panel.webview.html = this._getHtmlContent(workspace, repoSlug, repoName, {
+            groupedUpstreams: new Map(),
+            failedFormats: SUPPORTED_UPSTREAM_FORMATS,
+            uninspectedFormats: [],
+            successfulFormats: 0,
+            complete: false,
+          });
+        }
         return;
       }
 
@@ -79,7 +88,10 @@ class UpstreamDetailProvider {
   }
 
   async _fetchGroupedUpstreams(workspace, repoSlug, signal) {
-    const upstreamData = await getAllUpstreamData(this.context, workspace, repoSlug, { signal });
+    const upstreamData = await getAllUpstreamData(this.context, workspace, repoSlug, {
+      signal,
+      bypassCache: true,
+    });
     if (upstreamData === null || signal.aborted) {
       return null;
     }
@@ -113,10 +125,14 @@ class UpstreamDetailProvider {
     return {
       groupedUpstreams: grouped,
       failedFormats: Array.isArray(upstreamData.failedFormats) ? upstreamData.failedFormats : [],
+      uninspectedFormats: Array.isArray(upstreamData.uninspectedFormats)
+        ? upstreamData.uninspectedFormats
+        : [],
       successfulFormats: typeof upstreamData.successfulFormats === "number"
         ? upstreamData.successfulFormats
         : 0,
-      };
+      complete: upstreamData.complete === true,
+    };
   }
   _abortInFlightRequest() {
     if (this._abortController) {
@@ -172,10 +188,16 @@ class UpstreamDetailProvider {
   }
 
   _getHtmlContent(workspace, repoSlug, repoName, fetchState) {
-    const { groupedUpstreams, failedFormats, successfulFormats } = fetchState;
+    const {
+      groupedUpstreams,
+      failedFormats = [],
+      uninspectedFormats = [],
+      successfulFormats,
+    } = fetchState;
     const formatSections = [];
     const hasLoadedUpstreams = groupedUpstreams.size > 0;
-    const hasFailures = failedFormats.length > 0;
+    const unavailableFormats = [...new Set([...failedFormats, ...uninspectedFormats])];
+    const hasFailures = unavailableFormats.length > 0 || fetchState.complete === false;
 
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
       const upstreams = groupedUpstreams.get(format);
@@ -192,8 +214,16 @@ class UpstreamDetailProvider {
 </section>`);
     }
 
+    const partialWarning = hasLoadedUpstreams && hasFailures
+      ? `<div class="error-state">
+  <span class="error-state-title">Some upstream data could not be loaded.</span>
+  Loaded upstreams are shown, but configuration for ${this._escape(
+    unavailableFormats.length > 0 ? unavailableFormats.join(", ") : "one or more formats"
+  )} is incomplete.
+</div>`
+      : "";
     const contentHtml = hasLoadedUpstreams
-      ? formatSections.join("\n")
+      ? `${partialWarning}${formatSections.join("\n")}`
       : this._getEmptyOrErrorState(hasFailures, successfulFormats);
 
     return `<!DOCTYPE html>
@@ -541,6 +571,11 @@ class UpstreamDetailProvider {
       this._panel.dispose();
       this._panel = null;
     }
+  }
+
+
+  resetForAccountChange() {
+    this.dispose();
   }
 }
 

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -1,8 +1,14 @@
 const vscode = require("vscode");
 const { getAllUpstreamData } = require("../util/upstreamChecker");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
+const {
+  formatUpstreamOrigin,
+  formatUpstreamText,
+} = require("../util/upstreamPresentation");
 
 const SUPPORTED_FORMATS = SUPPORTED_UPSTREAM_FORMATS;
+const MAX_RENDERED_UPSTREAMS = 200;
+const MAX_DISTRIBUTION_VERSIONS = 20;
 
 class UpstreamDetailProvider {
   constructor(context) {
@@ -29,7 +35,7 @@ class UpstreamDetailProvider {
         return;
       }
 
-      panel.title = `Upstreams: ${repoName}`;
+      panel.title = `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`;
       panel.webview.html = this._getLoadingHtml(workspace, repoSlug, repoName);
 
       const fetchState = await this._fetchGroupedUpstreams(workspace, repoSlug, abortController.signal);
@@ -51,7 +57,7 @@ class UpstreamDetailProvider {
         return;
       }
 
-      panel.title = `Upstreams: ${repoName}`;
+      panel.title = `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`;
       panel.webview.html = this._getHtmlContent(workspace, repoSlug, repoName, fetchState);
     } finally {
       if (this._abortController === abortController) {
@@ -68,7 +74,7 @@ class UpstreamDetailProvider {
 
     const panel = vscode.window.createWebviewPanel(
       "cloudsmithUpstreams",
-      `Upstreams: ${repoName}`,
+      `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`,
       vscode.ViewColumn.One,
       {
         enableScripts: false,
@@ -198,6 +204,8 @@ class UpstreamDetailProvider {
     const hasLoadedUpstreams = groupedUpstreams.size > 0;
     const unavailableFormats = [...new Set([...failedFormats, ...uninspectedFormats])];
     const hasFailures = unavailableFormats.length > 0 || fetchState.complete === false;
+    let renderedCount = 0;
+    let loadedCount = 0;
 
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
       const upstreams = groupedUpstreams.get(format);
@@ -205,7 +213,12 @@ class UpstreamDetailProvider {
         continue;
       }
 
-      const cards = upstreams.map((upstream) => this._renderUpstreamCard(upstream)).join("\n");
+      loadedCount += upstreams.length;
+      const remaining = Math.max(0, MAX_RENDERED_UPSTREAMS - renderedCount);
+      const displayed = upstreams.slice(0, remaining);
+      renderedCount += displayed.length;
+      if (displayed.length === 0) continue;
+      const cards = displayed.map((upstream) => this._renderUpstreamCard(upstream)).join("\n");
       formatSections.push(`<section class="format-group">
   <div class="format-header">${this._escape(format)}</div>
   <div class="card-list">
@@ -222,8 +235,11 @@ class UpstreamDetailProvider {
   )} is incomplete.
 </div>`
       : "";
+    const displayLimitNotice = loadedCount > renderedCount
+      ? `<p class="subtle">Showing ${renderedCount} of ${loadedCount} loaded upstreams.</p>`
+      : "";
     const contentHtml = hasLoadedUpstreams
-      ? `${partialWarning}${formatSections.join("\n")}`
+      ? `${partialWarning}${displayLimitNotice}${formatSections.join("\n")}`
       : this._getEmptyOrErrorState(hasFailures, successfulFormats);
 
     return `<!DOCTYPE html>
@@ -399,7 +415,7 @@ class UpstreamDetailProvider {
     const statusClass = isActive ? "status-badge-active" : "status-badge-inactive";
 
     const details = [
-      this._renderDetail("URL", upstream.upstream_url, "mono"),
+      this._renderDetail("Origin", formatUpstreamOrigin(upstream.upstream_url), "mono"),
       this._renderDetail("Mode", typeof upstream.mode === "string" ? upstream.mode : "", ""),
       this._renderDetail("Priority", this._getPriority(upstream), ""),
       this._renderDetail("SSL verification", this._getSslVerification(upstream), ""),
@@ -413,7 +429,7 @@ class UpstreamDetailProvider {
 
     return `<article class="upstream-card">
   <div class="card-header">
-    <div class="card-title">${this._escape(typeof upstream.name === "string" && upstream.name ? upstream.name : "Unnamed")}</div>
+    <div class="card-title">${this._escape(formatUpstreamText(upstream.name, "Unnamed"))}</div>
     <span class="status-badge ${statusClass}">${this._escape(statusLabel)}</span>
   </div>
   <div class="details-grid">
@@ -424,12 +440,11 @@ class UpstreamDetailProvider {
   }
 
   _renderDetail(label, value, valueClass) {
-    if (!value) {
-      return "";
-    }
+    const displayValue = formatUpstreamText(value);
+    if (!displayValue) return "";
 
     const className = valueClass ? `detail-value ${valueClass}` : "detail-value";
-    return `<div class="detail-label">${label}</div><div class="${className}">${this._escape(value)}</div>`;
+    return `<div class="detail-label">${label}</div><div class="${className}">${this._escape(displayValue)}</div>`;
   }
 
   _renderTrustDetail(upstream) {
@@ -468,7 +483,7 @@ class UpstreamDetailProvider {
   }
 
   _getIndexingDisplay(upstream) {
-    const indexStatus = typeof upstream.index_status === "string" ? upstream.index_status : "";
+    const indexStatus = formatUpstreamText(upstream.index_status);
     const packageCount = this._formatIndexPackageCount(upstream.index_package_count);
 
     if (!indexStatus && !packageCount) {
@@ -505,8 +520,10 @@ class UpstreamDetailProvider {
       const label = indexPackageCount === 1 ? "package" : "packages";
       return `${indexPackageCount.toLocaleString()} ${label}`;
     }
-    if (typeof indexPackageCount === "string" && indexPackageCount.trim()) {
-      const numericValue = Number(indexPackageCount);
+    if (typeof indexPackageCount === "string") {
+      const displayValue = formatUpstreamText(indexPackageCount);
+      if (!displayValue) return "";
+      const numericValue = Number(displayValue);
       if (Number.isFinite(numericValue)) {
         const label = numericValue === 1 ? "package" : "packages";
         return `${numericValue.toLocaleString()} ${label}`;
@@ -519,31 +536,32 @@ class UpstreamDetailProvider {
     if (typeof upstream.priority === "number" && Number.isFinite(upstream.priority)) {
       return String(upstream.priority);
     }
-    if (typeof upstream.priority === "string" && upstream.priority.trim()) {
-      return upstream.priority;
+    if (typeof upstream.priority === "string") {
+      return formatUpstreamText(upstream.priority);
     }
     return "";
   }
 
   _getDistribution(upstream) {
     if (typeof upstream.distribution === "string" && upstream.distribution) {
-      return upstream.distribution;
+      return formatUpstreamText(upstream.distribution);
     }
     if (Array.isArray(upstream.distro_versions) && upstream.distro_versions.length > 0) {
-      return upstream.distro_versions.join(", ");
+      const versions = upstream.distro_versions
+        .slice(0, MAX_DISTRIBUTION_VERSIONS)
+        .map(value => formatUpstreamText(value))
+        .filter(Boolean);
+      if (versions.length === 0) return "";
+      return `${versions.join(", ")}${upstream.distro_versions.length > versions.length ? ", …" : ""}`;
     }
     if (typeof upstream.upstream_distribution === "string" && upstream.upstream_distribution) {
-      return upstream.upstream_distribution;
+      return formatUpstreamText(upstream.upstream_distribution);
     }
     return "";
   }
 
   _escape(value) {
-    if (value == null) {
-      return "";
-    }
-
-    return String(value)
+    return formatUpstreamText(value)
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
@@ -552,16 +570,17 @@ class UpstreamDetailProvider {
   }
 
   _formatCreatedAt(createdAt) {
-    if (typeof createdAt !== "string" || !createdAt) {
+    const displayValue = formatUpstreamText(createdAt);
+    if (!displayValue) {
       return "";
     }
 
-    const parsed = new Date(createdAt);
+    const parsed = new Date(displayValue);
     if (!Number.isNaN(parsed.getTime())) {
       return parsed.toLocaleDateString();
     }
 
-    return createdAt.slice(0, 10);
+    return displayValue.slice(0, 10);
   }
 
   dispose() {

--- a/views/upstreamPreviewProvider.js
+++ b/views/upstreamPreviewProvider.js
@@ -2,6 +2,14 @@
 // Shows a "what if I pull this?" dry run for packages that don't exist locally.
 
 const vscode = require("vscode");
+const {
+  formatUpstreamError,
+  formatUpstreamOrigin,
+  formatUpstreamText,
+} = require("../util/upstreamPresentation");
+
+const MAX_RENDERED_UPSTREAMS = 100;
+const MAX_PREVIEW_UPSTREAMS = 500;
 
 class UpstreamPreviewProvider {
   constructor(context) {
@@ -21,7 +29,7 @@ class UpstreamPreviewProvider {
 
     this._panel = vscode.window.createWebviewPanel(
       "cloudsmithUpstreamPreview",
-      `Upstream preview: ${result.name}`,
+      `Upstream preview: ${formatUpstreamText(result.name, "Unknown")}`,
       vscode.ViewColumn.One,
       { enableScripts: false, localResourceRoots: [] }
     );
@@ -34,19 +42,45 @@ class UpstreamPreviewProvider {
   }
 
   _getHtmlContent(result) {
-    const upstreamComplete = result.upstreams.complete === true;
-    const localStatus = result.local.error
-      ? `<span class="status-error">Could not verify local package data: ${this._escapeHtml(this._errorMessage(result.local.error))}</span>`
-      : result.local.data
-        ? `<span class="status-found">Found in ${this._escapeHtml(result.repo)} (${this._escapeHtml(result.local.data.status_str || "Unknown")})</span>`
-        : result.local.complete === true
-          ? `<span class="status-missing">Not found in ${this._escapeHtml(result.repo)}</span>`
+    const local = result.local && typeof result.local === "object" ? result.local : {};
+    const upstreamState = result.upstreams && typeof result.upstreams === "object"
+      ? result.upstreams
+      : {};
+    const upstreamData = upstreamState.data && typeof upstreamState.data === "object"
+      ? upstreamState.data
+      : {};
+    const rawConfigs = Array.isArray(upstreamData.configs) ? upstreamData.configs : [];
+    const boundedConfigs = rawConfigs.slice(0, MAX_PREVIEW_UPSTREAMS);
+    const configs = boundedConfigs.filter(isPreviewUpstreamConfig);
+    const metadataConsistent = rawConfigs.length <= MAX_PREVIEW_UPSTREAMS
+      && configs.length === rawConfigs.length
+      && upstreamData.total === configs.length
+      && upstreamData.active === configs.filter(config => config.is_active !== false).length;
+    const displayedConfigs = configs
+      .slice(0, MAX_RENDERED_UPSTREAMS);
+    const loadedTotal = configs.length;
+    const activeTotal = configs.filter(config => config.is_active !== false).length;
+    const localError = local.errorMessage == null
+      ? null
+      : formatUpstreamError(local.errorMessage, "local");
+    const upstreamError = upstreamState.errorMessage == null
+      ? null
+      : formatUpstreamError(upstreamState.errorMessage, "upstream");
+    const upstreamComplete = upstreamState.complete === true
+      && metadataConsistent
+      && upstreamError === null;
+    const localStatus = localError
+      ? `<span class="status-error">Could not verify local package data: ${this._escapeHtml(localError)}</span>`
+      : local.data
+        ? `<span class="status-found">Found in ${this._escapeHtml(formatUpstreamText(result.repo))} (${this._escapeHtml(formatUpstreamText(local.data.status_str, "Unknown"))})</span>`
+        : local.complete === true
+          ? `<span class="status-missing">Not found in ${this._escapeHtml(formatUpstreamText(result.repo))}</span>`
           : '<span class="status-error">Local package status is incomplete.</span>';
 
     let upstreamHtml = "";
-    if (result.upstreams.error) {
-      upstreamHtml = `<p class="error-banner">Could not load upstream data: ${this._escapeHtml(result.upstreams.error)}</p>`;
-    } else if (result.upstreams.data.configs.length === 0) {
+    if (upstreamError) {
+      upstreamHtml = `<p class="error-banner">Could not load upstream data: ${this._escapeHtml(upstreamError)}</p>`;
+    } else if (configs.length === 0) {
       upstreamHtml = upstreamComplete
         ? '<p class="muted">No upstreams configured for this format.</p>'
         : '<p class="error-banner">Upstream inspection is incomplete. Additional upstreams may exist.</p>';
@@ -54,29 +88,32 @@ class UpstreamPreviewProvider {
       if (!upstreamComplete) {
         upstreamHtml += '<p class="error-banner">Upstream inspection is incomplete. The loaded configurations are shown below.</p>';
       }
-      upstreamHtml += '<table class="data-table"><thead><tr><th>Name</th><th>URL</th><th>Status</th></tr></thead><tbody>';
-      for (const u of result.upstreams.data.configs) {
+      upstreamHtml += '<table class="data-table"><thead><tr><th>Name</th><th>Origin</th><th>Status</th></tr></thead><tbody>';
+      for (const u of displayedConfigs) {
         const active = u.is_active !== false;
         const statusClass = active ? "status-active" : "status-inactive";
         const statusLabel = active ? "Active" : "Inactive";
         upstreamHtml += `<tr>
-          <td>${this._escapeHtml(u.name || "Unnamed")}</td>
-          <td class="mono">${this._escapeHtml(u.upstream_url || "")}</td>
+          <td>${this._escapeHtml(formatUpstreamText(u.name, "Unnamed"))}</td>
+          <td class="mono">${this._escapeHtml(formatUpstreamOrigin(u.upstream_url))}</td>
           <td class="${statusClass}">${statusLabel}</td>
         </tr>`;
       }
       upstreamHtml += "</tbody></table>";
+      if (configs.length > displayedConfigs.length) {
+        upstreamHtml += `<p class="muted">Showing ${displayedConfigs.length} of ${configs.length} loaded upstreams.</p>`;
+      }
     }
 
-    const resolutionSummary = result.canResolveViaUpstream
-      ? `<div class="resolution-yes">This package can likely resolve through ${result.upstreams.data.active} active upstream${result.upstreams.data.active === 1 ? "" : "s"}.</div>`
-      : upstreamComplete && !result.upstreams.error
+    const resolutionSummary = activeTotal > 0
+      ? `<div class="resolution-yes">This package can likely resolve through ${activeTotal} active upstream${activeTotal === 1 ? "" : "s"}.</div>`
+      : upstreamComplete && !upstreamError
         ? '<div class="resolution-no">No active upstreams for this format. Upload the package directly.</div>'
         : '<div class="resolution-no">Upstream resolution could not be determined because inspection is incomplete.</div>';
 
     const upstreamHeading = upstreamComplete
-      ? `Upstreams (${result.upstreams.data.active} active of ${result.upstreams.data.total})`
-      : `Loaded upstreams (${result.upstreams.data.active} active of ${result.upstreams.data.total} loaded)`;
+      ? `Upstreams (${activeTotal} active of ${loadedTotal})`
+      : `Loaded upstreams (${activeTotal} active of ${loadedTotal} loaded)`;
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -108,9 +145,9 @@ class UpstreamPreviewProvider {
 <body>
   <h2>Upstream resolution preview</h2>
   <dl class="header-info">
-    <dt>Package</dt><dd>${this._escapeHtml(result.name)}</dd>
-    <dt>Format</dt><dd>${this._escapeHtml(result.format)}</dd>
-    <dt>Target repository</dt><dd>${this._escapeHtml(result.workspace)}/${this._escapeHtml(result.repo)}</dd>
+    <dt>Package</dt><dd>${this._escapeHtml(formatUpstreamText(result.name, "Unknown"))}</dd>
+    <dt>Format</dt><dd>${this._escapeHtml(formatUpstreamText(result.format, "Unknown"))}</dd>
+    <dt>Target repository</dt><dd>${this._escapeHtml(formatUpstreamText(result.workspace, "Unknown"))}/${this._escapeHtml(formatUpstreamText(result.repo, "Unknown"))}</dd>
     <dt>Local status</dt><dd>${localStatus}</dd>
   </dl>
 
@@ -131,12 +168,6 @@ class UpstreamPreviewProvider {
       .replace(/"/g, "&quot;");
   }
 
-  _errorMessage(error) {
-    return error && typeof error === "object" && typeof error.message === "string"
-      ? error.message
-      : String(error || "The local package collection could not be verified.");
-  }
-
   dispose() {
     if (this._panel) {
       this._panel.dispose();
@@ -147,6 +178,16 @@ class UpstreamPreviewProvider {
   resetForAccountChange() {
     this.dispose();
   }
+}
+
+function isPreviewUpstreamConfig(value) {
+  return Boolean(value)
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && typeof value.name === "string"
+    && value.name.length > 0
+    && (value.is_active === undefined || typeof value.is_active === "boolean")
+    && (value.upstream_url === undefined || typeof value.upstream_url === "string");
 }
 
 module.exports = { UpstreamPreviewProvider };

--- a/views/upstreamPreviewProvider.js
+++ b/views/upstreamPreviewProvider.js
@@ -14,6 +14,7 @@ class UpstreamPreviewProvider {
    * @param {Object} result - Output from UpstreamChecker.previewResolution()
    */
   show(result) {
+    if (!result || typeof result !== "object") return;
     if (this._panel) {
       this._panel.dispose();
     }
@@ -33,19 +34,27 @@ class UpstreamPreviewProvider {
   }
 
   _getHtmlContent(result) {
+    const upstreamComplete = result.upstreams.complete === true;
     const localStatus = result.local.error
-      ? `<span class="status-error">Could not load local package data: ${this._escapeHtml(result.local.error)}</span>`
+      ? `<span class="status-error">Could not verify local package data: ${this._escapeHtml(this._errorMessage(result.local.error))}</span>`
       : result.local.data
         ? `<span class="status-found">Found in ${this._escapeHtml(result.repo)} (${this._escapeHtml(result.local.data.status_str || "Unknown")})</span>`
-        : `<span class="status-missing">Not found in ${this._escapeHtml(result.repo)}</span>`;
+        : result.local.complete === true
+          ? `<span class="status-missing">Not found in ${this._escapeHtml(result.repo)}</span>`
+          : '<span class="status-error">Local package status is incomplete.</span>';
 
     let upstreamHtml = "";
     if (result.upstreams.error) {
       upstreamHtml = `<p class="error-banner">Could not load upstream data: ${this._escapeHtml(result.upstreams.error)}</p>`;
     } else if (result.upstreams.data.configs.length === 0) {
-      upstreamHtml = '<p class="muted">No upstreams configured for this format.</p>';
+      upstreamHtml = upstreamComplete
+        ? '<p class="muted">No upstreams configured for this format.</p>'
+        : '<p class="error-banner">Upstream inspection is incomplete. Additional upstreams may exist.</p>';
     } else {
-      upstreamHtml = '<table class="data-table"><thead><tr><th>Name</th><th>URL</th><th>Status</th></tr></thead><tbody>';
+      if (!upstreamComplete) {
+        upstreamHtml += '<p class="error-banner">Upstream inspection is incomplete. The loaded configurations are shown below.</p>';
+      }
+      upstreamHtml += '<table class="data-table"><thead><tr><th>Name</th><th>URL</th><th>Status</th></tr></thead><tbody>';
       for (const u of result.upstreams.data.configs) {
         const active = u.is_active !== false;
         const statusClass = active ? "status-active" : "status-inactive";
@@ -61,7 +70,13 @@ class UpstreamPreviewProvider {
 
     const resolutionSummary = result.canResolveViaUpstream
       ? `<div class="resolution-yes">This package can likely resolve through ${result.upstreams.data.active} active upstream${result.upstreams.data.active === 1 ? "" : "s"}.</div>`
-      : '<div class="resolution-no">No active upstreams for this format. Upload the package directly.</div>';
+      : upstreamComplete && !result.upstreams.error
+        ? '<div class="resolution-no">No active upstreams for this format. Upload the package directly.</div>'
+        : '<div class="resolution-no">Upstream resolution could not be determined because inspection is incomplete.</div>';
+
+    const upstreamHeading = upstreamComplete
+      ? `Upstreams (${result.upstreams.data.active} active of ${result.upstreams.data.total})`
+      : `Loaded upstreams (${result.upstreams.data.active} active of ${result.upstreams.data.total} loaded)`;
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -101,7 +116,7 @@ class UpstreamPreviewProvider {
 
   ${resolutionSummary}
 
-  <h3>Upstreams (${result.upstreams.data.active} active of ${result.upstreams.data.total})</h3>
+  <h3>${upstreamHeading}</h3>
   ${upstreamHtml}
 </body>
 </html>`;
@@ -116,11 +131,21 @@ class UpstreamPreviewProvider {
       .replace(/"/g, "&quot;");
   }
 
+  _errorMessage(error) {
+    return error && typeof error === "object" && typeof error.message === "string"
+      ? error.message
+      : String(error || "The local package collection could not be verified.");
+  }
+
   dispose() {
     if (this._panel) {
       this._panel.dispose();
       this._panel = null;
     }
+  }
+
+  resetForAccountChange() {
+    this.dispose();
   }
 }
 

--- a/views/vulnerabilityProvider.js
+++ b/views/vulnerabilityProvider.js
@@ -7,14 +7,26 @@
 const crypto = require("crypto");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
-const { apiEndpoint } = require("../util/apiEndpoint");
-const { formatApiError } = require("../util/errorFormatter");
 const { fetchPackageVulnerabilities } = require("../util/packageVulnerabilities");
+const { formatApiError } = require("../util/errorFormatter");
+const {
+  captureAccount,
+  isAccountCurrent,
+  resolveConnectionManager,
+} = require("../util/accountOperation");
+const {
+  fetchPackageDecisionLogs,
+  normalizePolicyStatusReason,
+  parsePolicyStatusReason,
+} = require("../util/policyDecisionLogs");
 
 class VulnerabilityProvider {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
     this._panel = null;
+    this._operation = null;
+    this._connectionManager = resolveConnectionManager(context, options.connectionManager);
+    this._cloudsmithAPI = options.cloudsmithAPI || null;
   }
 
   /**
@@ -47,12 +59,15 @@ class VulnerabilityProvider {
       version = typeof version.value === "object" ? version.value.value : version.value;
     }
 
-    const statusReason = item.status_reason || null;
+    const statusReason = normalizePolicyStatusReason(item.status_reason);
 
     if (!workspace || !repo || !slugPerm) {
       vscode.window.showWarningMessage("Could not determine package details.");
       return;
     }
+
+    const account = captureAccount(this._connectionManager);
+    if (!account || !isAccountCurrent(this._connectionManager, account)) return;
 
     // Create or reveal the WebView panel
     if (this._panel) {
@@ -67,6 +82,8 @@ class VulnerabilityProvider {
     );
     this._panel = panel;
     const requestController = new AbortController();
+    const operation = { account, controller: requestController, panel };
+    this._operation = operation;
     const nonce = this._getNonce();
 
     panel.onDidDispose(() => {
@@ -74,13 +91,14 @@ class VulnerabilityProvider {
       if (this._panel === panel) {
         this._panel = null;
       }
+      if (this._operation === operation) this._operation = null;
     });
 
     // Show loading state
     panel.webview.html = this._getLoadingHtml(name, version);
 
     // Fetch vulnerability data and policy decision logs in parallel
-    const cloudsmithAPI = new CloudsmithAPI(this.context);
+    const cloudsmithAPI = this._cloudsmithAPI || new CloudsmithAPI(this.context);
     const [vulnData, policyTrace] = await Promise.all([
       this._fetchVulnerabilities(cloudsmithAPI, workspace, repo, slugPerm, requestController.signal),
       this._fetchPolicyDecisionTrace(
@@ -92,7 +110,7 @@ class VulnerabilityProvider {
       ),
     ]);
 
-    if (this._panel !== panel) {
+    if (!this._isOperationCurrent(operation)) {
       return;
     }
 
@@ -107,14 +125,17 @@ class VulnerabilityProvider {
 
     // Handle messages from the WebView
     panel.webview.onDidReceiveMessage(async (message) => {
+      if (!this._isOperationCurrent(operation)) return;
       if (message.command === "findSafeVersion") {
-        vscode.commands.executeCommand("cloudsmith-vsc.findSafeVersion", item);
+        await vscode.commands.executeCommand("cloudsmith-vsc.findSafeVersion", item);
       } else if (message.command === "explainQuarantine") {
-        vscode.commands.executeCommand("cloudsmith-vsc.explainQuarantine", item);
+        await vscode.commands.executeCommand("cloudsmith-vsc.explainQuarantine", item);
       } else if (message.command === "copyReport") {
-        const report = this._buildPlainTextReport(name, version, vulnData.results);
+        const report = this._buildPlainTextReport(name, version, vulnData.results, vulnData);
         await vscode.env.clipboard.writeText(report);
-        vscode.window.showInformationMessage("Vulnerability report copied.");
+        if (this._isOperationCurrent(operation)) {
+          vscode.window.showInformationMessage("Vulnerability report copied.");
+        }
       } else if (message.command === "openExternal" && message.url) {
         const validatedUrl = this._validateNvdReference(message.url);
         if (validatedUrl) {
@@ -149,52 +170,30 @@ class VulnerabilityProvider {
     const trace = {
       parsedReason: null,
       decisionLogs: [],
+      decisionLogsComplete: false,
+      decisionLogsPartial: false,
+      decisionLogsIncomplete: true,
+      decisionLogsFailureCount: 0,
     };
 
     // Parse the status_reason field if present
-    if (statusReason) {
-      // Format: "Quarantined by {PolicyName}. {Description}. (Policy: {slug})"
-      const policyMatch = statusReason.match(/Quarantined by (.+?)\.(.+?)(?:\(Policy:\s*(.+?)\))?$/);
-      if (policyMatch) {
-        trace.parsedReason = {
-          policyName: policyMatch[1].trim(),
-          description: policyMatch[2].trim(),
-          policySlug: policyMatch[3] ? policyMatch[3].trim() : null,
-        };
-      } else {
-        trace.parsedReason = { raw: statusReason };
-      }
-    }
+    trace.parsedReason = parsePolicyStatusReason(statusReason);
 
     // Fetch decision logs from v2 API
     try {
-      const endpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"], {
-        query: { page_size: 100 },
-      });
-      const logsResult = await cloudsmithAPI.getV2(endpoint, {
-        responseType: "json",
-        validate: isArrayOrResultsEnvelope,
-        retry: "never",
+      const logsResult = await fetchPackageDecisionLogs(cloudsmithAPI, workspace, slugPerm, {
         signal,
       });
-
-      if (logsResult.ok) {
-        const logs = Array.isArray(logsResult.data) ? logsResult.data : logsResult.data.results;
-        // Filter for entries matching this package
-        trace.decisionLogs = logs.filter(entry => {
-          if (entry.package && entry.package.identifier === slugPerm) {
-            return true;
-          }
-          if (entry.package_slug_perm === slugPerm) {
-            return true;
-          }
-          return false;
-        });
-      } else if (logsResult.error.kind !== "cancelled") {
-        console.warn(`[Vulnerabilities] Policy decision logs unavailable: ${formatApiError(logsResult.error)}`);
-      }
-    } catch (error) { // eslint-disable-line no-unused-vars
-      // v2 policy decision log endpoint may not be available
+      trace.decisionLogs = [...logsResult.items];
+      trace.decisionLogsComplete = logsResult.complete;
+      trace.decisionLogsPartial = logsResult.partial;
+      trace.decisionLogsIncomplete = logsResult.incomplete;
+      trace.decisionLogsFailureCount = logsResult.failureCount;
+    } catch {
+      trace.decisionLogsComplete = false;
+      trace.decisionLogsPartial = false;
+      trace.decisionLogsIncomplete = true;
+      trace.decisionLogsFailureCount = 1;
     }
 
     return trace;
@@ -267,7 +266,10 @@ class VulnerabilityProvider {
     }
 
     const errorHtml = loadError
-      ? `<div class="error-banner"><strong>Could not load vulnerability data:</strong> ${this._esc(loadError)}</div>`
+      ? `<div class="error-banner"><strong>Could not load vulnerability data:</strong> ${this._esc(this._loadErrorMessage(loadError))}</div>`
+      : "";
+    const policyLogsHtml = policyTrace && policyTrace.decisionLogsComplete === false
+      ? `<div class="warning-banner"><strong>Policy history is incomplete.</strong> Some decision log entries could not be loaded.</div>`
       : "";
 
     // Compact quarantine notice — full policy trace is in the dedicated Explain Quarantine panel
@@ -355,6 +357,7 @@ class VulnerabilityProvider {
   .decision-log-table th, .decision-log-table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--vscode-panel-border); }
   .decision-log-table th { font-size: 0.9em; color: var(--vscode-descriptionForeground); }
   .error-banner { background: var(--vscode-inputValidation-errorBackground, rgba(255,0,0,0.08)); border: 1px solid var(--vscode-inputValidation-errorBorder, #c42b1c); color: var(--vscode-errorForeground); border-radius: 4px; padding: 10px 12px; margin-bottom: 16px; }
+  .warning-banner { background: var(--vscode-inputValidation-warningBackground, rgba(255,200,0,0.08)); border: 1px solid var(--vscode-inputValidation-warningBorder, #c8a000); border-radius: 4px; padding: 10px 12px; margin-bottom: 16px; }
 </style>
 </head>
 <body>
@@ -365,6 +368,7 @@ class VulnerabilityProvider {
     Max severity: ${severityBadge(maxSeverity)}
   </div>
   ${errorHtml}
+  ${policyLogsHtml}
   ${statusReasonHtml}
 
   <div class="actions">
@@ -413,10 +417,15 @@ class VulnerabilityProvider {
   /**
    * Build a plain-text CVE report for clipboard.
    */
-  _buildPlainTextReport(name, version, results) {
+  _buildPlainTextReport(name, version, results, collection = {}) {
     const lines = [];
     lines.push(`Vulnerability report: ${name} ${version || ""}`);
-    lines.push(`Total: ${results.length} vulnerabilit${results.length === 1 ? "y" : "ies"}`);
+    if (collection.complete === true) {
+      lines.push(`Total: ${results.length} vulnerabilit${results.length === 1 ? "y" : "ies"}`);
+    } else {
+      lines.push(`Loaded details: ${results.length} vulnerabilit${results.length === 1 ? "y" : "ies"}`);
+      lines.push("Completeness: Incomplete — the total vulnerability count could not be determined.");
+    }
     lines.push("=".repeat(60));
     lines.push("");
 
@@ -491,23 +500,36 @@ class VulnerabilityProvider {
     return crypto.randomBytes(16).toString("hex");
   }
 
+  _loadErrorMessage(error) {
+    const message = error && typeof error === "object"
+      ? formatApiError(error)
+      : String(error || "Vulnerability data could not be loaded.");
+    const normalized = message.replace(/[\r\n\t]+/g, " ").trim();
+    return normalized.length <= 512 ? normalized : `${normalized.slice(0, 511)}…`;
+  }
+
+  _isOperationCurrent(operation) {
+    return Boolean(
+      operation
+      && this._operation === operation
+      && this._panel === operation.panel
+      && !operation.controller.signal.aborted
+      && isAccountCurrent(this._connectionManager, operation.account)
+    );
+  }
+
+  resetForAccountChange() {
+    const operation = this._operation;
+    this._operation = null;
+    if (operation) operation.controller.abort();
+    const panel = this._panel;
+    this._panel = null;
+    if (panel) panel.dispose();
+  }
+
   dispose() {
-    if (this._panel) {
-      this._panel.dispose();
-      this._panel = null;
-    }
+    this.resetForAccountChange();
   }
-}
-
-function isRecord(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function isArrayOrResultsEnvelope(value) {
-  if (Array.isArray(value)) {
-    return value.every(isRecord);
-  }
-  return isRecord(value) && Array.isArray(value.results) && value.results.every(isRecord);
 }
 
 module.exports = { VulnerabilityProvider };


### PR DESCRIPTION
## Summary

- Normalize upstream preview failures into bounded public messages before rendering.
- Show only parsed upstream origins in tooltips and webviews, with fail-closed handling for malformed URLs.
- Remove registry request URLs from outward pull results and omit unsafe upstream URLs from generated Terraform.
- Bound upstream presentation output and harden generated Terraform against template and comment injection.

## Validation

- `npm run lint` passed with one existing warning.
- `npm test` passed: 951 passing, 7 skipped, 0 failing.
- `npm run build` passed.
- `npm audit --omit=dev` passed with 0 vulnerabilities.
- `git diff --check` passed.
- VSIX packaging and content validation passed.
