### PR TITLE
fix: make upstream inventory reliable

### DIFF
--- a/models/repositoryNode.js
+++ b/models/repositoryNode.js
@@ -1,3 +1,5 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 // Repo node treeview
 
 const vscode = require("vscode");
@@ -674,7 +676,7 @@ class RepositoryNode {
         upstreamState = null;
       }
       if (!this._isMetadataCurrent(account, generation, descriptor)) return [];
-      if (upstreamState?.upstreams.length > 0) {
+      if (upstreamState) {
         children.push(new UpstreamIndicatorNode(
           upstreamState.upstreams,
           {
@@ -686,21 +688,12 @@ class RepositoryNode {
           {
             complete: upstreamState.complete,
             failedFormats: upstreamState.failedFormats,
+            failures: upstreamState.failures,
+            unsupportedFormats: upstreamState.unsupportedFormats,
             uninspectedFormats: upstreamState.uninspectedFormats,
           }
         ));
-      } else if (upstreamState && !upstreamState.complete) {
-        const unavailableCount = upstreamState.failedFormats.length
-          + upstreamState.uninspectedFormats.length;
-        children.push(new InfoNode(
-          "Upstreams: incomplete",
-          unavailableCount > 0
-            ? `${unavailableCount} formats could not be loaded`
-            : "The collection could not be verified",
-          "The configured upstream total could not be determined.",
-          "warning"
-        ));
-      } else if (!upstreamState) {
+      } else {
         children.push(new InfoNode(
           "Upstreams: failed to load",
           "The upstream collection could not be verified",
@@ -1181,10 +1174,21 @@ function normalizeUpstreamState(result) {
   const uninspectedFormats = Array.isArray(result.uninspectedFormats)
     ? [...result.uninspectedFormats]
     : [];
+  const failures = Array.isArray(result.failures) ? [...result.failures] : [];
+  const unsupportedFormats = Array.isArray(result.unsupportedFormats)
+    ? [...result.unsupportedFormats]
+    : [];
   return Object.freeze({
     upstreams: Object.freeze([...result.upstreams]),
     failedFormats: Object.freeze(failedFormats),
+    failures: Object.freeze(failures),
+    unsupportedFormats: Object.freeze(unsupportedFormats),
     uninspectedFormats: Object.freeze(uninspectedFormats),
+    configuredTotal: Number.isSafeInteger(result.configuredTotal)
+      ? result.configuredTotal
+      : null,
+    loadedCount: result.upstreams.length,
+    state: typeof result.state === "string" ? result.state : "failed",
     complete: result.complete === true
       && failedFormats.length === 0
       && uninspectedFormats.length === 0,
@@ -1195,7 +1199,12 @@ function emptyUpstreamState() {
   return Object.freeze({
     upstreams: Object.freeze([]),
     failedFormats: Object.freeze([]),
+    failures: Object.freeze([]),
+    unsupportedFormats: Object.freeze([]),
     uninspectedFormats: Object.freeze([]),
+    configuredTotal: null,
+    loadedCount: 0,
+    state: "cancelled",
     complete: false,
   });
 }

--- a/models/upstreamIndicatorNode.js
+++ b/models/upstreamIndicatorNode.js
@@ -1,8 +1,11 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 // Upstream indicator node treeview.
 // Appears at the top of a repository's package list when upstream sources are configured.
 
 const vscode = require("vscode");
 const {
+    formatUpstreamFailureCategory,
     formatUpstreamOrigin,
     formatUpstreamText,
 } = require("../util/upstreamPresentation");
@@ -19,6 +22,10 @@ class UpstreamIndicatorNode {
         this.uninspectedFormats = Array.isArray(options.uninspectedFormats)
             ? options.uninspectedFormats.filter(format => typeof format === "string")
             : [];
+        this.failures = Array.isArray(options.failures) ? options.failures : [];
+        this.unsupportedFormats = Array.isArray(options.unsupportedFormats)
+            ? options.unsupportedFormats.filter(format => typeof format === "string")
+            : [];
         this.complete = options.complete === true
             && this.failedFormats.length === 0
             && this.uninspectedFormats.length === 0;
@@ -32,19 +39,40 @@ class UpstreamIndicatorNode {
         const active = this.upstreams.filter(u => u.is_active !== false).length;
         const partial = !this.complete;
         const label = partial
-            ? `Upstreams: ${active} active among ${count} loaded (partial)`
-            : `Upstreams: ${active} active of ${count} configured`;
+            ? count > 0
+                ? `Upstreams: ${active} active among ${count} loaded (partial)`
+                : "Upstreams: incomplete"
+            : count > 0
+                ? `Upstreams: ${active} active of ${count} configured`
+                : "Upstreams: none configured";
         const unavailableFormats = [...new Set([
             ...this.failedFormats,
             ...this.uninspectedFormats,
         ])];
+        const safeFailureLines = this.failures.slice(0, 20).map(failure => (
+            `${formatUpstreamText(failure.format, "unknown")} — ${formatUpstreamFailureCategory(
+                failure.category
+            )}`
+        ));
         const failureDetail = unavailableFormats.length > 0
-            ? `\nCould not load formats: ${unavailableFormats.join(", ")}`
+            ? `\nCould not inspect:\n${safeFailureLines.length > 0
+                ? safeFailureLines.join("\n")
+                : unavailableFormats.join(", ")}`
             : partial ? "\nThe configured total could not be verified." : "";
+        const unsupportedDetail = this.unsupportedFormats.length > 0
+            ? `\nNot applicable to the upstream API: ${this.unsupportedFormats.join(", ")}`
+            : "";
 
         const displayedUpstreams = this.upstreams.slice(0, MAX_TOOLTIP_UPSTREAMS);
         const loadedUpstreamDetail = displayedUpstreams.map((upstream) => (
-            `${formatUpstreamText(upstream.name, "Unnamed")} (${formatUpstreamOrigin(upstream.upstream_url)})`
+            `${formatUpstreamText(upstream.name, "Unnamed")} (${formatUpstreamText(
+                formatUpstreamOrigin(
+                    typeof upstream.origin === "string" && upstream.origin
+                        ? upstream.origin
+                        : upstream.upstream_url
+                ),
+                "Origin unavailable"
+            )})`
         )).join("\n");
         const omittedDetail = this.upstreams.length > displayedUpstreams.length
             ? `\nShowing ${displayedUpstreams.length} of ${this.upstreams.length} loaded upstreams.`
@@ -52,7 +80,7 @@ class UpstreamIndicatorNode {
 
         return {
             label,
-            tooltip: `${loadedUpstreamDetail}${omittedDetail}${failureDetail}`,
+            tooltip: `${loadedUpstreamDetail}${omittedDetail}${failureDetail}${unsupportedDetail}`,
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "upstreamIndicator",
             iconPath: new vscode.ThemeIcon('cloud'),

--- a/models/upstreamIndicatorNode.js
+++ b/models/upstreamIndicatorNode.js
@@ -23,9 +23,6 @@ class UpstreamIndicatorNode {
             ? options.uninspectedFormats.filter(format => typeof format === "string")
             : [];
         this.failures = Array.isArray(options.failures) ? options.failures : [];
-        this.unsupportedFormats = Array.isArray(options.unsupportedFormats)
-            ? options.unsupportedFormats.filter(format => typeof format === "string")
-            : [];
         this.complete = options.complete === true
             && this.failedFormats.length === 0
             && this.uninspectedFormats.length === 0;
@@ -59,10 +56,6 @@ class UpstreamIndicatorNode {
                 ? safeFailureLines.join("\n")
                 : unavailableFormats.join(", ")}`
             : partial ? "\nThe configured total could not be verified." : "";
-        const unsupportedDetail = this.unsupportedFormats.length > 0
-            ? `\nNot applicable to the upstream API: ${this.unsupportedFormats.join(", ")}`
-            : "";
-
         const displayedUpstreams = this.upstreams.slice(0, MAX_TOOLTIP_UPSTREAMS);
         const loadedUpstreamDetail = displayedUpstreams.map((upstream) => (
             `${formatUpstreamText(upstream.name, "Unnamed")} (${formatUpstreamText(
@@ -80,7 +73,7 @@ class UpstreamIndicatorNode {
 
         return {
             label,
-            tooltip: `${loadedUpstreamDetail}${omittedDetail}${failureDetail}${unsupportedDetail}`,
+            tooltip: `${loadedUpstreamDetail}${omittedDetail}${failureDetail}`,
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "upstreamIndicator",
             iconPath: new vscode.ThemeIcon('cloud'),

--- a/models/upstreamIndicatorNode.js
+++ b/models/upstreamIndicatorNode.js
@@ -60,9 +60,7 @@ class UpstreamIndicatorNode {
         const loadedUpstreamDetail = displayedUpstreams.map((upstream) => (
             `${formatUpstreamText(upstream.name, "Unnamed")} (${formatUpstreamText(
                 formatUpstreamOrigin(
-                    typeof upstream.origin === "string" && upstream.origin
-                        ? upstream.origin
-                        : upstream.upstream_url
+                    upstream.origin
                 ),
                 "Origin unavailable"
             )})`

--- a/test/apiResultHelpers.js
+++ b/test/apiResultHelpers.js
@@ -1,9 +1,17 @@
 function apiSuccess(data, options = {}) {
+  const defaultHeaders = Array.isArray(data) && data.length > 0
+    ? {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-count": String(data.length),
+        "x-pagination-pagesize": "100",
+      }
+    : {};
   return {
     ok: true,
     data,
     status: options.status || 200,
-    headers: options.headers || {},
+    headers: options.headers || defaultHeaders,
     requestId: options.requestId || "test-request-id",
     serverRequestId: null,
     attempts: options.attempts || 1,

--- a/test/integration/upstreams.test.js
+++ b/test/integration/upstreams.test.js
@@ -1,0 +1,56 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const assert = require("assert");
+const RepositoryNode = require("../../models/repositoryNode");
+const UpstreamIndicatorNode = require("../../models/upstreamIndicatorNode");
+const { liveFixture } = require("./setup");
+
+suite("Live integration: upstream inventory production path", function () {
+  this.timeout(60_000);
+
+  test("settles the RepositoryNode inventory with canonical safe outcomes", async () => {
+    const repository = process.env.CLOUDSMITH_TEST_UPSTREAM_REPOSITORY
+      || liveFixture.repository;
+    const context = {
+      secrets: {
+        async get() { return liveFixture.apiKey; },
+      },
+      globalState: {
+        get() { return undefined; },
+        async update() {},
+      },
+    };
+    const connectionManager = {
+      activationId: "live-upstream-contract",
+      getState() {
+        return {
+          activationId: this.activationId,
+          accountEpoch: 1,
+          sessionConnected: true,
+          status: "connected",
+        };
+      },
+    };
+    const node = new RepositoryNode(
+      { slug: repository, slug_perm: repository, name: repository },
+      liveFixture.workspace,
+      context,
+      { connectionManager }
+    );
+    node.getPackages = async () => [{ format: "python" }];
+    node._packageState = { ...node._packageState, pageCount: 1 };
+
+    const children = await node.getChildren();
+    const indicator = children.find(child => child instanceof UpstreamIndicatorNode);
+
+    assert.ok(indicator, "Production path did not publish a settled upstream summary");
+    assert.ok(["boolean"].includes(typeof indicator.complete));
+    assert.strictEqual(new Set(indicator.upstreams.map(upstream => (
+      `${upstream.format}\0${upstream.slug_perm || upstream.name}`
+    ))).size, indicator.upstreams.length);
+    const serialized = JSON.stringify(indicator.upstreams);
+    for (const forbidden of ["auth_secret", "extra_value_1", "extra_value_2", "Authorization"]) {
+      assert.strictEqual(serialized.includes(forbidden), false);
+    }
+  });
+});

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -322,6 +322,80 @@ suite("RepositoryNode Test Suite", () => {
     assert.strictEqual(children[0].getTreeItem().label, "Upstreams: 1 active of 1 configured");
   });
 
+  test("loads upstreams through the exact RepositoryNode production aggregation path", async () => {
+    let upstreamRequests = 0;
+    CloudsmithAPI.prototype.get = async (endpoint) => {
+      if (!endpoint.includes("/upstream/")) {
+        throw new Error("Unexpected non-upstream transport request");
+      }
+      upstreamRequests += 1;
+      if (endpoint.includes("/upstream/python/")) {
+        return apiSuccess([{
+          name: "PyPI",
+          slug_perm: "pypi",
+          upstream_url: "https://pypi.org/simple",
+          auth_username: null,
+          index_package_count: null,
+          is_active: true,
+        }]);
+      }
+      return apiSuccess([]);
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "production-repo", slug_perm: "production-repo", name: "Production Repo" },
+      "acme",
+      context,
+      { connectionManager }
+    );
+    repositoryNode.getPackages = async () => [{ format: "python" }];
+    repositoryNode._packageState = { ...repositoryNode._packageState, pageCount: 1 };
+
+    const children = await repositoryNode.getChildren();
+
+    assert.strictEqual(upstreamRequests, 20);
+    assert.ok(children[0] instanceof UpstreamIndicatorNode);
+    assert.strictEqual(children[0].complete, true);
+    assert.strictEqual(children[0].upstreams.length, 1);
+    assert.strictEqual(children[0].upstreams[0].slug_perm, "pypi");
+    assert.strictEqual(children[0].upstreams[0].origin, "https://pypi.org");
+  });
+
+  test("retains production-path upstream data when another format fails", async () => {
+    CloudsmithAPI.prototype.get = async (endpoint) => {
+      if (endpoint.includes("/upstream/python/")) {
+        return apiSuccess([{
+          name: "PyPI",
+          slug_perm: "pypi",
+          upstream_url: "https://pypi.org/simple",
+          is_active: true,
+        }]);
+      }
+      if (endpoint.includes("/upstream/npm/")) {
+        return apiFailure("permission", { status: 403 });
+      }
+      return apiSuccess([]);
+    };
+    const repositoryNode = new RepositoryNode(
+      { slug: "partial-repo", slug_perm: "partial-repo", name: "Partial Repo" },
+      "acme",
+      context,
+      { connectionManager }
+    );
+    repositoryNode.getPackages = async () => [{ format: "python" }];
+    repositoryNode._packageState = { ...repositoryNode._packageState, pageCount: 1 };
+
+    const children = await repositoryNode.getChildren();
+    const indicator = children.find(child => child instanceof UpstreamIndicatorNode);
+
+    assert.ok(indicator);
+    assert.strictEqual(indicator.complete, false);
+    assert.strictEqual(indicator.upstreams.length, 1);
+    assert.strictEqual(indicator.failures[0].format, "npm");
+    assert.strictEqual(indicator.failures[0].category, "permission");
+    assert.ok(indicator.getTreeItem().label.includes("partial"));
+    assert.ok(!indicator.getTreeItem().label.includes("configured"));
+  });
+
   test("repository packages do not expose vulnerability nodes for clean npm and Python scans", async () => {
     const packageBase = {
       namespace: "acme",
@@ -1245,7 +1319,8 @@ suite("RepositoryNode Test Suite", () => {
     );
     const item = indicator.getTreeItem();
     assert.strictEqual(item.label, "Upstreams: 1 active among 1 loaded (partial)");
-    assert.ok(item.tooltip.includes("Could not load formats: npm"));
+    assert.ok(item.tooltip.includes("Could not inspect:"));
+    assert.ok(item.tooltip.includes("npm"));
     assert.ok(item.tooltip.includes("PyPI (https://pypi.org)"));
     assert.ok(!item.tooltip.includes("user:pass"));
     assert.ok(!item.tooltip.includes("/simple/"));

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -1310,6 +1310,7 @@ suite("RepositoryNode Test Suite", () => {
     const indicator = new UpstreamIndicatorNode(
       [{
         name: "PyPI",
+        origin: "https://pypi.org",
         upstream_url: "https://user:pass@pypi.org/simple/?token=secret#fragment",
         is_active: true,
       }],

--- a/test/repositoryNode.test.js
+++ b/test/repositoryNode.test.js
@@ -1315,12 +1315,18 @@ suite("RepositoryNode Test Suite", () => {
       }],
       {},
       context,
-      { complete: false, failedFormats: ["npm"] }
+      {
+        complete: false,
+        failedFormats: ["npm"],
+        unsupportedFormats: ["terraform"],
+      }
     );
     const item = indicator.getTreeItem();
     assert.strictEqual(item.label, "Upstreams: 1 active among 1 loaded (partial)");
     assert.ok(item.tooltip.includes("Could not inspect:"));
     assert.ok(item.tooltip.includes("npm"));
+    assert.ok(!item.tooltip.includes("Not applicable"));
+    assert.ok(!item.tooltip.includes("terraform"));
     assert.ok(item.tooltip.includes("PyPI (https://pypi.org)"));
     assert.ok(!item.tooltip.includes("user:pass"));
     assert.ok(!item.tooltip.includes("/simple/"));

--- a/test/testInventories.js
+++ b/test/testInventories.js
@@ -20,6 +20,7 @@ const STANDALONE_NODE_TESTS = Object.freeze([
   "test/searchQueryBuilder.test.js",
   "test/testHelpers.test.js",
   "test/testInventories.test.js",
+  "test/upstreamFormats.test.js",
   "test/upstreamOperationScheduler.test.js",
   "test/upstreamPresentation.test.js",
   "test/webAppUrls.test.js",
@@ -82,6 +83,7 @@ const VSCODE_SMOKE_TESTS = Object.freeze([
 
 const LIVE_TESTS = Object.freeze([
   "test/integration/search.test.js",
+  "test/integration/upstreams.test.js",
   "test/integration/vulnerabilities.test.js",
 ]);
 

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -7,6 +7,7 @@ const {
   getUpstreamCacheKey,
   isBenignUpstreamFormatError,
   MAX_RUNTIME_UPSTREAMS_PER_FORMAT,
+  sanitizeSafeInventoryUpstream,
   SUPPORTED_UPSTREAM_FORMATS,
   UpstreamChecker,
   UPSTREAM_CACHE_SCHEMA_VERSION,
@@ -123,7 +124,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       successfulFormats: 1,
       groupedUpstreams: {
         python: [
-          { name: "PyPI", _format: "python", format: "python" },
+          { name: "PyPI", _format: "python", format: "python", origin: "https://pypi.org" },
         ],
       },
       ...overrides,
@@ -411,6 +412,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
           name: "PyPI",
           _format: "python",
           format: "python",
+          origin: "https://pypi.org",
           is_active: true,
         },
       ],
@@ -550,6 +552,8 @@ suite("UpstreamChecker shared helper and format handling", () => {
     assert.strictEqual(updates[0].value.accountEpoch, 1);
     assert.strictEqual(JSON.stringify(updates[0].value).includes("url-secret"), false);
     assert.strictEqual(JSON.stringify(updates[0].value).includes("nested-secret"), false);
+    const redacted = updates[0].value.upstreams.find(upstream => upstream.name === "PyPI");
+    assert.strictEqual(redacted.origin, "");
 
     const secondState = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
@@ -741,14 +745,14 @@ suite("UpstreamChecker shared helper and format handling", () => {
     for (const poisoned of [
       createCachedEntry({
         upstreams: [
-          { name: "PyPI", _format: "python", format: "python", is_active: true },
-          { name: "PyPI", _format: "python", format: "python", is_active: true },
+          { name: "PyPI", _format: "python", format: "python", origin: "", is_active: true },
+          { name: "PyPI", _format: "python", format: "python", origin: "", is_active: true },
         ],
         active: 2,
         total: 2,
       }),
       createCachedEntry({
-        upstreams: [{ name: "PyPI", _format: "python", format: "npm", is_active: true }],
+        upstreams: [{ name: "PyPI", _format: "python", format: "npm", origin: "", is_active: true }],
       }),
       createCachedEntry({ active: 0 }),
     ]) {
@@ -761,10 +765,10 @@ suite("UpstreamChecker shared helper and format handling", () => {
   test("rejects duplicate and format-conflicting upstream records", async () => {
     const { checker } = createResponseAwareChecker(createContext().context, {
       python: [
-        { name: "PyPI", format: "python" },
-        { name: "PyPI", format: "python" },
+        { name: "PyPI", format: "python", upstream_url: "https://pypi.org" },
+        { name: "PyPI", format: "python", upstream_url: "https://pypi.org" },
       ],
-      npm: [{ name: "npmjs", format: "python" }],
+      npm: [{ name: "npmjs", format: "python", upstream_url: "https://npmjs.org" }],
     });
 
     const duplicate = await checker.getUpstreamDataForFormats(
@@ -778,7 +782,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
       ["npm"]
     );
 
-    assert.deepStrictEqual(duplicate.upstreams, []);
+    assert.deepStrictEqual(duplicate.upstreams.map(upstream => upstream.name), ["PyPI"]);
     assert.deepStrictEqual(duplicate.failedFormats, ["python"]);
     assert.strictEqual(duplicate.complete, false);
     assert.deepStrictEqual(conflicting.failedFormats, ["npm"]);
@@ -793,6 +797,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
         name: "PyPI",
         _format: "python",
         format: "python",
+        origin: "https://pypi.org",
         mode: { token: "nested-secret" },
         is_active: true,
       }],
@@ -809,7 +814,9 @@ suite("UpstreamChecker shared helper and format handling", () => {
     const { checker } = createResponseAwareChecker(context, {});
     const cacheKey = getUpstreamCacheKey("workspace-a", "repo-a");
     store.set(cacheKey, createCachedEntry({
-      upstreams: [{ name: "x".repeat(501), _format: "python", format: "python" }],
+      upstreams: [{
+        name: "x".repeat(501), _format: "python", format: "python", origin: "",
+      }],
     }));
 
     await checker.getAllUpstreamData("workspace-a", "repo-a");
@@ -947,6 +954,164 @@ suite("UpstreamChecker shared helper and format handling", () => {
     for (const secret of ["password", "token=secret", "auth_secret", "extra_value_1"]) {
       assert.strictEqual(serialized.includes(secret), false);
     }
+  });
+
+  test("creates fresh safe inventory projections from plain own data properties only", () => {
+    const source = Object.assign(Object.create(null), {
+      name: "PyPI",
+      _format: "python",
+      format: "python",
+      origin: "",
+      verify_ssl: false,
+      priority: 0,
+      distro_versions: ["3.12"],
+    });
+    const sanitized = sanitizeSafeInventoryUpstream(source, "python");
+
+    assert.ok(sanitized);
+    assert.notStrictEqual(sanitized, source);
+    assert.strictEqual(Object.getPrototypeOf(sanitized), Object.prototype);
+    assert.ok(Object.isFrozen(sanitized));
+    assert.ok(Object.isFrozen(sanitized.distro_versions));
+    assert.notStrictEqual(sanitized.distro_versions, source.distro_versions);
+    assert.strictEqual(sanitized.origin, "");
+
+    const inherited = Object.create(source);
+    assert.strictEqual(sanitizeSafeInventoryUpstream(inherited, "python"), null);
+
+    let getterReads = 0;
+    const accessor = { ...source };
+    Object.defineProperty(accessor, "name", {
+      enumerable: true,
+      get() {
+        getterReads += 1;
+        return "Accessor PyPI";
+      },
+    });
+    assert.strictEqual(sanitizeSafeInventoryUpstream(accessor, "python"), null);
+    assert.strictEqual(getterReads, 0);
+
+    let proxyReads = 0;
+    const proxy = new Proxy({ ...source }, {
+      get(target, property, receiver) {
+        proxyReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    assert.strictEqual(sanitizeSafeInventoryUpstream(proxy, "python"), null);
+    assert.strictEqual(proxyReads, 0);
+  });
+
+  test("rejects inherited, accessor, and format-conflicting API upstream records", async () => {
+    const inherited = Object.create({
+      name: "Inherited",
+      upstream_url: "https://inherited.example",
+    });
+    const accessor = { upstream_url: "https://accessor.example" };
+    Object.defineProperty(accessor, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("Getter must not execute");
+      },
+    });
+    for (const [repo, record] of [
+      ["inherited", inherited],
+      ["accessor", accessor],
+      ["mismatch", {
+        name: "Wrong format",
+        format: "npm",
+        _format: "npm",
+        upstream_url: "https://mismatch.example",
+      }],
+    ]) {
+      const { checker } = createResponseAwareChecker(createContext().context, {
+        python: [record],
+      });
+      const result = await checker.getUpstreamDataForFormats(
+        "workspace-a", repo, ["python"]
+      );
+      assert.deepStrictEqual(result.upstreams, [], repo);
+      assert.deepStrictEqual(result.failedFormats, ["python"], repo);
+      assert.strictEqual(result.failures[0].category, "invalid_response", repo);
+    }
+  });
+
+  test("preserves the redacted origin sentinel across the v5 cache boundary", async () => {
+    const { context, store } = createContext();
+    const { checker, getRequestCount } = createResponseAwareChecker(context, {
+      python: [{
+        name: "Private PyPI",
+        slug_perm: "private-pypi",
+        upstream_url: "https://user:password@example.com/private?token=secret#signed",
+        priority: "10",
+        verify_ssl: false,
+        index_package_count: 0,
+      }],
+    });
+
+    const cold = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"]
+    );
+    const warm = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["PYTHON"]
+    );
+
+    assert.strictEqual(getRequestCount(), 1);
+    assert.deepStrictEqual(warm.upstreams, cold.upstreams);
+    assert.strictEqual(cold.upstreams[0].origin, "");
+    assert.strictEqual(cold.upstreams[0].priority, "10");
+    const persisted = [...store.values()][0];
+    assert.strictEqual(persisted.version, UPSTREAM_CACHE_SCHEMA_VERSION);
+    assert.strictEqual(persisted.upstreams[0].origin, "");
+    assert.ok(!JSON.stringify(persisted).includes("password"));
+    assert.ok(!JSON.stringify(persisted).includes("token=secret"));
+  });
+
+  test("evicts prior-schema and noncanonical-origin cache entries", async () => {
+    const cases = [
+      createCachedEntry({ version: 4 }),
+      createCachedEntry({ upstreams: [{
+        name: "PyPI", _format: "python", format: "python",
+        origin: "https://user:password@example.com",
+      }] }),
+      createCachedEntry({ upstreams: [{
+        name: "PyPI", _format: "python", format: "python",
+        origin: "https://example.com/path?token=secret#fragment",
+      }] }),
+      createCachedEntry({ upstreams: [{
+        name: "PyPI", _format: "python", format: "python", origin: " ",
+      }] }),
+      createCachedEntry({ upstreams: [{
+        name: "PyPI", _format: "python", format: "python",
+        origin: "", api_key: "secret",
+      }] }),
+    ];
+    for (const [index, cached] of cases.entries()) {
+      const { context, store, updates } = createContext();
+      const { checker } = createResponseAwareChecker(context, {});
+      const key = getUpstreamCacheKey("workspace-a", `repo-${index}`, ["python"]);
+      store.set(key, cached);
+      await checker.getUpstreamDataForFormats(
+        "workspace-a", `repo-${index}`, ["python"]
+      );
+      assert.strictEqual(updates[0].value, undefined, `case ${index}`);
+    }
+  });
+
+  test("repository-state format wrapper validates original identities before canonicalization", async () => {
+    const checker = createChecker({});
+    await assert.rejects(
+      checker.getRepositoryUpstreamStateForFormats(
+        "workspace-a", "repo-a", ["npm", "unknown"]
+      ),
+      /unrecognized format/
+    );
+    await assert.rejects(
+      checker.getRepositoryUpstreamStateForFormats(
+        "workspace-a", "repo-a", ["npm", null]
+      ),
+      /unrecognized format/
+    );
   });
 
   test("does not issue requests for recognized formats without an upstream API", async () => {
@@ -1298,12 +1463,16 @@ suite("UpstreamChecker preview resolution", () => {
       data: [
         {
           name: "PyPI",
-          upstream_url: "https://pypi.org/simple/",
+          format: "python",
+          _format: "python",
+          origin: "https://pypi.org",
           is_active: true,
         },
         {
           name: "Disabled mirror",
-          upstream_url: "https://disabled.example/python",
+          format: "python",
+          _format: "python",
+          origin: "https://disabled.example",
           is_active: false,
         },
       ],
@@ -1330,7 +1499,10 @@ suite("UpstreamChecker preview resolution", () => {
       throw new Error("https://user:pass@example.com/private?token=secret\nprivate stack");
     };
     checker.getUpstreamsForFormat = async () => ({
-      data: [{ name: "PyPI", upstream_url: "https://pypi.org/simple/", is_active: true }],
+      data: [{
+        name: "PyPI", format: "python", _format: "python",
+        origin: "https://pypi.org", is_active: true,
+      }],
       error: null,
       complete: true,
     });
@@ -1358,5 +1530,40 @@ suite("UpstreamChecker preview resolution", () => {
     assert.strictEqual(result.upstreams.errorMessage, "Upstream request failed");
     assert.strictEqual("error" in result.upstreams, false);
     assert.ok(!JSON.stringify(result).includes("private body"));
+  });
+
+  test("previewResolution canonicalizes identity and rejects mismatched configs", async () => {
+    const checker = createChecker({});
+    const formats = [];
+    checker.existsLocally = async (_workspace, _repo, _name, format) => {
+      formats.push(format);
+      return { data: null, error: null, complete: true };
+    };
+    checker.getUpstreamsForFormat = async (_workspace, _repo, format) => {
+      formats.push(format);
+      return {
+        data: [{
+          name: "npmjs",
+          format: "npm",
+          _format: "npm",
+          origin: "https://registry.npmjs.org",
+          is_active: true,
+        }],
+        error: null,
+        complete: true,
+      };
+    };
+
+    const result = await checker.previewResolution(
+      "acme", "repo", "flask", " Python "
+    );
+
+    assert.strictEqual(result.format, "python");
+    assert.deepStrictEqual(formats, ["python", "python"]);
+    assert.deepStrictEqual(result.upstreams.data.configs, []);
+    assert.strictEqual(result.upstreams.data.total, 0);
+    assert.strictEqual(result.upstreams.complete, false);
+    assert.strictEqual(result.canResolveViaUpstream, false);
+    assert.strictEqual(result.upstreams.errorMessage, "Cloudsmith returned invalid upstream data.");
   });
 });

--- a/test/upstreamChecker.test.js
+++ b/test/upstreamChecker.test.js
@@ -12,6 +12,7 @@ const {
   UPSTREAM_CACHE_SCHEMA_VERSION,
 } = require("../util/upstreamChecker");
 const {
+  INSPECTABLE_UPSTREAM_FORMATS,
   SUPPORTED_UPSTREAM_FORMATS: SHARED_SUPPORTED_UPSTREAM_FORMATS,
 } = require("../util/upstreamFormats");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
@@ -83,7 +84,7 @@ suite("UpstreamChecker repository upstream cache", () => {
     CredentialManager.prototype.getApiKey = async () => "test-api-key";
     CloudsmithAPI.prototype.get = async function(endpoint, options = {}) {
       requestCount += 1;
-      const match = endpoint.match(/upstream\/([^/]+)\/$/);
+      const match = endpoint.match(/upstream\/([^/?]+)\/(?:\?.*)?$/);
       const format = match ? match[1] : null;
       const response = formatResponses[format];
 
@@ -162,13 +163,12 @@ suite("UpstreamChecker repository upstream cache", () => {
       docker: [
         { name: "Docker Hub", upstream_url: "https://registry-1.docker.io/" },
       ],
-      conda: apiFailure("not_found", { status: 404 }),
     };
 
     const checker = createChecker(context);
     const firstState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
-    assert.strictEqual(requestCount, SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(requestCount, INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(firstState.total, 6);
     assert.strictEqual(firstState.active, 5);
     assert.deepStrictEqual(firstState.failedFormats, []);
@@ -188,7 +188,7 @@ suite("UpstreamChecker repository upstream cache", () => {
 
     const secondState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
-    assert.strictEqual(requestCount, SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(requestCount, INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(secondState.total, 6);
     assert.strictEqual(secondState.active, 5);
     assert.strictEqual(secondState.groupedUpstreams.get("python")[0].name, "Internal mirror");
@@ -227,13 +227,14 @@ suite("UpstreamChecker repository upstream cache", () => {
     const firstState = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.ok(firstState.failedFormats.includes("npm"));
-    assert.strictEqual(firstState.total, 1);
+    assert.strictEqual(firstState.total, null);
+    assert.strictEqual(firstState.loadedCount, 1);
     assert.strictEqual(firstState.active, 1);
     assert.strictEqual(store.size, 0);
 
     await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
-    assert.strictEqual(requestCount, SUPPORTED_UPSTREAM_FORMATS.length * 2);
+    assert.strictEqual(requestCount, INSPECTABLE_UPSTREAM_FORMATS.length * 2);
     assert.strictEqual(store.size, 0);
   });
 
@@ -244,7 +245,7 @@ suite("UpstreamChecker repository upstream cache", () => {
     const state = await checker.getRepositoryUpstreamState("workspace-a", "repo-a");
 
     assert.strictEqual(state.active, 0);
-    assert.strictEqual(state.total, 0);
+    assert.strictEqual(state.total, null);
     assert.ok(state.failedFormats.includes("python"));
     assert.strictEqual(store.size, 0);
   });
@@ -261,7 +262,7 @@ suite("UpstreamChecker repository upstream cache", () => {
 
     assert.strictEqual(state.complete, false);
     assert.strictEqual(state.active, 0);
-    assert.strictEqual(state.total, 0);
+    assert.strictEqual(state.total, null);
     assert.deepStrictEqual(state.failedFormats, ["python"]);
     assert.strictEqual(store.size, 0);
   });
@@ -362,13 +363,7 @@ suite("UpstreamChecker repository upstream cache", () => {
       assert.strictEqual(state.active, 2);
       assert.deepStrictEqual(state.failedFormats, []);
       assert.strictEqual(store.size, 0);
-      assert.strictEqual(logCalls.length, 1);
-      assert.deepStrictEqual(logCalls[0].slice(0, 3), [
-        "persist",
-        "workspace-a",
-        "repo-a",
-      ]);
-      assert.strictEqual(logCalls[0][3].message, "quota exceeded");
+      assert.strictEqual(logCalls.length, 0);
     } finally {
       context.globalState.update = originalUpdate;
     }
@@ -433,7 +428,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     checker.api.get = async (endpoint) => {
       requestCount += 1;
-      const match = endpoint.match(/upstream\/([^/]+)\/$/);
+      const match = endpoint.match(/upstream\/([^/?]+)\/(?:\?.*)?$/);
       const format = match ? match[1] : null;
       const response = formatResponses[format];
 
@@ -492,10 +487,10 @@ suite("UpstreamChecker shared helper and format handling", () => {
   });
 
   [400, 404, 405, 422].forEach((statusCode) => {
-    test(`${statusCode} is classified as a benign upstream format error`, () => {
+    test(`${statusCode} is not misclassified as an empty upstream result`, () => {
       assert.strictEqual(
         isBenignUpstreamFormatError({ status: statusCode }),
-        true
+        false
       );
     });
   });
@@ -529,12 +524,11 @@ suite("UpstreamChecker shared helper and format handling", () => {
       docker: [
         { name: "Docker Hub", upstream_url: "https://registry-1.docker.io/" },
       ],
-      conda: apiFailure("not_found", { status: 404 }),
     });
 
     const firstState = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
-    assert.strictEqual(getRequestCount(), SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(getRequestCount(), INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(firstState.total, 6);
     assert.strictEqual(firstState.active, 5);
     assert.deepStrictEqual(firstState.failedFormats, []);
@@ -559,7 +553,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     const secondState = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
-    assert.strictEqual(getRequestCount(), SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(getRequestCount(), INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(secondState.total, 6);
     assert.strictEqual(secondState.active, 5);
   });
@@ -582,7 +576,8 @@ suite("UpstreamChecker shared helper and format handling", () => {
     );
 
     assert.deepStrictEqual(firstState.failedFormats, ["npm"]);
-    assert.strictEqual(firstState.total, 1);
+    assert.strictEqual(firstState.total, null);
+    assert.strictEqual(firstState.loadedCount, 1);
     assert.strictEqual(firstState.active, 1);
     assert.strictEqual(updates.length, 0);
 
@@ -644,7 +639,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
       ["python"]
     );
     assert.deepStrictEqual(countResult.failedFormats, ["python"]);
-    assert.strictEqual(countResult.total, 0);
+    assert.strictEqual(countResult.total, null);
     assert.strictEqual(updates.length, 0);
 
     checker.api.get = async (_endpoint, options) => {
@@ -658,7 +653,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
       ["python"]
     );
     assert.deepStrictEqual(fieldResult.failedFormats, ["python"]);
-    assert.strictEqual(fieldResult.total, 0);
+    assert.strictEqual(fieldResult.total, null);
     assert.strictEqual(updates.length, 0);
   });
 
@@ -680,7 +675,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     const state = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
-    assert.strictEqual(getRequestCount(), SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(getRequestCount(), INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(state.total, 0);
     assert.strictEqual(updates[0].key, cacheKey);
     assert.strictEqual(updates[0].value, undefined);
@@ -695,7 +690,7 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     const state = await checker.getAllUpstreamData("workspace-a", "repo-a");
 
-    assert.strictEqual(getRequestCount(), SUPPORTED_UPSTREAM_FORMATS.length);
+    assert.strictEqual(getRequestCount(), INSPECTABLE_UPSTREAM_FORMATS.length);
     assert.strictEqual(state.total, 0);
     assert.strictEqual(updates[0].key, cacheKey);
     assert.strictEqual(updates[0].value, undefined);
@@ -735,7 +730,8 @@ suite("UpstreamChecker shared helper and format handling", () => {
     );
 
     assert.strictEqual(getRequestCount(), 1);
-    assert.strictEqual(result.upstreams[0].upstream_url, "https://pypi.org/simple/");
+    assert.strictEqual(result.upstreams[0].upstream_url, undefined);
+    assert.strictEqual(result.upstreams[0].origin, "https://pypi.org");
   });
 
   test("evicts cached upstream summaries with duplicate, conflicting, or stale derived metadata", async () => {
@@ -917,6 +913,287 @@ suite("UpstreamChecker shared helper and format handling", () => {
 
     assert.strictEqual(await pending, null);
     assert.strictEqual(updates.length, 0);
+  });
+
+  test("accepts documented nullable fields while keeping inventory entries secret-free", async () => {
+    const { checker, getRequestCount } = createResponseAwareChecker({}, {
+      python: [{
+        name: "PyPI",
+        slug_perm: "pypi",
+        upstream_url: "https://user:password@pypi.org/simple?token=secret#signed",
+        auth_username: null,
+        auth_secret: null,
+        extra_header_1: null,
+        extra_value_1: null,
+        index_package_count: null,
+        index_status: null,
+        is_active: true,
+        verify_ssl: false,
+        priority: 0,
+        distro_versions: [],
+      }],
+    });
+
+    const result = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"]
+    );
+
+    assert.strictEqual(getRequestCount(), 1);
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.configuredTotal, 1);
+    assert.strictEqual(result.upstreams[0].slug_perm, "pypi");
+    assert.strictEqual(result.upstreams[0].origin, "");
+    const serialized = JSON.stringify(result);
+    for (const secret of ["password", "token=secret", "auth_secret", "extra_value_1"]) {
+      assert.strictEqual(serialized.includes(secret), false);
+    }
+  });
+
+  test("does not issue requests for recognized formats without an upstream API", async () => {
+    const { checker, getRequestCount } = createResponseAwareChecker({}, {});
+
+    const result = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["cocoapods", "conan", "luarocks", "raw", "terraform", "vagrant"]
+    );
+
+    assert.strictEqual(getRequestCount(), 0);
+    assert.deepStrictEqual(result.unsupportedFormats, [
+      "cocoapods", "conan", "luarocks", "raw", "terraform", "vagrant",
+    ]);
+    assert.deepStrictEqual(result.failedFormats, []);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.configuredTotal, null);
+    assert.strictEqual(result.state, "unsupported");
+  });
+
+  test("normalizes each transport failure category without treating 404 as empty", async () => {
+    const cases = [
+      ["unauthorized", 401, "authentication"],
+      ["forbidden", 403, "permission"],
+      ["not_found", 404, "not_found"],
+      ["timeout", 408, "timeout"],
+      ["rate_limited", 429, "rate_limit"],
+      ["server_error", 503, "server"],
+    ];
+    for (const [kind, status, category] of cases) {
+      const checker = createChecker({}, {
+        cloudsmithAPI: {
+          async get() {
+            const result = apiFailure(kind, { status, requestId: `local-${status}` });
+            result.serverRequestId = `server-${status}`;
+            return result;
+          },
+        },
+      });
+      const result = await checker.getUpstreamDataForFormats(
+        "workspace-a", `repo-${status}`, ["python"]
+      );
+      assert.strictEqual(result.complete, false);
+      assert.strictEqual(result.configuredTotal, null);
+      assert.strictEqual(result.failures[0].category, category);
+      assert.strictEqual(result.failures[0].httpStatus, status);
+      assert.strictEqual(result.failures[0].requestId, `local-${status}`);
+      assert.strictEqual(result.failures[0].serverRequestId, `server-${status}`);
+    }
+  });
+
+  test("collects every validated upstream page and rejects duplicate canonical identities", async () => {
+    const calls = [];
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get(endpoint) {
+          calls.push(endpoint);
+          const page = Number(new URL(`https://api.cloudsmith.io/v1/${endpoint}`).searchParams.get("page"));
+          const data = page === 1
+            ? [{ name: "First", slug_perm: "first", upstream_url: "https://first.example/path" }]
+            : [{ name: "Second", slug_perm: "second", upstream_url: "https://second.example/path" }];
+          return apiSuccess(data, { headers: {
+            "x-pagination-page": String(page),
+            "x-pagination-pagetotal": "2",
+            "x-pagination-count": "2",
+            "x-pagination-pagesize": "1",
+          } });
+        },
+      },
+    });
+
+    const complete = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"]
+    );
+    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(complete.complete, true);
+    assert.deepStrictEqual(complete.upstreams.map(upstream => upstream.slug_perm), ["first", "second"]);
+
+    checker.api.get = async () => apiSuccess([
+      { name: "Duplicate", slug_perm: "same", upstream_url: "https://example.com" },
+      { name: "Other label", slug_perm: "same", upstream_url: "https://example.org" },
+    ]);
+    const duplicate = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-b", ["python"], { bypassCache: true }
+    );
+    assert.deepStrictEqual(duplicate.failedFormats, ["python"]);
+    assert.strictEqual(duplicate.configuredTotal, null);
+  });
+
+  test("keeps headerless non-empty data partial but accepts headerless empty as authoritative", async () => {
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get() {
+          return apiSuccess(
+            [{ name: "PyPI", slug_perm: "pypi", upstream_url: "https://pypi.org/simple" }],
+            { headers: {} }
+          );
+        },
+      },
+    });
+    const partial = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"]
+    );
+    assert.strictEqual(partial.state, "partial");
+    assert.strictEqual(partial.loadedCount, 1);
+    assert.strictEqual(partial.configuredTotal, null);
+
+    checker.api.get = async () => apiSuccess([], { headers: {} });
+    const empty = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-b", ["python"]
+    );
+    assert.strictEqual(empty.state, "empty");
+    assert.strictEqual(empty.configuredTotal, 0);
+  });
+
+  test("bounds aggregate concurrency at four and settles the operation deadline", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get(_endpoint, options) {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise(resolve => setImmediate(resolve));
+          active -= 1;
+          if (options.signal.aborted) return apiFailure("cancelled");
+          return apiSuccess([]);
+        },
+      },
+    });
+    const complete = await checker.getAllUpstreamData("workspace-a", "repo-a");
+    assert.strictEqual(complete.requestCount, INSPECTABLE_UPSTREAM_FORMATS.length);
+    assert.ok(maxActive <= 4);
+
+    checker.api.get = async (_endpoint, options) => new Promise((resolve) => {
+      options.signal.addEventListener("abort", () => resolve(apiFailure("cancelled")), { once: true });
+    });
+    const timed = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-b", ["python", "npm"], { operationTimeoutMs: 5 }
+    );
+    assert.strictEqual(timed.complete, false);
+    assert.deepStrictEqual([...timed.uninspectedFormats].sort(), ["npm", "python"]);
+    assert.ok(timed.failures.every(failure => (
+      failure.category === "timeout" && failure.retryable === true
+    )));
+
+    const controller = new AbortController();
+    checker.api.get = async (_endpoint, options) => new Promise((resolve) => {
+      options.signal.addEventListener("abort", () => resolve(apiFailure("cancelled")), { once: true });
+    });
+    const cancelledPromise = checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-c", ["python"], { signal: controller.signal }
+    );
+    controller.abort();
+    const cancelled = await cancelledPromise;
+    assert.strictEqual(cancelled.state, "cancelled");
+    assert.strictEqual(cancelled.failures[0].category, "cancelled");
+  });
+
+  test("rejects malformed repository and format scopes without claiming empty success", async () => {
+    const checker = createChecker();
+    await assert.rejects(
+      checker.getUpstreamDataForFormats("", "repo-a", ["python"]),
+      /repository identity/
+    );
+    await assert.rejects(
+      checker.getUpstreamDataForFormats("w".repeat(501), "repo-a", ["python"]),
+      /repository identity/
+    );
+    await assert.rejects(
+      checker.getUpstreamDataForFormats("workspace-a", "repo-a", null),
+      /formats must be an array/
+    );
+    await assert.rejects(
+      checker.getUpstreamDataForFormats("workspace-a", "repo-a", ["unknown"]),
+      /unrecognized format/
+    );
+    await assert.rejects(
+      checker.getUpstreamDataForFormats("workspace-a", "repo-a", ["python", "unknown"]),
+      /unrecognized format/
+    );
+    const deliberateEmpty = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", []
+    );
+    assert.strictEqual(deliberateEmpty.state, "empty");
+    const unsupported = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["raw"]
+    );
+    assert.strictEqual(unsupported.state, "unsupported");
+    assert.strictEqual(unsupported.complete, false);
+  });
+
+  test("rejects cross-page upstream pagination drift while retaining verified data", async () => {
+    let page = 0;
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get() {
+          page += 1;
+          return apiSuccess([{
+            name: `Mirror ${page}`,
+            slug_perm: `mirror-${page}`,
+            upstream_url: `https://mirror-${page}.example`,
+          }], {
+            headers: {
+              "x-pagination-page": String(page),
+              "x-pagination-pagetotal": String(page === 1 ? 2 : 3),
+              "x-pagination-count": String(page === 1 ? 2 : 3),
+              "x-pagination-pagesize": "1",
+            },
+          });
+        },
+      },
+    });
+    const result = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"]
+    );
+    assert.strictEqual(result.state, "partial");
+    assert.strictEqual(result.loadedCount, 2);
+    assert.strictEqual(result.failures[0].category, "invalid_response");
+  });
+
+  test("uses one canonical loader for safe and privileged projections", async () => {
+    const endpoints = [];
+    const checker = createChecker({}, {
+      cloudsmithAPI: {
+        async get(endpoint) {
+          endpoints.push(endpoint);
+          return apiSuccess([{
+            name: "Private",
+            slug_perm: "private",
+            upstream_url: "https://user:password@example.com/private?token=secret",
+            auth_username: "user",
+            extra_value_1: "header-secret",
+          }]);
+        },
+      },
+    });
+    const safe = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"], { bypassCache: true }
+    );
+    const privileged = await checker.getUpstreamDataForFormats(
+      "workspace-a", "repo-a", ["python"], { bypassCache: true, projection: "privileged" }
+    );
+    assert.strictEqual(endpoints[0], endpoints[1]);
+    assert.strictEqual(safe.upstreams[0].slug_perm, privileged.upstreams[0].slug_perm);
+    assert.strictEqual(safe.upstreams[0].upstream_url, undefined);
+    assert.strictEqual(privileged.upstreams[0].upstream_url.includes("password"), true);
+    assert.strictEqual(privileged.upstreams[0].extra_value_1, "header-secret");
   });
 });
 

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -117,26 +117,28 @@ suite("UpstreamDetailProvider Test Suite", () => {
     assert.ok(html.length < 20_000);
   });
 
-  test("shows trust level without explanatory trust callouts", () => {
+  test("shows supported trust values as status pills without explanatory copy", () => {
     const provider = new UpstreamDetailProvider({});
     const html = provider._getHtmlContent("acme", "repo", "Repo", {
       groupedUpstreams: new Map([
         ["python", [
           { name: "Trusted source", trust_level: "Trusted" },
           { name: "Untrusted source", trust_level: "Untrusted" },
+          { name: "Future source", trust_level: "Future value" },
         ]],
       ]),
       failedFormats: [],
       uninspectedFormats: [],
       successfulFormats: 20,
-      configuredTotal: 2,
+      configuredTotal: 3,
       complete: true,
       state: "complete",
     });
 
-    assert.ok(html.includes("Trust level"));
-    assert.ok(html.includes("Trusted"));
-    assert.ok(html.includes("Untrusted"));
+    assert.match(html, /status-badge status-badge-trusted">Trusted<\/span>/);
+    assert.match(html, /status-badge status-badge-untrusted">Untrusted<\/span>/);
+    assert.ok(!html.includes("Trust level"));
+    assert.ok(!html.includes("Future value"));
     assert.ok(!html.includes("Trusted upstream:"));
     assert.ok(!html.includes("Untrusted upstream (recommended):"));
     assert.ok(!html.includes("dependency confusion"));

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -1,8 +1,48 @@
 const assert = require("assert");
+const vscode = require("vscode");
 const { UpstreamDetailProvider, SUPPORTED_FORMATS } = require("../views/upstreamDetailProvider");
 const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
+const { formatUpstreamFailureCategory } = require("../util/upstreamPresentation");
 
 suite("UpstreamDetailProvider Test Suite", () => {
+  function aggregate(overrides = {}) {
+    const result = {
+      upstreams: [],
+      failedFormats: [],
+      uninspectedFormats: [],
+      unsupportedFormats: [],
+      failures: [],
+      successfulFormats: 20,
+      configuredTotal: 0,
+      complete: true,
+      state: "empty",
+      ...overrides,
+    };
+    result.upstreams = result.upstreams.map(upstream => ({
+      ...upstream,
+      format: upstream.format || upstream._format,
+      _format: upstream._format || upstream.format,
+    }));
+    result.failures = result.failures.map((failure) => {
+      const category = failure.category || (/permission/i.test(failure.message || "")
+        ? "permission"
+        : /time/i.test(failure.message || "") ? "timeout" : "unknown");
+      return {
+        ...failure,
+        category,
+        message: formatUpstreamFailureCategory(category),
+        retryable: failure.retryable === true,
+      };
+    });
+    return result;
+  }
+
+  function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => { resolve = resolvePromise; });
+    return { promise, resolve };
+  }
+
   test("uses the shared upstream format list", () => {
     assert.strictEqual(SUPPORTED_FORMATS, SUPPORTED_UPSTREAM_FORMATS);
   });
@@ -107,7 +147,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
     });
 
     assert.ok(html.includes("Could not load upstreams."));
-    assert.ok(html.includes("The upstream configuration could not be loaded for this repository."));
+    assert.ok(html.includes("The upstream inventory could not be loaded for this repository."));
   });
 
   test("account reset aborts in-flight work and disposes the panel", () => {
@@ -142,5 +182,359 @@ suite("UpstreamDetailProvider Test Suite", () => {
 
     assert.ok(panel.webview.html.includes("Could not load upstreams."));
     assert.ok(!panel.webview.html.includes("Loading upstreams..."));
+  });
+
+  test("shows safe per-format failures without hiding successful partial cards", async () => {
+    const provider = new UpstreamDetailProvider({});
+    const html = provider._getHtmlContent("acme", "repo", "Repo", {
+      groupedUpstreams: new Map([["python", [{
+        name: "PyPI <script>",
+        origin: "https://pypi.org",
+        is_active: true,
+      }]]]),
+      failedFormats: ["npm"],
+      uninspectedFormats: [],
+      unsupportedFormats: ["terraform"],
+      failures: [{ format: "npm", category: "timeout", message: "The upstream request timed out." }],
+      successfulFormats: 19,
+      configuredTotal: null,
+      complete: false,
+      state: "partial",
+    });
+
+    assert.ok(html.includes("PyPI &lt;script&gt;"));
+    assert.ok(html.includes("npm"));
+    assert.ok(html.includes("timed out"));
+    assert.ok(html.includes("Not applicable to this API: terraform"));
+    assert.ok(html.includes(">Retry<"));
+    assert.ok(/script-src 'nonce-[^']+'/.test(html));
+    assert.ok(!html.includes("[object Object]"));
+  });
+
+  test("coalesces repeated Retry and replaces cards without duplication", async () => {
+    const replacement = deferred();
+    let calls = 0;
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return aggregate({
+            upstreams: [{ name: "Old", format: "python", origin: "https://old.example" }],
+            failedFormats: ["npm"],
+            failures: [{
+              format: "npm",
+              message: "The upstream request timed out.",
+              retryable: true,
+            }],
+            successfulFormats: 19,
+            configuredTotal: null,
+            complete: false,
+            state: "partial",
+          });
+        }
+        return replacement.promise;
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+    await provider.show("acme", "repo", "Repo");
+    const firstRetry = provider.retry();
+    const duplicateRetry = provider.retry();
+    assert.strictEqual(calls, 2);
+    assert.ok(panel.webview.html.includes("Existing results remain visible"));
+    replacement.resolve(aggregate({
+      upstreams: [{ name: "New", format: "npm", origin: "https://new.example" }],
+      configuredTotal: 1,
+      state: "complete",
+    }));
+    await Promise.all([firstRetry, duplicateRetry]);
+    assert.ok(panel.webview.html.includes("New"));
+    assert.ok(panel.webview.html.includes("Old"));
+    assert.strictEqual((panel.webview.html.match(/class="upstream-card"/g) || []).length, 2);
+  });
+
+  test("targets Retry to unavailable formats and retains success per format", async () => {
+    const calls = [];
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async (_workspace, _repo, options) => {
+        calls.push(options);
+        if (calls.length === 1) {
+          return aggregate({
+            upstreams: [{ name: "PyPI", format: "python", _format: "python", origin: "https://pypi.org" }],
+            failedFormats: ["npm"],
+            failures: [{ format: "npm", message: "Timed out.", retryable: true }],
+            successfulFormats: 19,
+            configuredTotal: null,
+            complete: false,
+            state: "partial",
+          });
+        }
+        return aggregate({
+          upstreams: [{ name: "npmjs", format: "npm", _format: "npm", origin: "https://registry.npmjs.org" }],
+          successfulFormats: 1,
+          configuredTotal: 1,
+          complete: true,
+          state: "complete",
+        });
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+    await provider.show("acme", "repo", "Repo");
+    await provider.retry();
+
+    assert.deepStrictEqual(calls[1].formats, ["npm"]);
+    assert.ok(panel.webview.html.includes("PyPI"));
+    assert.ok(panel.webview.html.includes("npmjs"));
+    assert.strictEqual((panel.webview.html.match(/class="upstream-card"/g) || []).length, 2);
+  });
+
+  test("retains a verified format over an incomplete Retry page", async () => {
+    let calls = 0;
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => {
+        calls += 1;
+        if (calls === 1) return aggregate({
+          upstreams: [{ name: "Verified", format: "python", origin: "https://verified.example" }],
+          uninspectedFormats: ["python"],
+          failures: [{ format: "python", category: "timeout", retryable: true }],
+          successfulFormats: 19,
+          configuredTotal: null,
+          complete: false,
+          state: "partial",
+        });
+        return aggregate({
+          upstreams: [{ name: "Partial page", format: "python", origin: "https://partial.example" }],
+          uninspectedFormats: ["python"],
+          failures: [{ format: "python", category: "invalid_response", retryable: false }],
+          successfulFormats: 0,
+          configuredTotal: null,
+          complete: false,
+          state: "partial",
+        });
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+    await provider.show("acme", "repo", "Repo");
+    await provider.retry();
+    assert.ok(panel.webview.html.includes("Verified"));
+    assert.ok(!panel.webview.html.includes("Partial page"));
+    assert.ok(panel.webview.html.includes("Previously verified: python"));
+  });
+
+  test("keeps zero-card Retry partial when other formats were inspected empty", async () => {
+    let calls = 0;
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => {
+        calls += 1;
+        return aggregate({
+          failedFormats: ["npm"],
+          failures: [{ format: "npm", category: "timeout", retryable: true }],
+          successfulFormats: calls === 1 ? 19 : 0,
+          configuredTotal: null,
+          complete: false,
+          state: calls === 1 ? "partial" : "failed",
+        });
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+    await provider.show("acme", "repo", "Repo");
+    await provider.retry();
+    assert.strictEqual(provider._lastSettled.state, "partial");
+    assert.strictEqual(provider._lastSettled.successfulFormats, 19);
+  });
+
+  test("keeps prior successful cards when Retry produces no useful replacement", async () => {
+    let calls = 0;
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return aggregate({
+            upstreams: [{ name: "Existing", format: "python", origin: "https://pypi.org" }],
+            failedFormats: ["npm"],
+            failures: [{
+              format: "npm",
+              message: "The upstream request timed out.",
+              retryable: true,
+            }],
+            successfulFormats: 19,
+            configuredTotal: null,
+            complete: false,
+            state: "partial",
+          });
+        }
+        return aggregate({
+          failedFormats: ["npm"],
+          failures: [{ format: "npm", message: "Permission denied." }],
+          successfulFormats: 0,
+          configuredTotal: null,
+          complete: false,
+          state: "failed",
+        });
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+
+    await provider.show("acme", "repo", "Repo");
+    await provider.retry();
+
+    assert.ok(panel.webview.html.includes("Existing"));
+    assert.ok(panel.webview.html.includes("You do not have permission"));
+    assert.ok(panel.webview.html.includes("Refresh failed; showing the previous verified results."));
+    assert.strictEqual((panel.webview.html.match(/class="upstream-card"/g) || []).length, 1);
+  });
+
+  test("an older repository completion cannot clear or publish over the current load", async () => {
+    const oldLoad = deferred();
+    const currentLoad = deferred();
+    let calls = 0;
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async (_workspace, repoSlug) => {
+        calls += 1;
+        return repoSlug === "old" ? oldLoad.promise : currentLoad.promise;
+      },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+
+    const older = provider.show("acme", "old", "Old");
+    const current = provider.show("acme", "current", "Current");
+    oldLoad.resolve(aggregate({
+      upstreams: [{ name: "Stale", format: "python", origin: "https://stale.example" }],
+      configuredTotal: 1,
+      state: "complete",
+    }));
+    await older;
+
+    const duplicateCurrent = provider.show("acme", "current", "Current");
+    assert.strictEqual(calls, 2);
+    currentLoad.resolve(aggregate({
+      upstreams: [{ name: "Current", format: "python", origin: "https://current.example" }],
+      configuredTotal: 1,
+      state: "complete",
+    }));
+    await Promise.all([current, duplicateCurrent]);
+
+    assert.ok(panel.webview.html.includes("Current"));
+    assert.ok(!panel.webview.html.includes("Stale"));
+  });
+
+  test("settles an unexpected loader throw instead of leaving the loading state", async () => {
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => { throw new Error("https://user:secret@example.com/?token=secret"); },
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+
+    await provider.show("acme", "repo", "Repo");
+
+    assert.ok(panel.webview.html.includes("Could not load upstreams."));
+    assert.ok(!panel.webview.html.includes("Loading upstreams..."));
+    assert.ok(!panel.webview.html.includes("user:secret"));
+    assert.ok(!panel.webview.html.includes("token=secret"));
+  });
+
+  test("fails closed on malformed aggregate contracts", async () => {
+    for (const malformed of [undefined, {}, { upstreams: {} }, {
+      ...aggregate(),
+      complete: true,
+      configuredTotal: null,
+    }, aggregate({
+      upstreams: [{
+        name: "Secret origin",
+        format: "python",
+        origin: "https://user:secret@example.com/?token=secret",
+      }],
+      configuredTotal: 1,
+      state: "complete",
+    }), {
+      ...aggregate({
+        failedFormats: ["npm"],
+        failures: [{
+          format: "npm",
+          category: "timeout",
+          message: "https://user:secret@example.com/?token=secret",
+        }],
+        successfulFormats: 19,
+        configuredTotal: null,
+        complete: false,
+        state: "failed",
+      }),
+      failures: [{
+        format: "npm",
+        category: "timeout",
+        message: "https://user:secret@example.com/?token=secret",
+      }],
+    }]) {
+      const provider = new UpstreamDetailProvider({}, { loadUpstreams: async () => malformed });
+      const panel = { title: "", webview: { html: "" }, reveal() {} };
+      provider._getOrCreatePanel = () => {
+        provider._panel = panel;
+        return panel;
+      };
+      await provider.show("acme", "repo", "Repo");
+      assert.ok(panel.webview.html.includes("Could not load upstreams."));
+      assert.ok(!panel.webview.html.includes("[object Object]"));
+      assert.ok(!panel.webview.html.includes("user:secret"));
+      assert.ok(!panel.webview.html.includes("token=secret"));
+    }
+  });
+
+  test("accepts only the exact Retry message and disposes its listener", () => {
+    const original = vscode.window.createWebviewPanel;
+    let listener;
+    let listenerDisposed = 0;
+    let retries = 0;
+    const panel = {
+      webview: {
+        html: "",
+        onDidReceiveMessage(callback) {
+          listener = callback;
+          return { dispose() { listenerDisposed += 1; } };
+        },
+      },
+      onDidDispose() {},
+      reveal() {},
+      dispose() {},
+    };
+    vscode.window.createWebviewPanel = () => panel;
+    try {
+      const provider = new UpstreamDetailProvider({});
+      provider.retry = () => { retries += 1; };
+      provider._getOrCreatePanel("Repo");
+      listener({ command: "retry", extra: true });
+      listener(Object.defineProperty({}, "command", { get() { throw new Error("hostile"); } }));
+      listener({ command: "retry" });
+      assert.strictEqual(retries, 1);
+      provider.dispose();
+      assert.strictEqual(listenerDisposed, 1);
+    } finally {
+      vscode.window.createWebviewPanel = original;
+    }
   });
 });

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -1,27 +1,44 @@
 const assert = require("assert");
 const vscode = require("vscode");
 const { UpstreamDetailProvider, SUPPORTED_FORMATS } = require("../views/upstreamDetailProvider");
-const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
+const { UpstreamChecker } = require("../util/upstreamChecker");
+const {
+  getUpstreamFormatDescriptor,
+  SUPPORTED_UPSTREAM_FORMATS,
+} = require("../util/upstreamFormats");
 const { formatUpstreamFailureCategory } = require("../util/upstreamPresentation");
+const { apiSuccess } = require("./apiResultHelpers");
 
 suite("UpstreamDetailProvider Test Suite", () => {
+  const NON_INSPECTABLE_FORMATS = SUPPORTED_UPSTREAM_FORMATS.filter(format => (
+    !getUpstreamFormatDescriptor(format)?.inspectable
+  ));
+
   function aggregate(overrides = {}) {
+    const requestedFormats = Array.isArray(overrides.requestedFormats)
+      ? overrides.requestedFormats
+      : SUPPORTED_UPSTREAM_FORMATS;
+    const aggregateOverrides = { ...overrides };
+    delete aggregateOverrides.requestedFormats;
     const result = {
       upstreams: [],
       failedFormats: [],
       uninspectedFormats: [],
-      unsupportedFormats: [],
+      unsupportedFormats: requestedFormats.filter(format => (
+        !getUpstreamFormatDescriptor(format)?.inspectable
+      )),
       failures: [],
       successfulFormats: 20,
       configuredTotal: 0,
       complete: true,
       state: "empty",
-      ...overrides,
+      ...aggregateOverrides,
     };
     result.upstreams = result.upstreams.map(upstream => ({
       ...upstream,
       format: upstream.format || upstream._format,
       _format: upstream._format || upstream.format,
+      origin: Object.prototype.hasOwnProperty.call(upstream, "origin") ? upstream.origin : "",
     }));
     result.failures = result.failures.map((failure) => {
       const category = failure.category || (/permission/i.test(failure.message || "")
@@ -29,11 +46,55 @@ suite("UpstreamDetailProvider Test Suite", () => {
         : /time/i.test(failure.message || "") ? "timeout" : "unknown");
       return {
         ...failure,
+        apiFormat: failure.apiFormat || failure.format,
         category,
+        state: failure.state || (result.failedFormats.includes(failure.format)
+          ? "failed"
+          : "uninspected"),
         message: formatUpstreamFailureCategory(category),
+        httpStatus: failure.httpStatus ?? null,
         retryable: failure.retryable === true,
+        retryAfterMs: failure.retryAfterMs ?? null,
+        requestId: failure.requestId ?? null,
+        serverRequestId: failure.serverRequestId ?? null,
       };
     });
+    if (!Object.prototype.hasOwnProperty.call(aggregateOverrides, "outcomes")) {
+      const failed = new Set(result.failedFormats);
+      const uninspected = new Set(result.uninspectedFormats);
+      const unsupported = new Set(result.unsupportedFormats);
+      result.outcomes = requestedFormats.map((format) => {
+        const descriptor = getUpstreamFormatDescriptor(format);
+        const entries = result.upstreams.filter(upstream => upstream.format === descriptor?.format);
+        let state = "success";
+        if (!descriptor?.inspectable || unsupported.has(descriptor.format)) state = "unsupported";
+        else if (failed.has(descriptor.format)) state = "failed";
+        else if (uninspected.has(descriptor.format)) state = "uninspected";
+        const aggregateFailure = result.failures.find(failure => failure.format === descriptor?.format);
+        const failure = ["failed", "uninspected"].includes(state)
+          ? {
+              category: aggregateFailure?.category || "unknown",
+              message: aggregateFailure?.message || formatUpstreamFailureCategory("unknown"),
+              httpStatus: aggregateFailure?.httpStatus ?? null,
+              retryable: aggregateFailure?.retryable === true,
+              retryAfterMs: aggregateFailure?.retryAfterMs ?? null,
+              requestId: aggregateFailure?.requestId ?? null,
+              serverRequestId: aggregateFailure?.serverRequestId ?? null,
+            }
+          : null;
+        return {
+          format: descriptor?.format,
+          apiFormat: descriptor?.apiFormat ?? null,
+          state,
+          status: state === "success" ? "loaded" : state,
+          entries,
+          upstreams: entries,
+          authoritative: ["success", "unsupported"].includes(state),
+          failure,
+          pageCount: state === "success" ? 1 : 0,
+        };
+      });
+    }
     return result;
   }
 
@@ -55,6 +116,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
         [
           {
             name: "PyPI",
+            origin: "https://pypi.org",
             upstream_url: "https://user:pass@pypi.org/simple/?token=secret#fragment",
             is_active: true,
           },
@@ -276,6 +338,8 @@ suite("UpstreamDetailProvider Test Suite", () => {
     assert.ok(panel.webview.html.includes("Existing results remain visible"));
     replacement.resolve(aggregate({
       upstreams: [{ name: "New", format: "npm", origin: "https://new.example" }],
+      requestedFormats: ["npm"],
+      successfulFormats: 1,
       configuredTotal: 1,
       state: "complete",
     }));
@@ -303,6 +367,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
         }
         return aggregate({
           upstreams: [{ name: "npmjs", format: "npm", _format: "npm", origin: "https://registry.npmjs.org" }],
+          requestedFormats: options.formats,
           successfulFormats: 1,
           configuredTotal: 1,
           complete: true,
@@ -340,6 +405,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
         });
         return aggregate({
           upstreams: [{ name: "Partial page", format: "python", origin: "https://partial.example" }],
+          requestedFormats: ["python"],
           uninspectedFormats: ["python"],
           failures: [{ format: "python", category: "invalid_response", retryable: false }],
           successfulFormats: 0,
@@ -367,6 +433,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
       loadUpstreams: async () => {
         calls += 1;
         return aggregate({
+          requestedFormats: calls === 1 ? SUPPORTED_UPSTREAM_FORMATS : ["npm"],
           failedFormats: ["npm"],
           failures: [{ format: "npm", category: "timeout", retryable: true }],
           successfulFormats: calls === 1 ? 19 : 0,
@@ -408,6 +475,7 @@ suite("UpstreamDetailProvider Test Suite", () => {
           });
         }
         return aggregate({
+          requestedFormats: ["npm"],
           failedFormats: ["npm"],
           failures: [{ format: "npm", message: "Permission denied." }],
           successfulFormats: 0,
@@ -501,6 +569,22 @@ suite("UpstreamDetailProvider Test Suite", () => {
       }],
       configuredTotal: 1,
       state: "complete",
+    }), aggregate({
+      upstreams: [{
+        name: "Privileged", format: "python", origin: "", upstream_url: "https://example.com",
+      }],
+      configuredTotal: 1,
+      state: "complete",
+    }), aggregate({
+      upstreams: [{ name: "Bad priority", format: "python", origin: "", priority: -1 }],
+      configuredTotal: 1,
+      state: "complete",
+    }), aggregate({
+      upstreams: [{
+        name: "Bad indexing", format: "python", origin: "", index_package_count: "0",
+      }],
+      configuredTotal: 1,
+      state: "complete",
     }), {
       ...aggregate({
         failedFormats: ["npm"],
@@ -531,6 +615,226 @@ suite("UpstreamDetailProvider Test Suite", () => {
       assert.ok(!panel.webview.html.includes("[object Object]"));
       assert.ok(!panel.webview.html.includes("user:secret"));
       assert.ok(!panel.webview.html.includes("token=secret"));
+    }
+  });
+
+  test("accepts only canonical or explicitly redacted origins at the aggregate boundary", async () => {
+    const cases = [
+      ["https://example.com", true],
+      ["", true],
+      [undefined, false],
+      [" ", false],
+      ["https://user:pass@example.com", false],
+      ["https://example.com?token=secret", false],
+      ["https://example.com#fragment", false],
+      ["https://example.com/path", false],
+      ["not a URL", false],
+      ["Origin unavailable", false],
+    ];
+    for (const [origin, accepted] of cases) {
+      const provider = new UpstreamDetailProvider({}, {
+        loadUpstreams: async () => aggregate({
+          upstreams: [{ name: "Mirror", format: "python", origin }],
+          unsupportedFormats: NON_INSPECTABLE_FORMATS,
+          successfulFormats: 20,
+          configuredTotal: 1,
+          complete: true,
+          state: "complete",
+        }),
+      });
+      const panel = { title: "", webview: { html: "" }, reveal() {} };
+      provider._getOrCreatePanel = () => {
+        provider._panel = panel;
+        return panel;
+      };
+      await provider.show("acme", "repo", "Repo");
+      assert.strictEqual(panel.webview.html.includes("Mirror"), accepted, String(origin));
+      if (origin === "") {
+        assert.ok(panel.webview.html.includes("Origin unavailable"));
+        assert.ok(!panel.webview.html.includes("()"));
+      }
+      assert.ok(!panel.webview.html.includes("user:pass"));
+      assert.ok(!panel.webview.html.includes("token=secret"));
+      assert.ok(!panel.webview.html.includes("#fragment"));
+    }
+  });
+
+  test("binds aggregate completeness to the exact requested format scope", async () => {
+    const oneFormat = aggregate({
+      requestedFormats: ["python"],
+      upstreams: [{ name: "Scoped", format: "python", origin: "" }],
+      successfulFormats: 1,
+      configuredTotal: 1,
+      complete: true,
+      state: "complete",
+    });
+    const provider = new UpstreamDetailProvider({}, { loadUpstreams: async () => oneFormat });
+    const full = await provider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal
+    );
+    assert.strictEqual(full.state, "failed");
+
+    const targeted = await provider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal, { formats: ["python"] }
+    );
+    assert.strictEqual(targeted.state, "complete");
+    assert.strictEqual(targeted.groupedUpstreams.get("python")[0].name, "Scoped");
+  });
+
+  test("snapshots validated failure diagnostics and rejects proxy failures", async () => {
+    const source = aggregate({
+      requestedFormats: ["npm"],
+      failedFormats: ["npm"],
+      failures: [{ format: "npm", category: "timeout", retryable: true }],
+      successfulFormats: 0,
+      configuredTotal: null,
+      complete: false,
+      state: "failed",
+    });
+    const provider = new UpstreamDetailProvider({}, { loadUpstreams: async () => source });
+    const settled = await provider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal, { formats: ["npm"] }
+    );
+    source.failures[0].format = "https://user:secret@example.com/?token=secret";
+    source.failedFormats[0] = "https://user:secret@example.com/?token=secret";
+    assert.deepStrictEqual(settled.failedFormats, ["npm"]);
+    assert.strictEqual(settled.failures[0].format, "npm");
+    assert.ok(Object.isFrozen(settled.failures));
+    assert.ok(Object.isFrozen(settled.failures[0]));
+    const html = provider._getHtmlContent("acme", "repo", "Repo", settled);
+    assert.ok(!html.includes("user:secret"));
+    assert.ok(!html.includes("token=secret"));
+
+    let reads = 0;
+    const hostile = aggregate({
+      requestedFormats: ["npm"],
+      failedFormats: ["npm"],
+      failures: [{ format: "npm", category: "timeout", retryable: true }],
+      successfulFormats: 0,
+      configuredTotal: null,
+      complete: false,
+      state: "failed",
+    });
+    hostile.failures[0] = new Proxy(hostile.failures[0], {
+      get(target, property, receiver) {
+        reads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const hostileProvider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => hostile,
+    });
+    const rejected = await hostileProvider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal, { formats: ["npm"] }
+    );
+    assert.strictEqual(rejected.state, "failed");
+    assert.strictEqual(reads, 0);
+
+    let rootReads = 0;
+    const hostileRoot = aggregate({
+      requestedFormats: ["npm"],
+      failedFormats: ["npm"],
+      failures: [{ format: "npm", category: "timeout", retryable: true }],
+      successfulFormats: 0,
+      configuredTotal: null,
+      complete: false,
+      state: "failed",
+    });
+    Object.defineProperty(hostileRoot, "failures", {
+      enumerable: true,
+      get() {
+        rootReads += 1;
+        return [{ format: "https://user:secret@example.com/?token=secret" }];
+      },
+    });
+    const rootProvider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => hostileRoot,
+    });
+    const rootRejected = await rootProvider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal, { formats: ["npm"] }
+    );
+    assert.strictEqual(rootRejected.state, "failed");
+    assert.strictEqual(rootReads, 0);
+
+    let outcomeReads = 0;
+    const hostileOutcome = aggregate({
+      requestedFormats: ["npm"],
+      failedFormats: ["npm"],
+      failures: [{ format: "npm", category: "timeout", retryable: true }],
+      successfulFormats: 0,
+      configuredTotal: null,
+      complete: false,
+      state: "failed",
+    });
+    hostileOutcome.outcomes[0] = new Proxy(hostileOutcome.outcomes[0], {
+      get(target, property, receiver) {
+        outcomeReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const outcomeProvider = new UpstreamDetailProvider({}, {
+      loadUpstreams: async () => hostileOutcome,
+    });
+    const outcomeRejected = await outcomeProvider._fetchGroupedUpstreams(
+      "acme", "repo", new AbortController().signal, { formats: ["npm"] }
+    );
+    assert.strictEqual(outcomeRejected.state, "failed");
+    assert.strictEqual(outcomeReads, 0);
+  });
+
+  test("renders a real producer aggregate with a redacted origin without losing the card", async () => {
+    const endpoints = [];
+    const connectionManager = {
+      getState() {
+        return { activationId: "account-a", accountEpoch: 1, sessionConnected: true };
+      },
+    };
+    const checker = new UpstreamChecker({}, {
+      connectionManager,
+      cloudsmithAPI: {
+        async get(endpoint) {
+          endpoints.push(endpoint);
+          return endpoint.includes("upstream/python/")
+            ? apiSuccess([{
+                name: "Private PyPI",
+                slug_perm: "private-pypi",
+                upstream_url: "https://user:password@example.com/private?token=secret#signed",
+                is_active: true,
+                verify_ssl: false,
+                priority: "10",
+                trust_level: "Trusted",
+                index_status: "Up-to-date",
+                index_package_count: 0,
+                distro_versions: ["3.12"],
+              }])
+            : apiSuccess([]);
+        },
+      },
+    });
+    const provider = new UpstreamDetailProvider({}, {
+      loadUpstreams: (workspace, repo, options) => (
+        checker.getAllUpstreamData(workspace, repo, options)
+      ),
+    });
+    const panel = { title: "", webview: { html: "" }, reveal() {} };
+    provider._getOrCreatePanel = () => {
+      provider._panel = panel;
+      return panel;
+    };
+
+    await provider.show("acme", "repo", "Repo");
+
+    assert.strictEqual(endpoints.length, 20);
+    assert.ok(endpoints.every(endpoint => !/upstream\/(raw|terraform|conan|cocoapods|luarocks|vagrant)\//.test(endpoint)));
+    assert.ok(panel.webview.html.includes("Private PyPI"));
+    assert.ok(panel.webview.html.includes("Origin unavailable"));
+    assert.ok(panel.webview.html.includes(">Trusted<"));
+    assert.ok(panel.webview.html.includes("Disabled"));
+    assert.ok(panel.webview.html.includes(">10<"));
+    assert.ok(panel.webview.html.includes("0 packages"));
+    assert.ok(!panel.webview.html.includes("Could not load upstreams"));
+    for (const secret of ["user:password", "/private", "token=secret", "#signed"]) {
+      assert.ok(!panel.webview.html.includes(secret), secret);
     }
   });
 

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -233,7 +233,8 @@ suite("UpstreamDetailProvider Test Suite", () => {
     assert.ok(html.includes("PyPI &lt;script&gt;"));
     assert.ok(html.includes("npm"));
     assert.ok(html.includes("timed out"));
-    assert.ok(html.includes("Not applicable to this API: terraform"));
+    assert.ok(!html.includes("Not applicable"));
+    assert.ok(!html.includes("terraform"));
     assert.ok(html.includes(">Retry<"));
     assert.ok(/script-src 'nonce-[^']+'/.test(html));
     assert.ok(!html.includes("[object Object]"));

--- a/test/upstreamDetailProvider.test.js
+++ b/test/upstreamDetailProvider.test.js
@@ -117,6 +117,32 @@ suite("UpstreamDetailProvider Test Suite", () => {
     assert.ok(html.length < 20_000);
   });
 
+  test("shows trust level without explanatory trust callouts", () => {
+    const provider = new UpstreamDetailProvider({});
+    const html = provider._getHtmlContent("acme", "repo", "Repo", {
+      groupedUpstreams: new Map([
+        ["python", [
+          { name: "Trusted source", trust_level: "Trusted" },
+          { name: "Untrusted source", trust_level: "Untrusted" },
+        ]],
+      ]),
+      failedFormats: [],
+      uninspectedFormats: [],
+      successfulFormats: 20,
+      configuredTotal: 2,
+      complete: true,
+      state: "complete",
+    });
+
+    assert.ok(html.includes("Trust level"));
+    assert.ok(html.includes("Trusted"));
+    assert.ok(html.includes("Untrusted"));
+    assert.ok(!html.includes("Trusted upstream:"));
+    assert.ok(!html.includes("Untrusted upstream (recommended):"));
+    assert.ok(!html.includes("dependency confusion"));
+    assert.ok(!html.includes("namesquatting"));
+  });
+
   test("caps rendered cards before joining HTML", () => {
     const provider = new UpstreamDetailProvider({});
     const groupedUpstreams = new Map([

--- a/test/upstreamFormats.test.js
+++ b/test/upstreamFormats.test.js
@@ -1,0 +1,104 @@
+const assert = require("assert");
+const {
+  getInspectableUpstreamFormatDescriptors,
+  getInspectableUpstreamFormats,
+  getSupportedUpstreamFormats,
+  getUpstreamFormatDescriptor,
+  INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS,
+  INSPECTABLE_UPSTREAM_FORMATS,
+  normalizeUpstreamFormat,
+  SUPPORTED_UPSTREAM_FORMATS,
+  UPSTREAM_FORMAT_DESCRIPTORS,
+} = require("../util/upstreamFormats");
+
+const EXPECTED_FORMATS = Object.freeze([
+  "alpine", "cargo", "cocoapods", "composer", "conan", "conda", "cran", "dart",
+  "deb", "docker", "generic", "go", "helm", "hex", "huggingface", "luarocks",
+  "maven", "npm", "nuget", "python", "raw", "rpm", "ruby", "swift", "terraform",
+  "vagrant",
+]);
+
+const EXPECTED_INSPECTABLE_FORMATS = Object.freeze([
+  "alpine", "cargo", "composer", "conda", "cran", "dart", "deb", "docker", "generic",
+  "go", "helm", "hex", "huggingface", "maven", "npm", "nuget", "python", "rpm",
+  "ruby", "swift",
+]);
+
+const EXPECTED_NOT_APPLICABLE_FORMATS = Object.freeze([
+  "cocoapods", "conan", "luarocks", "raw", "terraform", "vagrant",
+]);
+
+suite("upstream format registry", () => {
+  test("recognizes every canonical package format and rejects unknown values", () => {
+    assert.strictEqual(SUPPORTED_UPSTREAM_FORMATS.length, 26);
+    assert.deepStrictEqual(SUPPORTED_UPSTREAM_FORMATS, EXPECTED_FORMATS);
+    assert.strictEqual(UPSTREAM_FORMAT_DESCRIPTORS.length, EXPECTED_FORMATS.length);
+
+    for (const format of EXPECTED_FORMATS) {
+      assert.strictEqual(normalizeUpstreamFormat(`  ${format.toUpperCase()}  `), format);
+      const descriptor = getUpstreamFormatDescriptor(format);
+      assert.ok(descriptor);
+      assert.strictEqual(descriptor.format, format);
+    }
+
+    for (const value of [null, undefined, "", "unknown", {}, []]) {
+      assert.strictEqual(normalizeUpstreamFormat(value), null);
+      assert.strictEqual(getUpstreamFormatDescriptor(value), null);
+    }
+  });
+
+  test("exposes exactly twenty inspectable API formats with canonical endpoints", () => {
+    assert.strictEqual(INSPECTABLE_UPSTREAM_FORMATS.length, 20);
+    assert.deepStrictEqual(INSPECTABLE_UPSTREAM_FORMATS, EXPECTED_INSPECTABLE_FORMATS);
+    assert.strictEqual(INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS.length, 20);
+    assert.deepStrictEqual(getInspectableUpstreamFormats(), EXPECTED_INSPECTABLE_FORMATS);
+
+    for (const descriptor of INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS) {
+      assert.strictEqual(descriptor.inspectable, true);
+      assert.strictEqual(descriptor.apiFormat, descriptor.format);
+      assert.strictEqual(descriptor.endpoint, `upstream/${descriptor.apiFormat}`);
+    }
+  });
+
+  test("marks six recognized formats as neutral and without an API endpoint", () => {
+    const descriptors = EXPECTED_NOT_APPLICABLE_FORMATS.map(getUpstreamFormatDescriptor);
+
+    assert.strictEqual(descriptors.length, 6);
+    for (const descriptor of descriptors) {
+      assert.ok(descriptor);
+      assert.strictEqual(descriptor.inspectable, false);
+      assert.strictEqual(descriptor.apiFormat, null);
+      assert.strictEqual(descriptor.endpoint, null);
+    }
+  });
+
+  test("deduplicates and canonicalizes caller-provided formats without identity drift", () => {
+    const requested = [" NPM ", "npm", "COCOAPODS", "unknown", null, "Python", "python"];
+
+    assert.deepStrictEqual(getSupportedUpstreamFormats(requested), ["npm", "cocoapods", "python"]);
+    assert.deepStrictEqual(getInspectableUpstreamFormats(requested), ["npm", "python"]);
+    const descriptors = getInspectableUpstreamFormatDescriptors(requested);
+    assert.deepStrictEqual(descriptors.map(descriptor => descriptor.format), ["npm", "python"]);
+    assert.ok(descriptors.every(descriptor => descriptor.apiFormat === descriptor.format));
+    assert.deepStrictEqual(getSupportedUpstreamFormats(null), []);
+    assert.deepStrictEqual(getInspectableUpstreamFormats("npm"), []);
+  });
+
+  test("freezes registry constants and canonical descriptors", () => {
+    for (const value of [
+      SUPPORTED_UPSTREAM_FORMATS,
+      INSPECTABLE_UPSTREAM_FORMATS,
+      UPSTREAM_FORMAT_DESCRIPTORS,
+      INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS,
+    ]) {
+      assert.strictEqual(Object.isFrozen(value), true);
+    }
+    assert.ok(UPSTREAM_FORMAT_DESCRIPTORS.every(Object.isFrozen));
+
+    const npmDescriptor = getUpstreamFormatDescriptor("npm");
+    assert.strictEqual(Object.isFrozen(npmDescriptor), true);
+    assert.strictEqual(Reflect.set(npmDescriptor, "apiFormat", "python"), false);
+    assert.strictEqual(npmDescriptor.apiFormat, "npm");
+    assert.strictEqual(getUpstreamFormatDescriptor("npm"), npmDescriptor);
+  });
+});

--- a/test/upstreamGapAnalyzer.test.js
+++ b/test/upstreamGapAnalyzer.test.js
@@ -87,6 +87,26 @@ suite("upstreamGapAnalyzer", () => {
     assert.strictEqual(enriched[0].upstreamDetail, "Not available through Cloudsmith");
   });
 
+  test("does not inspect a recognized package format without an upstream API", async () => {
+    let calls = 0;
+    const enriched = await analyzeUpstreamGaps([{
+      name: "archive",
+      version: "1.0.0",
+      format: "raw",
+      ecosystem: "raw",
+      cloudsmithStatus: "NOT_FOUND",
+    }], "workspace-a", ["production"], {
+      upstreamChecker: {
+        async getRepositoryUpstreamStateForFormats() {
+          calls += 1;
+          return createState();
+        },
+      },
+    });
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(enriched[0].upstreamStatus, "unreachable");
+  });
+
   test("limits upstream repository lookups to four concurrent requests and emits one final patch", async () => {
     const dependencies = [
       {

--- a/test/upstreamPresentation.test.js
+++ b/test/upstreamPresentation.test.js
@@ -3,9 +3,11 @@
 const assert = require("assert");
 const {
   formatUpstreamError,
+  formatUpstreamFailureCategory,
   formatUpstreamOrigin,
   formatUpstreamText,
   getTerraformUpstreamUrl,
+  normalizeUpstreamFailure,
 } = require("../util/upstreamPresentation");
 
 suite("Upstream presentation safety", () => {
@@ -53,6 +55,113 @@ suite("Upstream presentation safety", () => {
       formatUpstreamError(hostile),
       "Upstream availability could not be determined."
     );
+  });
+
+  test("normalizes upstream failure categories with fixed safe copy", () => {
+    const cases = [
+      [{ kind: "unauthorized" }, "authentication"],
+      [{ kind: "auth" }, "authentication"],
+      [{ status: 401 }, "authentication"],
+      [{ kind: "forbidden" }, "permission"],
+      [{ status: 403 }, "permission"],
+      [{ kind: "not_found" }, "not_found"],
+      [{ status: 404 }, "not_found"],
+      [{ kind: "timeout" }, "timeout"],
+      [{ status: 408 }, "timeout"],
+      [{ kind: "rate_limited" }, "rate_limit"],
+      [{ kind: "rate_limit_circuit" }, "rate_limit"],
+      [{ status: 429 }, "rate_limit"],
+      [{ kind: "server_error" }, "server"],
+      [{ status: 503 }, "server"],
+      [{ kind: "network_error" }, "network"],
+      [{ kind: "transport_failure" }, "network"],
+      [{ kind: "invalid_response" }, "invalid_response"],
+      [{ kind: "cancelled" }, "cancelled"],
+      [{ name: "AbortError" }, "cancelled"],
+      [{ code: "ABORT_ERR" }, "cancelled"],
+      [{ kind: "invalid_request" }, "request_rejected"],
+      [{ kind: "redirect_rejected" }, "request_rejected"],
+      [{ status: 422 }, "request_rejected"],
+      [{ kind: "request_limit" }, "request_limit"],
+      [{ kind: "resource_limit" }, "request_limit"],
+      [{ kind: "uninspected" }, "uninspected"],
+      [new Error("unknown https://user:pass@example.com/?token=secret"), "unknown"],
+    ];
+
+    for (const [error, category] of cases) {
+      const normalized = normalizeUpstreamFailure(error);
+      assert.strictEqual(normalized.category, category);
+      assert.strictEqual(normalized.message, formatUpstreamFailureCategory(category));
+      assert.ok(!normalized.message.includes("[object Object]"));
+      assert.ok(!normalized.message.includes("secret"));
+    }
+
+    assert.strictEqual(
+      formatUpstreamFailureCategory("constructor"),
+      "Upstream availability could not be determined."
+    );
+  });
+
+  test("retains only validated failure metadata and ignores hostile properties", () => {
+    const normalized = normalizeUpstreamFailure({
+      ok: false,
+      status: 429,
+      requestId: "local-request-1234",
+      serverRequestId: "0123456789abcdef-IAD",
+      headers: { authorization: "Bearer secret" },
+      diagnostic: { url: "https://user:pass@example.com/?token=secret" },
+      error: {
+        kind: "rate_limited",
+        status: 429,
+        retryable: true,
+        retryAfterMs: 2500,
+        requestId: "local-request-1234",
+        message: "token=secret",
+        cause: new Error("api-key=secret"),
+        stack: "private stack",
+      },
+    });
+    assert.deepStrictEqual(normalized, {
+      category: "rate_limit",
+      message: "Cloudsmith rate limited the upstream request. Try again later.",
+      httpStatus: 429,
+      retryable: true,
+      retryAfterMs: 2500,
+      requestId: "local-request-1234",
+      serverRequestId: "0123456789abcdef-IAD",
+    });
+    assert.ok(Object.isFrozen(normalized));
+
+    const malformed = normalizeUpstreamFailure({
+      status: "429",
+      requestId: "https://example.com/?token=secret",
+      serverRequestId: "bad id with spaces",
+      error: {
+        retryable: "true",
+        retryAfterMs: 24 * 60 * 60 * 1000 + 1,
+      },
+    });
+    assert.deepStrictEqual(malformed, {
+      category: "unknown",
+      message: "Upstream availability could not be determined.",
+      httpStatus: null,
+      retryable: false,
+      retryAfterMs: null,
+      requestId: null,
+      serverRequestId: null,
+    });
+
+    const hostile = new Proxy({}, {
+      get(_target, property) {
+        if (property === "kind") return "timeout";
+        throw new Error(`secret from ${String(property)}`);
+      },
+    });
+    const hostileNormalized = normalizeUpstreamFailure(hostile);
+    assert.strictEqual(hostileNormalized.category, "timeout");
+    assert.strictEqual(hostileNormalized.message, "The upstream request timed out.");
+    assert.strictEqual(hostileNormalized.requestId, null);
+    assert.strictEqual(hostileNormalized.serverRequestId, null);
   });
 
   test("projects only safe HTTP origins and fails closed", () => {

--- a/test/upstreamPreviewProvider.test.js
+++ b/test/upstreamPreviewProvider.test.js
@@ -1,5 +1,7 @@
 const assert = require("assert");
 const { UpstreamPreviewProvider } = require("../views/upstreamPreviewProvider");
+const { UpstreamChecker } = require("../util/upstreamChecker");
+const { apiSuccess } = require("./apiResultHelpers");
 
 suite("UpstreamPreviewProvider Test Suite", () => {
   test("renders upstream resolution details without any policy section", () => {
@@ -22,12 +24,16 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           configs: [
             {
               name: "PyPI",
-              upstream_url: "https://pypi.org/simple/",
+              format: "python",
+              _format: "python",
+              origin: "https://pypi.org",
               is_active: true,
             },
             {
               name: "Legacy mirror",
-              upstream_url: "https://legacy.example/python",
+              format: "python",
+              _format: "python",
+              origin: "https://legacy.example",
               is_active: false,
             },
           ],
@@ -100,7 +106,9 @@ suite("UpstreamPreviewProvider Test Suite", () => {
           active: 1,
           configs: [{
             name: "Private mirror",
-            upstream_url: "https://user:pass@example.com/private/path?token=secret#fragment",
+            format: "python",
+            _format: "python",
+            origin: "",
             is_active: true,
           }],
         },
@@ -111,7 +119,7 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     });
 
     assert.ok(html.includes("Request failed"));
-    assert.match(html, /<td class="mono">https:\/\/example\.com<\/td>/);
+    assert.match(html, /<td class="mono">Origin unavailable<\/td>/);
     assert.ok(!html.includes("[object Object]"));
     assert.ok(!html.includes("user:pass"));
     assert.ok(!html.includes("private/path"));
@@ -154,7 +162,9 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     const provider = new UpstreamPreviewProvider({});
     const configs = Array.from({ length: 101 }, (_, index) => ({
       name: `Mirror ${index}`,
-      upstream_url: `https://mirror-${index}.example/path`,
+      format: "python",
+      _format: "python",
+      origin: `https://mirror-${index}.example`,
       is_active: true,
     }));
     const html = provider._getHtmlContent({
@@ -187,7 +197,10 @@ suite("UpstreamPreviewProvider Test Suite", () => {
         data: {
           total: 99,
           active: 99,
-          configs: [{ name: "Malformed", is_active: "true", upstream_url: {} }],
+          configs: [{
+            name: "Malformed", format: "python", _format: "python", origin: "",
+            is_active: "true",
+          }],
         },
         errorMessage: null,
         complete: true,
@@ -203,6 +216,110 @@ suite("UpstreamPreviewProvider Test Suite", () => {
     assert.ok(!html.includes("[object Object]"));
   });
 
+  test("rejects inherited, accessor, and mismatched preview identities without invoking getters", () => {
+    const provider = new UpstreamPreviewProvider({});
+    const inherited = Object.create({
+      name: "Inherited secret",
+      format: "python",
+      _format: "python",
+      origin: "https://inherited.example",
+      is_active: true,
+    });
+    let getterReads = 0;
+    const accessor = {
+      format: "python",
+      _format: "python",
+      origin: "https://accessor.example",
+      is_active: true,
+    };
+    Object.defineProperty(accessor, "name", {
+      enumerable: true,
+      get() {
+        getterReads += 1;
+        return "Accessor secret";
+      },
+    });
+    const mismatch = {
+      name: "Mismatched secret",
+      format: "npm",
+      _format: "npm",
+      origin: "https://mismatch.example",
+      is_active: true,
+    };
+
+    const html = provider._getHtmlContent({
+      name: "package",
+      format: "python",
+      workspace: "acme",
+      repo: "repo",
+      local: { data: null, errorMessage: null, complete: true },
+      upstreams: {
+        data: { total: 3, active: 3, configs: [inherited, accessor, mismatch] },
+        errorMessage: null,
+        complete: true,
+      },
+      canResolveViaUpstream: true,
+    });
+
+    assert.strictEqual(getterReads, 0);
+    assert.ok(html.includes("Upstream inspection is incomplete"));
+    assert.ok(html.includes("0 active of 0 loaded"));
+    assert.ok(!html.includes("Inherited secret"));
+    assert.ok(!html.includes("Accessor secret"));
+    assert.ok(!html.includes("Mismatched secret"));
+    assert.ok(!html.includes("can likely resolve"));
+
+    let formatReads = 0;
+    const hostileResult = {
+      name: "package",
+      workspace: "acme",
+      repo: "repo",
+      local: { data: null, errorMessage: null, complete: true },
+      upstreams: {
+        data: { total: 0, active: 0, configs: [] },
+        errorMessage: null,
+        complete: true,
+      },
+    };
+    Object.defineProperty(hostileResult, "format", {
+      enumerable: true,
+      get() {
+        formatReads += 1;
+        return "python";
+      },
+    });
+    const hostileHtml = provider._getHtmlContent(hostileResult);
+    assert.strictEqual(formatReads, 0);
+    assert.ok(hostileHtml.includes("<dt>Format</dt><dd>Unknown</dd>"));
+    assert.ok(hostileHtml.includes("Upstream inspection is incomplete"));
+
+    let nestedReads = 0;
+    const hostileNested = {
+      name: "package",
+      format: "python",
+      workspace: "acme",
+      repo: "repo",
+      local: {},
+      upstreams: { data: { total: 0, active: 0, configs: [] } },
+    };
+    for (const [target, property, value] of [
+      [hostileNested.local, "errorMessage", "secret"],
+      [hostileNested.local, "data", { status_str: "secret" }],
+      [hostileNested.local, "complete", true],
+      [hostileNested.upstreams, "errorMessage", "secret"],
+      [hostileNested.upstreams, "complete", true],
+    ]) {
+      Object.defineProperty(target, property, {
+        enumerable: true,
+        get() { nestedReads += 1; return value; },
+      });
+    }
+    const nestedHtml = provider._getHtmlContent(hostileNested);
+    assert.strictEqual(nestedReads, 0);
+    assert.ok(nestedHtml.includes("Upstream inspection is incomplete"));
+    assert.ok(!nestedHtml.includes("secret"));
+  });
+
   test("account reset disposes the panel and null preview results are ignored", () => {
     const provider = new UpstreamPreviewProvider({});
     let disposed = 0;
@@ -213,5 +330,40 @@ suite("UpstreamPreviewProvider Test Suite", () => {
 
     assert.strictEqual(disposed, 1);
     assert.strictEqual(provider._panel, null);
+  });
+
+  test("renders the real safe preview producer contract without raw URL fallback", async () => {
+    const checker = new UpstreamChecker({}, {
+      connectionManager: {
+        getState() {
+          return { activationId: "account-a", accountEpoch: 1, sessionConnected: true };
+        },
+      },
+      cloudsmithAPI: {
+        async get(endpoint) {
+          assert.match(endpoint, /upstream\/python\//);
+          return apiSuccess([{
+            name: "Private PyPI",
+            slug_perm: "private-pypi",
+            upstream_url: "https://user:password@example.com/private?token=secret#signed",
+            is_active: true,
+          }]);
+        },
+      },
+    });
+    checker.existsLocally = async () => ({ data: null, error: null, complete: true });
+    const result = await checker.previewResolution(
+      "acme", "repo", "package-a", "python"
+    );
+    const html = new UpstreamPreviewProvider({})._getHtmlContent(result);
+
+    assert.ok(html.includes("Private PyPI"));
+    assert.ok(html.includes("Origin unavailable"));
+    assert.strictEqual(result.upstreams.data.configs[0].origin, "");
+    assert.strictEqual("upstream_url" in result.upstreams.data.configs[0], false);
+    for (const secret of ["user:password", "/private", "token=secret", "#signed"]) {
+      assert.ok(!html.includes(secret));
+      assert.ok(!JSON.stringify(result).includes(secret));
+    }
   });
 });

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -6,6 +6,8 @@ const {
 const {
   UpstreamPullService,
 } = require("../util/upstreamPullService");
+const { UpstreamChecker } = require("../util/upstreamChecker");
+const { apiSuccess } = require("./apiResultHelpers");
 
 function createResponse(status, body, headers = {}) {
   return new Response(body, { status, headers });
@@ -29,6 +31,34 @@ function cancellationToken() {
       listeners.add(listener);
       return { dispose() { listeners.delete(listener); } };
     },
+  };
+}
+
+function safeUpstream(format, name, overrides = {}) {
+  return {
+    name,
+    format,
+    _format: format,
+    origin: `https://${format}.example`,
+    ...overrides,
+  };
+}
+
+function completeRepositoryState(entriesByFormat) {
+  const groupedUpstreams = new Map(Object.entries(entriesByFormat));
+  const formats = [...groupedUpstreams.keys()];
+  return {
+    groupedUpstreams,
+    complete: true,
+    failedFormats: [],
+    uninspectedFormats: [],
+    unsupportedFormats: [],
+    outcomes: formats.map(format => ({
+      format,
+      apiFormat: format,
+      state: "success",
+      authoritative: true,
+    })),
   };
 }
 
@@ -133,12 +163,10 @@ suite("UpstreamPullService", () => {
       }),
       upstreamChecker: {
         async getRepositoryUpstreamState() {
-          return {
-            groupedUpstreams: new Map([
-              ["maven", [{ name: "Maven Central", is_active: true }]],
-            ]),
-            complete: true,
-          };
+          return completeRepositoryState({
+            maven: [safeUpstream("maven", "Maven Central", { is_active: true })],
+            python: [],
+          });
         },
       },
       showQuickPick: async (items) => items[0],
@@ -189,12 +217,9 @@ suite("UpstreamPullService", () => {
       }),
       upstreamChecker: {
         async getRepositoryUpstreamState() {
-          return {
-            groupedUpstreams: new Map([
-              ["npm", [{ name: "npm", is_active: true }]],
-            ]),
-            complete: true,
-          };
+          return completeRepositoryState({
+            npm: [safeUpstream("npm", "npm", { is_active: true })],
+          });
         },
       },
       showQuickPick: async (items) => items[0],
@@ -767,12 +792,11 @@ suite("UpstreamPullService", () => {
       }),
       upstreamChecker: {
         async getRepositoryUpstreamState(_workspace, repo) {
-          return {
-            groupedUpstreams: new Map([
-              ["python", repo === "repo-b" ? [{ name: "PyPI", is_active: true }] : []],
-            ]),
-            complete: true,
-          };
+          return completeRepositoryState({
+            python: repo === "repo-b"
+              ? [safeUpstream("python", "PyPI", { is_active: true })]
+              : [],
+          });
         },
       },
       showQuickPick: async (items) => {
@@ -856,6 +880,13 @@ suite("UpstreamPullService", () => {
             complete: false,
             failedFormats: [],
             uninspectedFormats: ["python"],
+            unsupportedFormats: [],
+            outcomes: [{
+              format: "python",
+              apiFormat: "python",
+              state: "cancelled",
+              authoritative: false,
+            }],
           };
         },
       },
@@ -952,5 +983,303 @@ suite("UpstreamPullService", () => {
 
     assert.strictEqual(warnings.length, 4);
     assert.ok(warnings.every((message) => /absence was not conclusively established/.test(message)));
+  });
+
+  test("uses real canonical outcomes for mixed inspectable and non-inspectable pull preparation", async () => {
+    const requests = [];
+    const warnings = [];
+    let repositoryFetches = 0;
+    const account = {
+      getState() {
+        return { activationId: "account-a", accountEpoch: 1, sessionConnected: true };
+      },
+    };
+    const checker = new UpstreamChecker({}, {
+      connectionManager: account,
+      cloudsmithAPI: {
+        async get(endpoint) {
+          requests.push(endpoint);
+          return apiSuccess([{
+            name: "npmjs",
+            slug_perm: "npmjs",
+            upstream_url: "https://registry.npmjs.org/",
+            is_active: true,
+          }]);
+        },
+      },
+    });
+    const service = new UpstreamPullService({}, {
+      connectionManager: account,
+      upstreamChecker: checker,
+      fetchRepositories: async () => {
+        repositoryFetches += 1;
+        return { items: [{ slug: "repo", name: "Repo" }], complete: true };
+      },
+      showQuickPick: async items => items[0],
+      showWarningMessage: async (message, _options, action) => {
+        warnings.push(message);
+        return action;
+      },
+      showInformationMessage: async () => {},
+      showErrorMessage: async () => {},
+    });
+
+    const prepared = await service.prepare({
+      workspace: "workspace",
+      dependencies: [
+        { name: "package-a", version: "1.0.0", format: "NPM", cloudsmithStatus: "ABSENT" },
+        { name: "archive", version: "1.0.0", format: "raw", cloudsmithStatus: "ABSENT" },
+      ],
+    });
+
+    assert.ok(prepared);
+    assert.strictEqual(repositoryFetches, 1);
+    assert.strictEqual(requests.length, 1);
+    assert.match(requests[0], /upstream\/npm\//);
+    assert.doesNotMatch(requests[0], /upstream\/raw\//);
+    assert.strictEqual(prepared.repositorySearchComplete, true);
+    assert.deepStrictEqual(prepared.plan.pullableDependencies.map(item => item.format), ["NPM"]);
+    assert.strictEqual(prepared.plan.skippedDependencies.length, 1);
+    assert.strictEqual(prepared.plan.skippedDependencies[0].reason, "no_pull_support");
+    assert.ok(warnings.every(message => !/inspection was incomplete/i.test(message)));
+    assert.match(warnings[0], /1 Raw will be skipped/);
+  });
+
+  test("short-circuits zero executable formats before repository enumeration", async () => {
+    for (const format of ["raw", "terraform", "alpine"]) {
+      let repositoryFetches = 0;
+      const messages = [];
+      const service = new UpstreamPullService({}, {
+        fetchRepositories: async () => {
+          repositoryFetches += 1;
+          return { items: [{ slug: "repo" }], complete: true };
+        },
+        showInformationMessage: async message => messages.push(message),
+        showWarningMessage: async () => {},
+        showErrorMessage: async () => {},
+      });
+      const prepared = await service.prepare({
+        workspace: "workspace",
+        dependencies: [{
+          name: "package-a", version: "1.0.0", format, cloudsmithStatus: "ABSENT",
+        }],
+      });
+      assert.strictEqual(prepared, null, format);
+      assert.strictEqual(repositoryFetches, 0, format);
+      assert.match(messages[0], /Pull-through caching is not available/i, format);
+      assert.doesNotMatch(messages[0], /incomplete/i, format);
+    }
+  });
+
+  test("prepareSingle reports a recognized non-inspectable format as unavailable", async () => {
+    let repositoryFetches = 0;
+    const messages = [];
+    const service = new UpstreamPullService({}, {
+      fetchRepositories: async () => {
+        repositoryFetches += 1;
+        return { items: [{ slug: "repo" }], complete: true };
+      },
+      showInformationMessage: async message => messages.push(message),
+      showWarningMessage: async () => {},
+      showErrorMessage: async () => {},
+    });
+    const prepared = await service.prepareSingle({
+      workspace: "workspace",
+      dependency: {
+        name: "archive", version: "1.0.0", format: "raw", cloudsmithStatus: "ABSENT",
+      },
+    });
+    assert.strictEqual(prepared, null);
+    assert.strictEqual(repositoryFetches, 0);
+    assert.match(messages[0], /not available for Raw dependencies/i);
+    assert.doesNotMatch(messages[0], /incomplete|failed/i);
+  });
+
+  test("proves pull inspection completeness from canonical authoritative outcomes", async () => {
+    const cases = [
+      {
+        name: "inspectable success",
+        formats: [" NPM "],
+        state: completeRepositoryState({ npm: [] }),
+        expected: true,
+      },
+      {
+        name: "inspectable failure",
+        formats: ["npm"],
+        state: {
+          groupedUpstreams: new Map(), complete: false,
+          failedFormats: ["npm"], uninspectedFormats: [], unsupportedFormats: [],
+          outcomes: [{ format: "npm", apiFormat: "npm", state: "failed", authoritative: false }],
+        },
+        expected: false,
+      },
+      {
+        name: "mixed inspectable and neutral",
+        formats: ["NPM", "raw"],
+        state: {
+          ...completeRepositoryState({ npm: [] }),
+          complete: true,
+          unsupportedFormats: ["raw"],
+          outcomes: [
+            { format: "npm", apiFormat: "npm", state: "success", authoritative: true },
+            { format: "raw", apiFormat: null, state: "unsupported", authoritative: true },
+          ],
+        },
+        expected: true,
+      },
+      {
+        name: "neutral only",
+        formats: ["raw", "terraform"],
+        state: {
+          groupedUpstreams: new Map(), complete: false,
+          failedFormats: [], uninspectedFormats: [], unsupportedFormats: ["raw", "terraform"],
+          outcomes: [
+            { format: "raw", apiFormat: null, state: "unsupported", authoritative: true },
+            { format: "terraform", apiFormat: null, state: "unsupported", authoritative: true },
+          ],
+        },
+        expected: true,
+      },
+      {
+        name: "unknown",
+        formats: ["unknown"],
+        state: completeRepositoryState({ npm: [] }),
+        expected: false,
+      },
+      {
+        name: "empty",
+        formats: [],
+        state: completeRepositoryState({ npm: [] }),
+        expected: false,
+      },
+      {
+        name: "missing outcome",
+        formats: ["npm"],
+        state: {
+          groupedUpstreams: new Map(), complete: true,
+          failedFormats: [], uninspectedFormats: [], unsupportedFormats: [], outcomes: [],
+        },
+        expected: false,
+      },
+      {
+        name: "duplicate outcome",
+        formats: ["npm"],
+        state: {
+          groupedUpstreams: new Map(), complete: true,
+          failedFormats: [], uninspectedFormats: [], unsupportedFormats: [],
+          outcomes: [
+            { format: "npm", apiFormat: "npm", state: "success", authoritative: true },
+            { format: "npm", apiFormat: "npm", state: "success", authoritative: true },
+          ],
+        },
+        expected: false,
+      },
+      {
+        name: "inspectable mislabeled unsupported",
+        formats: ["npm"],
+        state: {
+          groupedUpstreams: new Map(), complete: false,
+          failedFormats: [], uninspectedFormats: [], unsupportedFormats: ["npm"], outcomes: [],
+        },
+        expected: false,
+      },
+      {
+        name: "success contradicts failed list",
+        formats: ["npm"],
+        state: {
+          ...completeRepositoryState({ npm: [] }),
+          failedFormats: ["npm"],
+        },
+        expected: false,
+      },
+      {
+        name: "requested subset succeeds while another inspected format explains incompleteness",
+        formats: ["npm"],
+        state: {
+          groupedUpstreams: new Map(), complete: false, incomplete: true,
+          failedFormats: ["python"], uninspectedFormats: [], unsupportedFormats: [],
+          outcomes: [
+            { format: "npm", apiFormat: "npm", state: "success", authoritative: true },
+            { format: "python", apiFormat: "python", state: "failed", authoritative: false },
+          ],
+        },
+        expected: true,
+      },
+      {
+        name: "authoritative outcome contradicts incomplete aggregate",
+        formats: ["npm"],
+        state: {
+          ...completeRepositoryState({ npm: [] }),
+          complete: false,
+        },
+        expected: false,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const service = new UpstreamPullService({}, {
+        upstreamChecker: {
+          async getRepositoryUpstreamStateForFormats() { return testCase.state; },
+        },
+      });
+      const result = await service._findMatchingRepositories(
+        "workspace", [{ slug: "repo" }], testCase.formats,
+        service._createPreparationOperation(null, null)
+      );
+      assert.strictEqual(result.complete, testCase.expected, testCase.name);
+    }
+  });
+
+  test("requires canonical requested grouped data while retaining safe positive matches", async () => {
+    const valid = safeUpstream("npm", "npmjs", { is_active: true });
+    const missingOrigin = { ...valid };
+    delete missingOrigin.origin;
+    const cases = [
+      ["missing origin", [valid, missingOrigin], 1],
+      ["privileged field", [valid, { ...valid, upstream_url: "https://secret.example/path" }], 1],
+      ["wrong format", [valid, safeUpstream("python", "PyPI")], 1],
+      ["malformed record", [valid, {}], 1],
+      ["non-array format entry", { ...valid }, 0],
+    ];
+
+    for (const [name, groupedValue, expectedMatches] of cases) {
+      const state = completeRepositoryState({ npm: [] });
+      state.groupedUpstreams.set("npm", groupedValue);
+      const service = new UpstreamPullService({}, {
+        upstreamChecker: {
+          async getRepositoryUpstreamStateForFormats() { return state; },
+        },
+      });
+      const result = await service._findMatchingRepositories(
+        "workspace", [{ slug: "repo" }], ["npm"],
+        service._createPreparationOperation(null, null)
+      );
+      assert.strictEqual(result.complete, false, name);
+      assert.strictEqual(result.matches.length, expectedMatches, name);
+      if (expectedMatches > 0) {
+        assert.deepStrictEqual(result.matches[0].activeUpstreamsByFormat.get("npm"), [valid], name);
+      }
+    }
+  });
+
+  test("treats absent and empty requested grouped entries as valid verified absence", async () => {
+    for (const [name, groupedUpstreams] of [
+      ["absent", new Map()],
+      ["empty", new Map([["npm", []]])],
+    ]) {
+      const state = completeRepositoryState({ npm: [] });
+      state.groupedUpstreams = groupedUpstreams;
+      const service = new UpstreamPullService({}, {
+        upstreamChecker: {
+          async getRepositoryUpstreamStateForFormats() { return state; },
+        },
+      });
+      const result = await service._findMatchingRepositories(
+        "workspace", [{ slug: "repo" }], ["npm"],
+        service._createPreparationOperation(null, null)
+      );
+      assert.strictEqual(result.complete, true, name);
+      assert.deepStrictEqual(result.matches, [], name);
+    }
   });
 });

--- a/util/terraformExporter.js
+++ b/util/terraformExporter.js
@@ -205,6 +205,7 @@ async function fetchRepositoryUpstreams(context, workspace, repoSlug, options = 
   const upstreamData = await getAllUpstreamData(context, workspace, repoSlug, {
     ...options,
     bypassCache: true,
+    projection: "privileged",
   });
   if (upstreamData === null) {
     return null;

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -10,16 +10,26 @@ const {
   resolveConnectionManager,
 } = require("./accountOperation");
 const {
+  getInspectableUpstreamFormats,
   getSupportedUpstreamFormats,
+  getUpstreamFormatDescriptor,
   SUPPORTED_UPSTREAM_FORMATS,
 } = require("./upstreamFormats");
 const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
-const { formatUpstreamError } = require("./upstreamPresentation");
+const {
+  formatUpstreamError,
+  formatUpstreamOrigin,
+  normalizeUpstreamFailure,
+} = require("./upstreamPresentation");
 
-const UPSTREAM_CACHE_SCHEMA_VERSION = 3;
+const UPSTREAM_CACHE_SCHEMA_VERSION = 4;
 const UPSTREAM_CACHE_TTL_MS = 10 * 60 * 1000;
-const UPSTREAM_FETCH_BATCH_SIZE = 5;
-const UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v3";
+// Four active page requests is conservative enough for the API rate limit while
+// avoiding the latency-amplifying batch barriers used by the previous path.
+const UPSTREAM_REQUEST_CONCURRENCY = 4;
+// Compatibility export for callers that referenced the former batching name.
+const UPSTREAM_FETCH_BATCH_SIZE = UPSTREAM_REQUEST_CONCURRENCY;
+const UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v4";
 const MAX_PERSISTED_UPSTREAMS = 5000;
 const MAX_PERSISTED_UPSTREAMS_PER_FORMAT = 500;
 const MAX_PERSISTED_STRING_LENGTH = 2048;
@@ -28,12 +38,16 @@ const MAX_PERSISTED_DISTRO_VERSIONS = 100;
 const MAX_RUNTIME_UPSTREAMS = 5000;
 const MAX_RUNTIME_UPSTREAMS_PER_FORMAT = 500;
 const MAX_RUNTIME_URL_LENGTH = 8192;
+const MAX_REPOSITORY_IDENTITY_LENGTH = 500;
 const LOCAL_PACKAGE_PAGE_SIZE = 100;
 const MAX_LOCAL_PACKAGE_PAGES = 20;
 const MAX_LOCAL_PACKAGES = LOCAL_PACKAGE_PAGE_SIZE * MAX_LOCAL_PACKAGE_PAGES;
-const BENIGN_UPSTREAM_FORMAT_STATUS_CODES = new Set([400, 404, 405, 422]);
+const UPSTREAM_PAGE_SIZE = 100;
+const MAX_UPSTREAM_PAGES_PER_FORMAT = 5;
+const UPSTREAM_OPERATION_TIMEOUT_MS = 45_000;
 const PERSISTED_UPSTREAM_KEYS = Object.freeze([
   "name",
+  "slug_perm",
   "is_active",
   "_format",
   "format",
@@ -47,10 +61,12 @@ const PERSISTED_UPSTREAM_KEYS = Object.freeze([
   "distribution",
   "distro_versions",
   "upstream_distribution",
+  "origin",
 ]);
 const persistedUpstreamKeySet = new Set(PERSISTED_UPSTREAM_KEYS);
 const persistedStringFieldLimits = new Map([
   ["name", MAX_PERSISTED_NAME_LENGTH],
+  ["slug_perm", MAX_PERSISTED_NAME_LENGTH],
   ["_format", MAX_PERSISTED_NAME_LENGTH],
   ["format", MAX_PERSISTED_NAME_LENGTH],
   ["mode", MAX_PERSISTED_NAME_LENGTH],
@@ -59,6 +75,7 @@ const persistedStringFieldLimits = new Map([
   ["index_status", MAX_PERSISTED_NAME_LENGTH],
   ["distribution", MAX_PERSISTED_STRING_LENGTH],
   ["upstream_distribution", MAX_PERSISTED_STRING_LENGTH],
+  ["origin", MAX_PERSISTED_STRING_LENGTH],
 ]);
 const cacheOperations = new WeakMap();
 const cacheWriteQueues = new WeakMap();
@@ -75,9 +92,10 @@ function hasExactKeys(value, expectedKeys) {
 }
 
 function getUpstreamCacheKey(workspace, repo, formats = SUPPORTED_UPSTREAM_FORMATS) {
-  const normalizedFormats = getSupportedUpstreamFormats(formats);
+  const normalizedFormats = getSupportedUpstreamFormats(formats).sort();
+  const canonicalAllFormats = [...SUPPORTED_UPSTREAM_FORMATS].sort();
   const isAllFormats = normalizedFormats.length === SUPPORTED_UPSTREAM_FORMATS.length
-    && normalizedFormats.every((format, index) => format === SUPPORTED_UPSTREAM_FORMATS[index]);
+    && normalizedFormats.every((format, index) => format === canonicalAllFormats[index]);
   const tuple = isAllFormats
     ? ["all", workspace, repo]
     : ["formats", workspace, repo, normalizedFormats];
@@ -165,7 +183,12 @@ function normalizePersistedField(key, value) {
   if (["is_active", "verify_ssl"].includes(key)) {
     return typeof value === "boolean" ? value : null;
   }
-  if (["index_package_count", "priority"].includes(key)) {
+  if (key === "priority") {
+    return Number.isSafeInteger(value) && value >= 0
+      ? value
+      : boundedString(value, MAX_PERSISTED_NAME_LENGTH);
+  }
+  if (key === "index_package_count") {
     return Number.isSafeInteger(value) && value >= 0 ? value : null;
   }
   if (key === "distro_versions") {
@@ -195,46 +218,70 @@ function serializeUpstreamArray(upstreams, max = MAX_PERSISTED_UPSTREAMS) {
   return serialized.every(Boolean) ? serialized : null;
 }
 
-function canonicalizeRuntimeUpstream(value) {
+function canonicalizeRuntimeUpstream(value, options = {}) {
   if (!isObjectRecord(value)) return null;
   const name = boundedString(value.name, MAX_PERSISTED_NAME_LENGTH);
   if (!name) return null;
   const canonical = { name };
   for (const key of PERSISTED_UPSTREAM_KEYS) {
-    if (key === "name" || value[key] === undefined) continue;
+    if (["name", "origin", "_format", "format"].includes(key) || value[key] == null) continue;
     const normalized = normalizePersistedField(key, value[key]);
     if (normalized !== null) {
       canonical[key] = normalized;
       continue;
     }
-    if (
-      key === "priority"
-      && typeof value.priority === "string"
-      && boundedString(value.priority, MAX_PERSISTED_NAME_LENGTH)
-    ) {
-      canonical.priority = value.priority;
-      continue;
-    }
     return null;
   }
-  if (value.upstream_url !== undefined) {
-    if (!boundedString(value.upstream_url, MAX_RUNTIME_URL_LENGTH)) return null;
+  if (!isValidUpstreamUrl(value.upstream_url)) return null;
+  canonical.origin = safeInventoryOrigin(value.upstream_url);
+  // Privileged projection is explicit, ephemeral, and never persisted. The
+  // default inventory projection contains no URL path, userinfo, query, hash,
+  // authentication, or custom-header values.
+  if (options.privileged === true) {
     canonical.upstream_url = value.upstream_url;
   }
   for (const key of [
     "auth_mode", "auth_username", "extra_header_1", "extra_value_1",
     "extra_header_2", "extra_value_2",
   ]) {
-    if (value[key] === undefined) continue;
+    if (value[key] == null) continue;
     const normalized = boundedString(value[key], MAX_PERSISTED_STRING_LENGTH);
     if (normalized === null) return null;
-    canonical[key] = normalized;
+    if (options.privileged === true) canonical[key] = normalized;
   }
   return canonical;
 }
 
+function safeInventoryOrigin(value) {
+  try {
+    const parsed = new URL(value);
+    if (
+      !["http:", "https:"].includes(parsed.protocol)
+      || parsed.username
+      || parsed.password
+      || parsed.search
+      || parsed.hash
+    ) return "";
+    const origin = formatUpstreamOrigin(value);
+    return origin === "Origin unavailable" ? "" : origin;
+  } catch {
+    return "";
+  }
+}
+
+function isValidUpstreamUrl(value) {
+  if (!boundedString(value, MAX_RUNTIME_URL_LENGTH)) return false;
+  try {
+    const parsed = new URL(value);
+    return ["http:", "https:"].includes(parsed.protocol) && Boolean(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 function isPersistedUpstream(value) {
-  return isUpstreamRecord(value)
+  return isObjectRecord(value)
+    && Boolean(boundedString(value.name, MAX_PERSISTED_NAME_LENGTH))
     && Object.keys(value).every(key => persistedUpstreamKeySet.has(key))
     && Object.entries(value).every(([key, fieldValue]) => {
       const normalized = normalizePersistedField(key, fieldValue);
@@ -269,6 +316,7 @@ function getCachedFlatResponse(
   if (!globalState || typeof globalState.get !== "function") return null;
   const cached = globalState.get(cacheKey);
   if (cached === undefined) return null;
+  const inspectableFormats = getInspectableUpstreamFormats(requestedFormats);
   const valid = isAccountEnvelope(cached, account, [
     "accountEpoch", "activationId", "active", "failedFormats", "successfulFormats",
     "timestamp", "total", "upstreams", "version",
@@ -282,32 +330,40 @@ function getCachedFlatResponse(
     && cached.active === cached.upstreams.filter(upstream => upstream.is_active !== false).length
     && Array.isArray(cached.failedFormats) && cached.failedFormats.length === 0
     && Number.isInteger(cached.successfulFormats)
-    && cached.successfulFormats === requestedFormats.length
+    && cached.successfulFormats === inspectableFormats.length
     && cached.upstreams.every((upstream) => {
       const taggedFormats = [upstream._format, upstream.format]
         .filter(value => value !== undefined);
       return taggedFormats.length > 0
         && taggedFormats.every(value => value === taggedFormats[0])
-        && requestedFormats.includes(taggedFormats[0]);
+        && inspectableFormats.includes(taggedFormats[0]);
     })
-    && new Set(cached.upstreams.map(upstream => `${upstream._format || upstream.format}\0${upstream.name}`)).size
+    && new Set(cached.upstreams.map((upstream) => {
+      const format = upstream._format || upstream.format;
+      const identity = upstream.slug_perm ? `slug:${upstream.slug_perm}` : `name:${upstream.name}`;
+      return `${format}\0${identity}`;
+    })).size
       === cached.upstreams.length;
   if (!valid) {
     evictCacheEntry(globalState, cacheKey, workspace, repo);
     return null;
   }
-  return {
-    upstreams: cached.upstreams.map(upstream => ({ ...upstream })),
-    active: cached.active,
-    total: cached.total,
-    failedFormats: [],
-    uninspectedFormats: [],
-    successfulFormats: cached.successfulFormats,
-    complete: true,
-    incomplete: false,
-    partial: false,
-    cancelled: false,
-  };
+  const cachedUpstreams = cached.upstreams.map(upstream => ({ ...upstream }));
+  const outcomes = getUniqueRequestedDescriptors(requestedFormats).map((descriptor) => {
+    if (!descriptor.inspectable) {
+      return makeFormatOutcome(descriptor.format, null, "unsupported", [], true);
+    }
+    return makeFormatOutcome(
+      descriptor.format,
+      descriptor.apiFormat,
+      "success",
+      cachedUpstreams.filter(upstream => (
+        (upstream._format || upstream.format) === descriptor.format
+      )),
+      true
+    );
+  });
+  return buildAggregateResult(outcomes, 0);
 }
 
 async function persistFlatResponse(
@@ -360,12 +416,14 @@ async function persistFlatResponse(
   });
 }
 
-function isBenignUpstreamFormatError(error) {
-  return Boolean(error) && BENIGN_UPSTREAM_FORMAT_STATUS_CODES.has(error.status);
+// Retained for compatibility with callers outside the inventory path. HTTP
+// status alone can never prove that a format is unsupported or empty.
+function isBenignUpstreamFormatError() {
+  return false;
 }
 
-function isWarningWorthyUpstreamFormatError(error) {
-  return !isBenignUpstreamFormatError(error);
+function isWarningWorthyUpstreamFormatError() {
+  return true;
 }
 
 function isAbortError(error) {
@@ -374,6 +432,14 @@ function isAbortError(error) {
 
 function isCancelled(options = {}) {
   return Boolean(options.signal?.aborted || options.cancellationToken?.isCancellationRequested);
+}
+
+function isCanonicalRepositoryIdentity(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= MAX_REPOSITORY_IDENTITY_LENGTH
+    && value === value.trim()
+    && !/[\u0000-\u001f\u007f]/u.test(value);
 }
 
 function getActiveUpstreamsFromRepositoryState(state, format) {
@@ -397,50 +463,292 @@ function sortUpstreams(left, right) {
 }
 
 async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) {
+  const descriptor = getUpstreamFormatDescriptor(format);
+  if (!descriptor) {
+    return makeFormatOutcome(format, null, "failed", [], false, {
+      kind: "invalid_request",
+    });
+  }
+  if (!descriptor.inspectable) {
+    return makeFormatOutcome(descriptor.format, null, "unsupported", [], true, null);
+  }
+
+  const retained = [];
+  const seen = new Set();
+  let page = 1;
+  let paginationAnchor = null;
   try {
-    if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
-    const request = () => api.get(apiEndpoint(["repos", workspace, repo, "upstream", format]), {
+    while (page <= MAX_UPSTREAM_PAGES_PER_FORMAT) {
+      if (isCancelled(options)) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "cancelled", retained, false,
+          { kind: "cancelled" }, page
+        );
+      }
+      const endpoint = apiEndpoint(
+        ["repos", workspace, repo, "upstream", descriptor.apiFormat],
+        { query: { page, page_size: UPSTREAM_PAGE_SIZE } }
+      );
+      const request = () => api.get(endpoint, {
         responseType: "array",
-        validate: value => isUpstreamArray(value, format),
+        validate: Array.isArray,
         retry: "never",
         signal: options.signal,
         cancellationToken: options.cancellationToken,
       });
-    const result = options.scheduler
-      ? await options.scheduler.run(request, options)
-      : await request();
-    if (isCancelled(options)) return { format, status: "aborted", upstreams: [] };
-    if (!result.ok) {
-      if (result.error.kind === "cancelled") return { format, status: "aborted", upstreams: [] };
-      return isWarningWorthyUpstreamFormatError(result.error)
-        ? { format, status: "failed", error: result.error, upstreams: [] }
-        : { format, status: "loaded", upstreams: [] };
+      const result = options.scheduler
+        ? await options.scheduler.run(request, options)
+        : await request();
+      if (isCancelled(options)) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "cancelled", retained, false,
+          { kind: "cancelled" }, page
+        );
+      }
+      if (!result || !result.ok) {
+        const failure = normalizeUpstreamFailure(result || null);
+        const state = failure.category === "cancelled" ? "cancelled" : "failed";
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, state, retained, false, result || null, page
+        );
+      }
+      const raw = Array.isArray(result.data) ? result.data : null;
+      if (!raw || raw.length > MAX_RUNTIME_UPSTREAMS_PER_FORMAT) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "failed", retained, false,
+          { kind: "invalid_response", status: result.status, requestId: result.requestId,
+            serverRequestId: result.serverRequestId }, page
+        );
+      }
+      const canonicalPage = raw.map(value => canonicalizeRuntimeUpstream(value, {
+        privileged: options.projection === "privileged",
+      }));
+      if (canonicalPage.some(value => value === null)) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "failed", retained, false,
+          { kind: "invalid_response", status: result.status, requestId: result.requestId,
+            serverRequestId: result.serverRequestId }, page
+        );
+      }
+      for (const upstream of canonicalPage) {
+        const identity = upstreamIdentity(descriptor, upstream);
+        if (!identity || seen.has(identity)) {
+          return makeFormatOutcome(
+            descriptor.format, descriptor.apiFormat, "failed", retained, false,
+            { kind: "invalid_response", status: result.status, requestId: result.requestId,
+              serverRequestId: result.serverRequestId }, page
+          );
+        }
+        seen.add(identity);
+        retained.push({ ...upstream, _format: descriptor.format, format: descriptor.format });
+      }
+
+      const pagination = parseUpstreamPagination(result.headers || {}, page, raw.length);
+      if (pagination === "empty") {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "success", retained, true, null, page
+        );
+      }
+      if (!pagination) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "incomplete", retained, false,
+          { kind: "invalid_response", status: result.status, requestId: result.requestId,
+            serverRequestId: result.serverRequestId }, page
+        );
+      }
+      if (pagination !== "empty") {
+        if (paginationAnchor && (
+          pagination.count !== paginationAnchor.count
+          || pagination.pageTotal !== paginationAnchor.pageTotal
+          || pagination.pageSize !== paginationAnchor.pageSize
+        )) {
+          return makeFormatOutcome(
+            descriptor.format, descriptor.apiFormat, "incomplete", retained, false,
+            { kind: "invalid_response", status: result.status, requestId: result.requestId,
+              serverRequestId: result.serverRequestId }, page
+          );
+        }
+        paginationAnchor ||= pagination;
+      }
+      if (page >= pagination.pageTotal) {
+        return makeFormatOutcome(
+          descriptor.format, descriptor.apiFormat, "success", retained, true, null, page
+        );
+      }
+      page += 1;
     }
-    if (!isUpstreamArray(result.data, format)) {
-      return {
-        format,
-        status: "failed",
-        error: invalidUpstreamResponseError(),
-        upstreams: [],
-      };
-    }
-    return {
-      format,
-      status: "loaded",
-      upstreams: result.data.map(upstream => ({
-        ...canonicalizeRuntimeUpstream(upstream),
-        _format: format,
-        format,
-      })),
-    };
+    return makeFormatOutcome(
+      descriptor.format, descriptor.apiFormat, "incomplete", retained, false,
+      { kind: "resource_limit" }, MAX_UPSTREAM_PAGES_PER_FORMAT
+    );
   } catch (error) {
-    if (["request_limit", "rate_limit_circuit"].includes(error && error.kind)) {
-      return { format, status: "uninspected", error, upstreams: [] };
-    }
-    return isAbortError(error) || error?.kind === "cancelled" || isCancelled(options)
-      ? { format, status: "aborted", upstreams: [] }
-      : { format, status: "failed", error, upstreams: [] };
+    const failure = normalizeUpstreamFailure(error);
+    const state = isCancelled(options) || failure.category === "cancelled"
+      ? "cancelled"
+      : ["request_limit", "rate_limit"].includes(failure.category)
+        ? "uninspected"
+        : "failed";
+    return makeFormatOutcome(
+      descriptor.format, descriptor.apiFormat, state, retained, false, error, page
+    );
   }
+}
+
+function upstreamIdentity(descriptor, upstream) {
+  const slug = boundedString(upstream.slug_perm, MAX_PERSISTED_NAME_LENGTH);
+  const fallback = boundedString(upstream.name, MAX_PERSISTED_NAME_LENGTH);
+  return slug
+    ? `${descriptor.apiFormat}\0slug:${slug}`
+    : fallback ? `${descriptor.apiFormat}\0name:${fallback}` : null;
+}
+
+function parseUpstreamPagination(headers, requestedPage, itemCount) {
+  const names = [
+    "x-pagination-page", "x-pagination-pagetotal", "x-pagination-count",
+    "x-pagination-pagesize",
+  ];
+  const present = names.some(name => headers[name] !== undefined);
+  if (!present) return requestedPage === 1 && itemCount === 0 ? "empty" : null;
+  const values = names.map(name => parseStrictNonNegativeInteger(headers[name]));
+  if (values.some(value => value === null)) return null;
+  const [page, pageTotal, count, pageSize] = values;
+  if (
+    page !== requestedPage
+    || pageTotal < 1
+    || page > pageTotal
+    || pageSize < 1
+    || pageSize > UPSTREAM_PAGE_SIZE
+    || itemCount > pageSize
+    || pageTotal !== Math.max(1, Math.ceil(count / pageSize))
+  ) return null;
+  const expected = Math.min(pageSize, Math.max(0, count - ((page - 1) * pageSize)));
+  return expected === itemCount ? { page, pageTotal, count, pageSize } : null;
+}
+
+function parseStrictNonNegativeInteger(value) {
+  if (value === undefined) return null;
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) return null;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function makeFormatOutcome(format, apiFormat, state, entries, authoritative, source = null, pageCount = 0) {
+  const failure = ["failed", "incomplete", "uninspected", "cancelled"].includes(state)
+    ? normalizeUpstreamFailure(source)
+    : null;
+  return Object.freeze({
+    format,
+    apiFormat,
+    state,
+    status: state === "success" ? "loaded" : state === "cancelled" ? "aborted" : state,
+    entries: Object.freeze(entries.map(entry => Object.freeze({ ...entry }))),
+    upstreams: Object.freeze(entries.map(entry => Object.freeze({ ...entry }))),
+    authoritative: authoritative === true,
+    failure,
+    pageCount,
+  });
+}
+
+function getUniqueRequestedDescriptors(formats) {
+  return formats.map(getUpstreamFormatDescriptor).filter(Boolean);
+}
+
+function createOperationDeadline(options, scheduler) {
+  const controller = new AbortController();
+  const externalSignal = options.signal;
+  let expired = false;
+  const abort = () => {
+    controller.abort();
+    scheduler.cancel();
+  };
+  const onExternalAbort = () => abort();
+  if (externalSignal?.aborted) abort();
+  else externalSignal?.addEventListener?.("abort", onExternalAbort, { once: true });
+  const requestedTimeout = Number(options.operationTimeoutMs);
+  const timeoutMs = Number.isSafeInteger(requestedTimeout) && requestedTimeout > 0
+    ? Math.min(requestedTimeout, UPSTREAM_OPERATION_TIMEOUT_MS)
+    : UPSTREAM_OPERATION_TIMEOUT_MS;
+  const timer = setTimeout(() => {
+    expired = true;
+    abort();
+  }, timeoutMs);
+  timer.unref?.();
+  return {
+    signal: controller.signal,
+    timedOut: () => expired,
+    dispose() {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener?.("abort", onExternalAbort);
+    },
+  };
+}
+
+function buildAggregateResult(outcomes, requestCount, options = {}) {
+  const entries = outcomes.flatMap(outcome => outcome.entries);
+  if (entries.length > MAX_RUNTIME_UPSTREAMS) {
+    const overflow = outcomes.find(outcome => outcome.entries.length > 0);
+    return buildAggregateResult(outcomes.map(outcome => outcome === overflow
+      ? makeFormatOutcome(
+        outcome.format, outcome.apiFormat, "failed", [], false,
+        { kind: "resource_limit" }, outcome.pageCount
+      )
+      : outcome), requestCount, options);
+  }
+  entries.sort(sortUpstreams);
+  const failedOutcomes = outcomes.filter(outcome => outcome.state === "failed");
+  const uninspectedOutcomes = outcomes.filter(outcome => (
+    ["incomplete", "uninspected", "cancelled"].includes(outcome.state)
+  ));
+  const unsupportedOutcomes = outcomes.filter(outcome => outcome.state === "unsupported");
+  const successfulOutcomes = outcomes.filter(outcome => (
+    outcome.state === "success" && outcome.authoritative
+  ));
+  const inspectableOutcomes = outcomes.filter(outcome => outcome.apiFormat !== null);
+  const authoritative = outcomes.length === 0 || (
+    inspectableOutcomes.length > 0
+    && inspectableOutcomes.every(outcome => (
+      outcome.state === "success" && outcome.authoritative
+    ))
+  );
+  const cancelled = options.cancelled === true
+    || outcomes.some(outcome => outcome.state === "cancelled");
+  let state = "failed";
+  if (cancelled) state = "cancelled";
+  else if (inspectableOutcomes.length === 0 && unsupportedOutcomes.length > 0) {
+    state = "unsupported";
+  } else if (authoritative) state = entries.length > 0 ? "complete" : "empty";
+  else if (successfulOutcomes.length > 0 || entries.length > 0) state = "partial";
+  const failures = Object.freeze([
+    ...failedOutcomes,
+    ...uninspectedOutcomes.filter(outcome => outcome.failure),
+  ].map(outcome => Object.freeze({
+    format: outcome.format,
+    apiFormat: outcome.apiFormat,
+    state: outcome.state,
+    ...outcome.failure,
+  })));
+  const configuredTotal = authoritative ? entries.length : null;
+  return Object.freeze({
+    state,
+    outcomes: Object.freeze(outcomes.slice()),
+    upstreams: Object.freeze(entries),
+    entries: Object.freeze(entries),
+    active: entries.filter(upstream => upstream.is_active !== false).length,
+    loadedCount: entries.length,
+    total: configuredTotal,
+    configuredTotal,
+    failedFormats: Object.freeze(failedOutcomes.map(outcome => outcome.format)),
+    failures,
+    unsupportedFormats: Object.freeze(unsupportedOutcomes.map(outcome => outcome.format)),
+    uninspectedFormats: Object.freeze(uninspectedOutcomes.map(outcome => outcome.format)),
+    successfulFormats: successfulOutcomes.length,
+    complete: authoritative,
+    incomplete: !authoritative,
+    partial: state === "partial",
+    cancelled,
+    requestCount: Number.isSafeInteger(requestCount) ? requestCount : 0,
+  });
 }
 
 class UpstreamChecker {
@@ -528,54 +836,43 @@ class UpstreamChecker {
   }
 
   async getUpstreamsForFormat(workspace, repo, format, options = {}) {
-    const account = this._captureAccount(options);
-    if (!account) return { data: [], error: null, complete: false, stale: true };
-    let endpoint;
-    try {
-      endpoint = apiEndpoint(["repos", workspace, repo, "upstream", format]);
-    } catch (error) {
-      return { data: [], error, complete: false };
-    }
-    const result = await this.api.get(endpoint, {
-      responseType: "array",
-      validate: value => isUpstreamArray(value, format),
-      retry: "safe-read",
-      signal: options.signal,
-      cancellationToken: options.cancellationToken,
-    });
-    if (!isAccountCurrent(this.connectionManager, account)) {
-      return { data: [], error: null, complete: false, stale: true };
-    }
-    if (!result.ok) {
-      return isBenignUpstreamFormatError(result.error)
-        ? { data: [], error: null, complete: true }
-        : { data: [], error: result.error, complete: false };
-    }
-    if (!isUpstreamArray(result.data, format)) {
-      return { data: [], error: invalidUpstreamResponseError(), complete: false };
-    }
+    const result = await this.getUpstreamDataForFormats(workspace, repo, [format], options);
+    if (!result) return { data: [], error: null, complete: false, stale: true };
+    const failure = result.failures[0] || null;
     return {
-      data: result.data.map(canonicalizeRuntimeUpstream),
-      error: null,
-      complete: true,
+      data: result.upstreams,
+      error: failure,
+      complete: result.complete,
+      stale: false,
     };
   }
 
   async getUpstreamDataForFormats(workspace, repo, formats, options = {}) {
+    if (!isCanonicalRepositoryIdentity(workspace) || !isCanonicalRepositoryIdentity(repo)) {
+      throw new TypeError("Upstream repository identity must be a bounded canonical string");
+    }
+    if (!Array.isArray(formats)) {
+      throw new TypeError("Upstream formats must be an array");
+    }
+    if (formats.some(format => !getUpstreamFormatDescriptor(format))) {
+      throw new TypeError("Upstream formats contain an unrecognized format");
+    }
     const account = this._captureAccount(options);
     if (!account || isCancelled(options)) return null;
     const requestedFormats = getSupportedUpstreamFormats(formats);
+    if (formats.length > 0 && requestedFormats.length === 0) {
+      throw new TypeError("Upstream formats did not contain a recognized canonical format");
+    }
     if (requestedFormats.length === 0) {
-      return {
-        upstreams: [], active: 0, total: 0, failedFormats: [], uninspectedFormats: [],
-        successfulFormats: 0, complete: true, incomplete: false, partial: false, cancelled: false,
-      };
+      return buildAggregateResult([], 0);
     }
     const cacheKey = getUpstreamCacheKey(workspace, repo, requestedFormats);
     const globalState = this.context && this.context.globalState;
-    const operationToken = globalState ? beginCacheOperation(globalState, cacheKey) : null;
+    const operationToken = globalState && options.projection !== "privileged"
+      ? beginCacheOperation(globalState, cacheKey)
+      : null;
     try {
-      const cached = options.bypassCache === true
+      const cached = options.bypassCache === true || options.projection === "privileged"
         ? null
         : getCachedFlatResponse(
           globalState,
@@ -588,63 +885,44 @@ class UpstreamChecker {
         );
       if (cached && isAccountCurrent(this.connectionManager, account)) return cached;
 
-      const upstreams = [];
-      const failedFormats = [];
-      const uninspectedFormats = [];
-      let successfulFormats = 0;
-      const scheduler = options.scheduler || new UpstreamOperationScheduler();
-      for (let index = 0; index < requestedFormats.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
-        if (isCancelled(options) || !isAccountCurrent(this.connectionManager, account)) {
-          scheduler.cancel();
-          return null;
-        }
-        const batch = requestedFormats.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
-        const results = await Promise.all(batch.map(format => (
-          fetchFormatUpstreams(this.api, workspace, repo, format, { ...options, scheduler })
+      const descriptors = getUniqueRequestedDescriptors(requestedFormats);
+      const inspectableCount = descriptors.filter(descriptor => descriptor.inspectable).length;
+      const scheduler = options.scheduler || new UpstreamOperationScheduler({
+        concurrency: UPSTREAM_REQUEST_CONCURRENCY,
+        maxRequests: Math.max(1, inspectableCount * MAX_UPSTREAM_PAGES_PER_FORMAT),
+      });
+      const deadline = createOperationDeadline(options, scheduler);
+      let outcomes;
+      try {
+        outcomes = await Promise.all(descriptors.map(descriptor => fetchFormatUpstreams(
+          this.api,
+          workspace,
+          repo,
+          descriptor.format,
+          { ...options, signal: deadline.signal, scheduler }
         )));
-        if (!isAccountCurrent(this.connectionManager, account)) return null;
-        let cancelled = isCancelled(options);
-        for (const result of results) {
-          if (result.status === "aborted") {
-            cancelled = true;
-            uninspectedFormats.push(result.format);
-          }
-          if (result.status === "uninspected") uninspectedFormats.push(result.format);
-          if (result.status === "failed") failedFormats.push(result.format);
-          if (result.status === "loaded") {
-            if (upstreams.length + result.upstreams.length > MAX_RUNTIME_UPSTREAMS) {
-              failedFormats.push(result.format);
-              continue;
-            }
-            successfulFormats += 1;
-            upstreams.push(...result.upstreams);
-          }
-        }
-        if (cancelled) {
-          scheduler.cancel();
-          uninspectedFormats.push(...requestedFormats.slice(index + batch.length));
-          break;
-        }
+      } finally {
+        deadline.dispose();
       }
-      upstreams.sort(sortUpstreams);
-      const uniqueFailedFormats = [...new Set(failedFormats)];
-      const uniqueUninspectedFormats = [...new Set(uninspectedFormats)];
-      const complete = uniqueFailedFormats.length === 0 && uniqueUninspectedFormats.length === 0;
-      const response = {
-        upstreams,
-        active: upstreams.filter(upstream => upstream.is_active !== false).length,
-        total: upstreams.length,
-        failedFormats: uniqueFailedFormats,
-        uninspectedFormats: uniqueUninspectedFormats,
-        successfulFormats,
-        complete,
-        incomplete: !complete,
-        partial: !complete && successfulFormats > 0,
-        cancelled: isCancelled(options),
-        requestCount: scheduler.requestCount,
-      };
       if (!isAccountCurrent(this.connectionManager, account)) return null;
-      if (!isCancelled(options) && complete && globalState) {
+      if (deadline.timedOut()) {
+        outcomes = outcomes.map(outcome => outcome.state === "cancelled"
+          ? makeFormatOutcome(
+            outcome.format, outcome.apiFormat, "uninspected", outcome.entries, false,
+            { kind: "timeout", retryable: true }, outcome.pageCount
+          )
+          : outcome);
+      }
+      const response = buildAggregateResult(outcomes, scheduler.requestCount, {
+        cancelled: isCancelled(options),
+      });
+      if (!isAccountCurrent(this.connectionManager, account)) return null;
+      if (
+        !isCancelled(options)
+        && options.projection !== "privileged"
+        && response.complete
+        && globalState
+      ) {
         await persistFlatResponse(
           globalState,
           cacheKey,
@@ -654,7 +932,7 @@ class UpstreamChecker {
           account,
           this.connectionManager,
           operationToken,
-          requestedFormats,
+          getInspectableUpstreamFormats(requestedFormats),
           this.now
         );
       }
@@ -697,26 +975,9 @@ class UpstreamChecker {
   }
 
   async getRepositoryUpstreamState(workspace, repo, options = {}) {
-    const account = this._captureAccount(options);
-    if (!account || isCancelled(options)) return this._emptyRepositoryState();
-    const globalState = this.context && this.context.globalState;
-    const cacheKey = this._getRepositoryUpstreamCacheKey(workspace, repo);
-    const operationToken = globalState ? beginCacheOperation(globalState, cacheKey) : null;
-    try {
-      const cached = this._getCachedRepositoryUpstreamState(workspace, repo, account);
-      if (cached && isAccountCurrent(this.connectionManager, account)) return cached;
-      const fetched = await this._fetchRepositoryUpstreamState(workspace, repo, {
-        ...options,
-        account,
-      });
-      if (!isAccountCurrent(this.connectionManager, account)) return this._emptyRepositoryState();
-      if (!isCancelled(options) && fetched.complete) {
-        await this._cacheRepositoryUpstreamState(workspace, repo, fetched, account, operationToken);
-      }
-      return isAccountCurrent(this.connectionManager, account) ? fetched : this._emptyRepositoryState();
-    } finally {
-      finishCacheOperation(globalState, cacheKey, operationToken);
-    }
+    return this.getRepositoryUpstreamStateForFormats(
+      workspace, repo, SUPPORTED_UPSTREAM_FORMATS, options
+    );
   }
 
   async getRepositoryUpstreamStateForFormats(workspace, repo, formats, options = {}) {
@@ -739,13 +1000,10 @@ class UpstreamChecker {
       values.push(upstream);
       grouped.set(format, values);
     }
-    return this._buildRepositoryUpstreamState(
-      grouped,
-      result.failedFormats,
-      result.successfulFormats,
-      result.uninspectedFormats,
-      { cancelled: result.cancelled, requestCount: result.requestCount }
-    );
+    return {
+      ...result,
+      groupedUpstreams: grouped,
+    };
   }
 
   async getRepositoryUpstreams(workspace, repo, options = {}) {
@@ -830,7 +1088,9 @@ class UpstreamChecker {
         && cached.groupedUpstreams[format].every(upstream => (
           upstream._format === format && upstream.format === format
         ))
-        && new Set(cached.groupedUpstreams[format].map(upstream => upstream.name)).size
+        && new Set(cached.groupedUpstreams[format].map((upstream) => (
+          upstream.slug_perm ? `slug:${upstream.slug_perm}` : `name:${upstream.name}`
+        ))).size
           === cached.groupedUpstreams[format].length
       ))
       && formats.reduce((total, format) => (
@@ -889,53 +1149,11 @@ class UpstreamChecker {
   }
 
   async _fetchRepositoryUpstreamState(workspace, repo, options = {}) {
-    const grouped = new Map();
-    const failed = [];
-    const uninspected = [];
-    let successful = 0;
-    const scheduler = options.scheduler || new UpstreamOperationScheduler();
-    for (let index = 0; index < SUPPORTED_UPSTREAM_FORMATS.length; index += UPSTREAM_FETCH_BATCH_SIZE) {
-      if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
-        scheduler.cancel();
-        uninspected.push(...SUPPORTED_UPSTREAM_FORMATS.slice(index));
-        return this._buildRepositoryUpstreamState(
-          grouped, failed, successful, uninspected, { cancelled: true }
-        );
-      }
-      const batch = SUPPORTED_UPSTREAM_FORMATS.slice(index, index + UPSTREAM_FETCH_BATCH_SIZE);
-      const results = await Promise.all(batch.map(format => (
-        fetchFormatUpstreams(this.api, workspace, repo, format, { ...options, scheduler })
-      )));
-      if (isCancelled(options) || !isAccountCurrent(this.connectionManager, options.account)) {
-        scheduler.cancel();
-      }
-      for (const result of results) {
-        if (["aborted", "uninspected"].includes(result.status)) uninspected.push(result.format);
-        if (result.status === "failed") failed.push(result.format);
-        if (result.status === "loaded") {
-          const retainedCount = Array.from(grouped.values()).reduce(
-            (total, upstreams) => total + upstreams.length,
-            0
-          );
-          if (retainedCount + result.upstreams.length > MAX_RUNTIME_UPSTREAMS) {
-            failed.push(result.format);
-            continue;
-          }
-          successful += 1;
-          if (result.upstreams.length > 0) grouped.set(result.format, result.upstreams);
-        }
-      }
-      if (isCancelled(options)) {
-        uninspected.push(...SUPPORTED_UPSTREAM_FORMATS.slice(index + batch.length));
-        break;
-      }
-    }
-    return this._buildRepositoryUpstreamState(
-      grouped,
-      failed,
-      successful,
-      uninspected,
-      { cancelled: isCancelled(options), requestCount: scheduler.requestCount }
+    return this.getRepositoryUpstreamStateForFormats(
+      workspace,
+      repo,
+      SUPPORTED_UPSTREAM_FORMATS,
+      options
     );
   }
 
@@ -1036,37 +1254,6 @@ function incompleteLocalPackageError() {
   });
 }
 
-function isUpstreamRecord(value) {
-  return canonicalizeRuntimeUpstream(value) !== null;
-}
-
-function isUpstreamArray(value, expectedFormat = null) {
-  if (
-    !Array.isArray(value)
-    || value.length > MAX_RUNTIME_UPSTREAMS_PER_FORMAT
-    || !value.every(isUpstreamRecord)
-  ) return false;
-  const names = value.map(upstream => upstream.name);
-  if (new Set(names).size !== names.length) return false;
-  return !expectedFormat || value.every(upstream => (
-    (upstream._format === undefined || upstream._format === expectedFormat)
-    && (upstream.format === undefined || upstream.format === expectedFormat)
-  ));
-}
-
-function invalidUpstreamResponseError() {
-  return Object.freeze({
-    kind: "invalid_response",
-    status: null,
-    retryable: false,
-    message: "Cloudsmith returned an invalid upstream response.",
-    requestId: null,
-    retryAfterMs: null,
-    outcomeUnknown: false,
-    diagnostic: Object.freeze({}),
-  });
-}
-
 async function getAllUpstreamData(context, workspace, repo, options = {}) {
   const checker = new UpstreamChecker(context, options);
   return checker.getAllUpstreamData(workspace, repo, options);
@@ -1092,5 +1279,6 @@ module.exports = {
   UpstreamChecker,
   UPSTREAM_CACHE_SCHEMA_VERSION,
   UPSTREAM_FETCH_BATCH_SIZE,
+  UPSTREAM_REQUEST_CONCURRENCY,
   UPSTREAM_CACHE_TTL_MS,
 };

--- a/util/upstreamChecker.js
+++ b/util/upstreamChecker.js
@@ -1,4 +1,5 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const { types: { isProxy } } = require("util");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { apiEndpoint } = require("./apiEndpoint");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
@@ -22,14 +23,14 @@ const {
   normalizeUpstreamFailure,
 } = require("./upstreamPresentation");
 
-const UPSTREAM_CACHE_SCHEMA_VERSION = 4;
+const UPSTREAM_CACHE_SCHEMA_VERSION = 5;
 const UPSTREAM_CACHE_TTL_MS = 10 * 60 * 1000;
 // Four active page requests is conservative enough for the API rate limit while
 // avoiding the latency-amplifying batch barriers used by the previous path.
 const UPSTREAM_REQUEST_CONCURRENCY = 4;
 // Compatibility export for callers that referenced the former batching name.
 const UPSTREAM_FETCH_BATCH_SIZE = UPSTREAM_REQUEST_CONCURRENCY;
-const UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v4";
+const UPSTREAM_CACHE_KEY_PREFIX = "cloudsmith-upstreams:v5";
 const MAX_PERSISTED_UPSTREAMS = 5000;
 const MAX_PERSISTED_UPSTREAMS_PER_FORMAT = 500;
 const MAX_PERSISTED_STRING_LENGTH = 2048;
@@ -177,6 +178,14 @@ function boundedString(value, maxLength = MAX_PERSISTED_STRING_LENGTH) {
 }
 
 function normalizePersistedField(key, value) {
+  if (key === "origin") {
+    if (value === "") return "";
+    const origin = boundedString(value, MAX_PERSISTED_STRING_LENGTH);
+    const formatted = origin ? formatUpstreamOrigin(origin) : null;
+    return formatted && formatted !== "Origin unavailable" && formatted === origin
+      ? origin
+      : null;
+  }
   if (persistedStringFieldLimits.has(key)) {
     return boundedString(value, persistedStringFieldLimits.get(key));
   }
@@ -192,21 +201,22 @@ function normalizePersistedField(key, value) {
     return Number.isSafeInteger(value) && value >= 0 ? value : null;
   }
   if (key === "distro_versions") {
-    if (
-      !Array.isArray(value)
-      || value.length > MAX_PERSISTED_DISTRO_VERSIONS
-      || !value.every(item => boundedString(item, MAX_PERSISTED_NAME_LENGTH))
-    ) return null;
-    return value.slice();
+    return snapshotStringArray(
+      value,
+      MAX_PERSISTED_DISTRO_VERSIONS,
+      MAX_PERSISTED_NAME_LENGTH
+    );
   }
   return null;
 }
 
 function serializeUpstream(upstream) {
+  const safeUpstream = sanitizeSafeInventoryUpstream(upstream);
+  if (!safeUpstream) return null;
   const serialized = {};
   for (const key of PERSISTED_UPSTREAM_KEYS) {
-    if (upstream[key] === undefined) continue;
-    const normalized = normalizePersistedField(key, upstream[key]);
+    if (safeUpstream[key] === undefined) continue;
+    const normalized = normalizePersistedField(key, safeUpstream[key]);
     if (normalized !== null) serialized[key] = normalized;
   }
   return serialized.name ? serialized : null;
@@ -219,33 +229,42 @@ function serializeUpstreamArray(upstreams, max = MAX_PERSISTED_UPSTREAMS) {
 }
 
 function canonicalizeRuntimeUpstream(value, options = {}) {
-  if (!isObjectRecord(value)) return null;
-  const name = boundedString(value.name, MAX_PERSISTED_NAME_LENGTH);
+  const source = snapshotOwnDataRecord(value);
+  if (!source) return null;
+  const name = boundedString(source.name, MAX_PERSISTED_NAME_LENGTH);
   if (!name) return null;
+  const expectedDescriptor = getUpstreamFormatDescriptor(options.expectedFormat);
+  if (expectedDescriptor) {
+    for (const key of ["_format", "format"]) {
+      if (source[key] == null) continue;
+      const sourceDescriptor = getUpstreamFormatDescriptor(source[key]);
+      if (sourceDescriptor?.format !== expectedDescriptor.format) return null;
+    }
+  }
   const canonical = { name };
   for (const key of PERSISTED_UPSTREAM_KEYS) {
-    if (["name", "origin", "_format", "format"].includes(key) || value[key] == null) continue;
-    const normalized = normalizePersistedField(key, value[key]);
+    if (["name", "origin", "_format", "format"].includes(key) || source[key] == null) continue;
+    const normalized = normalizePersistedField(key, source[key]);
     if (normalized !== null) {
       canonical[key] = normalized;
       continue;
     }
     return null;
   }
-  if (!isValidUpstreamUrl(value.upstream_url)) return null;
-  canonical.origin = safeInventoryOrigin(value.upstream_url);
+  if (!isValidUpstreamUrl(source.upstream_url)) return null;
+  canonical.origin = safeInventoryOrigin(source.upstream_url);
   // Privileged projection is explicit, ephemeral, and never persisted. The
   // default inventory projection contains no URL path, userinfo, query, hash,
   // authentication, or custom-header values.
   if (options.privileged === true) {
-    canonical.upstream_url = value.upstream_url;
+    canonical.upstream_url = source.upstream_url;
   }
   for (const key of [
     "auth_mode", "auth_username", "extra_header_1", "extra_value_1",
     "extra_header_2", "extra_value_2",
   ]) {
-    if (value[key] == null) continue;
-    const normalized = boundedString(value[key], MAX_PERSISTED_STRING_LENGTH);
+    if (source[key] == null) continue;
+    const normalized = boundedString(source[key], MAX_PERSISTED_STRING_LENGTH);
     if (normalized === null) return null;
     if (options.privileged === true) canonical[key] = normalized;
   }
@@ -279,17 +298,118 @@ function isValidUpstreamUrl(value) {
   }
 }
 
-function isPersistedUpstream(value) {
-  return isObjectRecord(value)
-    && Boolean(boundedString(value.name, MAX_PERSISTED_NAME_LENGTH))
-    && Object.keys(value).every(key => persistedUpstreamKeySet.has(key))
-    && Object.entries(value).every(([key, fieldValue]) => {
-      const normalized = normalizePersistedField(key, fieldValue);
-      if (normalized === null) return false;
-      return Array.isArray(normalized)
-        ? JSON.stringify(normalized) === JSON.stringify(fieldValue)
-        : normalized === fieldValue;
-    });
+/**
+ * Validates the exact secret-free record emitted by the default inventory
+ * projection. `origin` is mandatory: an empty string is the canonical
+ * withheld/unavailable sentinel, while a non-empty value must already be an
+ * origin-only HTTP(S) URL. Privileged and unknown fields are rejected.
+ */
+function sanitizeSafeInventoryUpstream(value, expectedFormat = null) {
+  const source = snapshotOwnDataRecord(value);
+  if (!source) return null;
+  const keys = Object.keys(source);
+  if (!keys.every(key => persistedUpstreamKeySet.has(key))) return null;
+  if (!["name", "_format", "format", "origin"].every(key => (
+    Object.prototype.hasOwnProperty.call(source, key)
+  ))) return null;
+  const descriptor = getUpstreamFormatDescriptor(source.format);
+  const expectedDescriptor = expectedFormat === null
+    ? null
+    : getUpstreamFormatDescriptor(expectedFormat);
+  if (
+    !descriptor?.inspectable
+    || source._format !== descriptor.format
+    || source.format !== descriptor.format
+    || (expectedFormat !== null && expectedDescriptor?.format !== descriptor.format)
+  ) return null;
+  const safe = {};
+  for (const [key, fieldValue] of Object.entries(source)) {
+    const normalized = normalizePersistedField(key, fieldValue);
+    if (normalized === null) return null;
+    if (Array.isArray(normalized)) {
+      const original = snapshotStringArray(
+        fieldValue,
+        MAX_PERSISTED_DISTRO_VERSIONS,
+        MAX_PERSISTED_NAME_LENGTH
+      );
+      if (!original || normalized.length !== original.length
+        || normalized.some((item, index) => item !== original[index])) return null;
+      safe[key] = Object.freeze(normalized.slice());
+    } else {
+      if (normalized !== fieldValue) return null;
+      safe[key] = normalized;
+    }
+  }
+  return Object.freeze(safe);
+}
+
+function isSafeInventoryUpstream(value, expectedFormat = null) {
+  return sanitizeSafeInventoryUpstream(value, expectedFormat) !== null;
+}
+
+function snapshotOwnDataRecord(value) {
+  if (!value || typeof value !== "object" || isProxy(value)) return null;
+  let prototype;
+  let descriptors;
+  try {
+    if (Array.isArray(value)) return null;
+    prototype = Object.getPrototypeOf(value);
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    return null;
+  }
+  if (prototype !== Object.prototype && prototype !== null) return null;
+  const ownKeys = Reflect.ownKeys(descriptors);
+  if (ownKeys.some(key => typeof key !== "string")) return null;
+  const snapshot = Object.create(null);
+  for (const key of ownKeys) {
+    const descriptor = descriptors[key];
+    if (!descriptor || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+    snapshot[key] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function snapshotStringArray(value, maxItems, maxStringLength) {
+  const values = snapshotOwnDataArray(value, maxItems);
+  if (!values) return null;
+  const copy = [];
+  for (const valueItem of values) {
+    const item = boundedString(valueItem, maxStringLength);
+    if (!item) return null;
+    copy.push(item);
+  }
+  return copy;
+}
+
+function snapshotOwnDataArray(value, maxItems) {
+  if (isProxy(value)) return null;
+  let descriptors;
+  try {
+    if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) return null;
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    return null;
+  }
+  const lengthDescriptor = descriptors.length;
+  if (!lengthDescriptor || !Object.prototype.hasOwnProperty.call(lengthDescriptor, "value")) {
+    return null;
+  }
+  const length = lengthDescriptor.value;
+  if (!Number.isSafeInteger(length) || length < 0 || length > maxItems) return null;
+  const keys = Reflect.ownKeys(descriptors);
+  if (keys.some(key => (
+    typeof key !== "string" || (key !== "length" && !/^(0|[1-9]\d*)$/u.test(key))
+  ))) return null;
+  const copy = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || descriptor.enumerable !== true
+      || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+    copy.push(descriptor.value);
+  }
+  return copy;
 }
 
 function isAccountEnvelope(value, account, expectedKeys) {
@@ -314,41 +434,46 @@ function getCachedFlatResponse(
   now
 ) {
   if (!globalState || typeof globalState.get !== "function") return null;
-  const cached = globalState.get(cacheKey);
-  if (cached === undefined) return null;
+  const cachedValue = globalState.get(cacheKey);
+  if (cachedValue === undefined) return null;
+  const cached = snapshotOwnDataRecord(cachedValue);
+  const cachedValues = cached
+    ? snapshotOwnDataArray(cached.upstreams, MAX_PERSISTED_UPSTREAMS)
+    : null;
+  const cachedUpstreams = cachedValues
+    ? cachedValues.map(upstream => sanitizeSafeInventoryUpstream(upstream))
+    : null;
   const inspectableFormats = getInspectableUpstreamFormats(requestedFormats);
-  const valid = isAccountEnvelope(cached, account, [
+  const valid = cachedUpstreams !== null
+    && cachedUpstreams.every(Boolean)
+    && isAccountEnvelope(cached, account, [
     "accountEpoch", "activationId", "active", "failedFormats", "successfulFormats",
     "timestamp", "total", "upstreams", "version",
   ])
     && isFresh(cached.timestamp, now)
-    && Array.isArray(cached.upstreams)
-    && cached.upstreams.length <= MAX_PERSISTED_UPSTREAMS
-    && cached.upstreams.every(isPersistedUpstream)
     && Number.isInteger(cached.active) && cached.active >= 0
-    && Number.isInteger(cached.total) && cached.total === cached.upstreams.length
-    && cached.active === cached.upstreams.filter(upstream => upstream.is_active !== false).length
+    && Number.isInteger(cached.total) && cached.total === cachedUpstreams.length
+    && cached.active === cachedUpstreams.filter(upstream => upstream.is_active !== false).length
     && Array.isArray(cached.failedFormats) && cached.failedFormats.length === 0
     && Number.isInteger(cached.successfulFormats)
     && cached.successfulFormats === inspectableFormats.length
-    && cached.upstreams.every((upstream) => {
+    && cachedUpstreams.every((upstream) => {
       const taggedFormats = [upstream._format, upstream.format]
         .filter(value => value !== undefined);
       return taggedFormats.length > 0
         && taggedFormats.every(value => value === taggedFormats[0])
         && inspectableFormats.includes(taggedFormats[0]);
     })
-    && new Set(cached.upstreams.map((upstream) => {
+    && new Set(cachedUpstreams.map((upstream) => {
       const format = upstream._format || upstream.format;
       const identity = upstream.slug_perm ? `slug:${upstream.slug_perm}` : `name:${upstream.name}`;
       return `${format}\0${identity}`;
     })).size
-      === cached.upstreams.length;
+      === cachedUpstreams.length;
   if (!valid) {
     evictCacheEntry(globalState, cacheKey, workspace, repo);
     return null;
   }
-  const cachedUpstreams = cached.upstreams.map(upstream => ({ ...upstream }));
   const outcomes = getUniqueRequestedDescriptors(requestedFormats).map((descriptor) => {
     if (!descriptor.inspectable) {
       return makeFormatOutcome(descriptor.format, null, "unsupported", [], true);
@@ -521,9 +646,12 @@ async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) 
         );
       }
       const canonicalPage = raw.map(value => canonicalizeRuntimeUpstream(value, {
+        expectedFormat: descriptor.format,
         privileged: options.projection === "privileged",
       }));
-      if (canonicalPage.some(value => value === null)) {
+      if (canonicalPage.some((value, index) => (
+        value === null || !hasCompatibleRawFormatIdentity(raw[index], descriptor)
+      ))) {
         return makeFormatOutcome(
           descriptor.format, descriptor.apiFormat, "failed", retained, false,
           { kind: "invalid_response", status: result.status, requestId: result.requestId,
@@ -592,6 +720,13 @@ async function fetchFormatUpstreams(api, workspace, repo, format, options = {}) 
       descriptor.format, descriptor.apiFormat, state, retained, false, error, page
     );
   }
+}
+
+function hasCompatibleRawFormatIdentity(value, descriptor) {
+  return [value?._format, value?.format].every((format) => {
+    if (format == null) return true;
+    return getUpstreamFormatDescriptor(format)?.format === descriptor.format;
+  });
 }
 
 function upstreamIdentity(descriptor, upstream) {
@@ -981,8 +1116,8 @@ class UpstreamChecker {
   }
 
   async getRepositoryUpstreamStateForFormats(workspace, repo, formats, options = {}) {
+    const result = await this.getUpstreamDataForFormats(workspace, repo, formats, options);
     const requestedFormats = getSupportedUpstreamFormats(formats);
-    const result = await this.getUpstreamDataForFormats(workspace, repo, requestedFormats, options);
     if (result === null) {
       return this._buildRepositoryUpstreamState(
         new Map(),
@@ -1016,25 +1151,37 @@ class UpstreamChecker {
   }
 
   async previewResolution(workspace, repo, name, format, options = {}) {
+    const descriptor = getUpstreamFormatDescriptor(format);
+    if (!descriptor?.inspectable) {
+      throw new TypeError("Upstream preview format must be a recognized inspectable format");
+    }
+    const canonicalFormat = descriptor.format;
     const account = this._captureAccount(options);
     if (!account) return null;
     const sharedOptions = { ...options, account };
     const [localResult, upstreamResult] = await Promise.allSettled([
-      this.existsLocally(workspace, repo, name, format, sharedOptions),
-      this.getUpstreamsForFormat(workspace, repo, format, sharedOptions),
+      this.existsLocally(workspace, repo, name, canonicalFormat, sharedOptions),
+      this.getUpstreamsForFormat(workspace, repo, canonicalFormat, sharedOptions),
     ]);
     if (!isAccountCurrent(this.connectionManager, account)) return null;
     const localPkg = localResult.status === "fulfilled"
       ? localResult.value
       : { data: null, error: localResult.reason, complete: false };
     const upstreams = upstreamResult.status === "fulfilled"
+      && upstreamResult.value && typeof upstreamResult.value === "object"
       ? upstreamResult.value
       : { data: [], error: upstreamResult.reason, complete: false };
-    const configs = Array.isArray(upstreams.data) ? upstreams.data : [];
+    const rawConfigs = Array.isArray(upstreams.data) ? upstreams.data : [];
+    const sanitizedConfigs = rawConfigs.map(upstream => (
+      sanitizeSafeInventoryUpstream(upstream, canonicalFormat)
+    ));
+    const configsValid = sanitizedConfigs.every(Boolean);
+    const configs = sanitizedConfigs.filter(Boolean);
     const active = configs.filter(upstream => upstream.is_active !== false);
+    const upstreamError = upstreams.error || (configsValid ? null : { kind: "invalid_response" });
     return {
       name,
-      format,
+      format: canonicalFormat,
       workspace,
       repo,
       local: {
@@ -1044,8 +1191,8 @@ class UpstreamChecker {
       },
       upstreams: {
         data: { total: configs.length, active: active.length, configs },
-        errorMessage: upstreams.error ? formatUpstreamError(upstreams.error, "upstream") : null,
-        complete: upstreams.complete === true,
+        errorMessage: upstreamError ? formatUpstreamError(upstreamError, "upstream") : null,
+        complete: upstreams.complete === true && configsValid,
       },
       canResolveViaUpstream: active.length > 0,
     };
@@ -1069,32 +1216,44 @@ class UpstreamChecker {
     if (!account || !isAccountCurrent(this.connectionManager, account)) return null;
     const globalState = this.context && this.context.globalState;
     if (!globalState || typeof globalState.get !== "function") return null;
-    const cached = globalState.get(this._getRepositoryUpstreamCacheKey(workspace, repo));
-    if (cached === undefined) return null;
-    const formats = isObjectRecord(cached.groupedUpstreams)
-      ? Object.keys(cached.groupedUpstreams)
-      : [];
-    const valid = isAccountEnvelope(cached, account, [
+    const cachedValue = globalState.get(this._getRepositoryUpstreamCacheKey(workspace, repo));
+    if (cachedValue === undefined) return null;
+    const cached = snapshotOwnDataRecord(cachedValue);
+    const groupedValue = cached ? snapshotOwnDataRecord(cached.groupedUpstreams) : null;
+    const formats = groupedValue ? Object.keys(groupedValue) : [];
+    const safeGrouped = new Map();
+    let groupedValid = groupedValue !== null;
+    for (const format of formats) {
+      const values = snapshotOwnDataArray(
+        groupedValue[format],
+        MAX_PERSISTED_UPSTREAMS_PER_FORMAT
+      );
+      const safeValues = values?.map(upstream => (
+        sanitizeSafeInventoryUpstream(upstream, format)
+      ));
+      if (!safeValues || safeValues.some(value => value === null)) {
+        groupedValid = false;
+        break;
+      }
+      safeGrouped.set(format, safeValues);
+    }
+    const valid = groupedValid && isAccountEnvelope(cached, account, [
       "accountEpoch", "activationId", "groupedUpstreams", "successfulFormats",
       "timestamp", "version",
     ])
       && isFresh(cached.timestamp, this.now())
-      && isObjectRecord(cached.groupedUpstreams)
       && formats.every(format => SUPPORTED_UPSTREAM_FORMATS.includes(format))
       && formats.every(format => (
-        Array.isArray(cached.groupedUpstreams[format])
-        && cached.groupedUpstreams[format].length <= MAX_PERSISTED_UPSTREAMS_PER_FORMAT
-        && cached.groupedUpstreams[format].every(isPersistedUpstream)
-        && cached.groupedUpstreams[format].every(upstream => (
+        safeGrouped.get(format).every(upstream => (
           upstream._format === format && upstream.format === format
         ))
-        && new Set(cached.groupedUpstreams[format].map((upstream) => (
+        && new Set(safeGrouped.get(format).map((upstream) => (
           upstream.slug_perm ? `slug:${upstream.slug_perm}` : `name:${upstream.name}`
         ))).size
-          === cached.groupedUpstreams[format].length
+          === safeGrouped.get(format).length
       ))
       && formats.reduce((total, format) => (
-        total + cached.groupedUpstreams[format].length
+        total + safeGrouped.get(format).length
       ), 0) <= MAX_PERSISTED_UPSTREAMS
       && Number.isInteger(cached.successfulFormats)
       && cached.successfulFormats === SUPPORTED_UPSTREAM_FORMATS.length;
@@ -1103,7 +1262,7 @@ class UpstreamChecker {
       return null;
     }
     return this._buildRepositoryUpstreamState(
-      this._deserializeGroupedUpstreams(cached.groupedUpstreams),
+      safeGrouped,
       [],
       cached.successfulFormats,
       []
@@ -1205,7 +1364,10 @@ class UpstreamChecker {
     const grouped = new Map();
     for (const format of SUPPORTED_UPSTREAM_FORMATS) {
       if (Array.isArray(groupedUpstreams[format])) {
-        grouped.set(format, groupedUpstreams[format].map(upstream => ({ ...upstream })));
+        const upstreams = groupedUpstreams[format]
+          .map(upstream => sanitizeSafeInventoryUpstream(upstream, format))
+          .filter(Boolean);
+        grouped.set(format, upstreams);
       }
     }
     return grouped;
@@ -1271,6 +1433,8 @@ module.exports = {
   getActiveUpstreamsFromRepositoryState,
   getActiveUpstreamCacheOperationCount,
   isBenignUpstreamFormatError,
+  isSafeInventoryUpstream,
+  sanitizeSafeInventoryUpstream,
   getUpstreamCacheKey,
   MAX_PERSISTED_UPSTREAMS,
   MAX_RUNTIME_UPSTREAMS_PER_FORMAT,

--- a/util/upstreamFormats.js
+++ b/util/upstreamFormats.js
@@ -1,33 +1,60 @@
-const SUPPORTED_UPSTREAM_FORMATS = Object.freeze([
-  "alpine",
-  "cargo",
-  "cocoapods",
-  "composer",
-  "conan",
-  "conda",
-  "cran",
-  "dart",
-  "deb",
-  "docker",
-  "generic",
-  "go",
-  "helm",
-  "hex",
-  "huggingface",
-  "luarocks",
-  "maven",
-  "npm",
-  "nuget",
-  "python",
-  "raw",
-  "rpm",
-  "ruby",
-  "swift",
-  "terraform",
-  "vagrant",
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const FORMAT_DEFINITIONS = Object.freeze([
+  ["alpine", true],
+  ["cargo", true],
+  ["cocoapods", false],
+  ["composer", true],
+  ["conan", false],
+  ["conda", true],
+  ["cran", true],
+  ["dart", true],
+  ["deb", true],
+  ["docker", true],
+  ["generic", true],
+  ["go", true],
+  ["helm", true],
+  ["hex", true],
+  ["huggingface", true],
+  ["luarocks", false],
+  ["maven", true],
+  ["npm", true],
+  ["nuget", true],
+  ["python", true],
+  ["raw", false],
+  ["rpm", true],
+  ["ruby", true],
+  ["swift", true],
+  ["terraform", false],
+  ["vagrant", false],
 ]);
 
-const SUPPORTED_UPSTREAM_FORMAT_SET = new Set(SUPPORTED_UPSTREAM_FORMATS);
+const UPSTREAM_FORMAT_DESCRIPTORS = Object.freeze(FORMAT_DEFINITIONS.map((definition) => {
+  const [format, inspectable] = definition;
+  const apiFormat = inspectable ? format : null;
+  return Object.freeze({
+    format,
+    apiFormat,
+    endpoint: apiFormat ? `upstream/${apiFormat}` : null,
+    inspectable,
+  });
+}));
+
+const descriptorByFormat = new Map(
+  UPSTREAM_FORMAT_DESCRIPTORS.map(descriptor => [descriptor.format, descriptor])
+);
+
+const SUPPORTED_UPSTREAM_FORMATS = Object.freeze(
+  UPSTREAM_FORMAT_DESCRIPTORS.map(descriptor => descriptor.format)
+);
+
+const INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS = Object.freeze(
+  UPSTREAM_FORMAT_DESCRIPTORS.filter(descriptor => descriptor.inspectable)
+);
+
+const INSPECTABLE_UPSTREAM_FORMATS = Object.freeze(
+  INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS.map(descriptor => descriptor.format)
+);
 
 function normalizeUpstreamFormat(format) {
   if (typeof format !== "string") {
@@ -35,28 +62,49 @@ function normalizeUpstreamFormat(format) {
   }
 
   const normalized = format.trim().toLowerCase();
-  return SUPPORTED_UPSTREAM_FORMAT_SET.has(normalized) ? normalized : null;
+  return descriptorByFormat.has(normalized) ? normalized : null;
+}
+
+function getUpstreamFormatDescriptor(format) {
+  const normalized = normalizeUpstreamFormat(format);
+  return normalized ? descriptorByFormat.get(normalized) : null;
 }
 
 function getSupportedUpstreamFormats(formats = SUPPORTED_UPSTREAM_FORMATS) {
-  const uniqueFormats = [];
+  return getUniqueDescriptors(formats).map(descriptor => descriptor.format);
+}
+
+function getInspectableUpstreamFormatDescriptors(formats = SUPPORTED_UPSTREAM_FORMATS) {
+  return getUniqueDescriptors(formats).filter(descriptor => descriptor.inspectable);
+}
+
+function getInspectableUpstreamFormats(formats = SUPPORTED_UPSTREAM_FORMATS) {
+  return getInspectableUpstreamFormatDescriptors(formats).map(descriptor => descriptor.format);
+}
+
+function getUniqueDescriptors(formats) {
+  if (!Array.isArray(formats)) return [];
+  const descriptors = [];
   const seen = new Set();
 
   for (const format of formats) {
-    const normalized = normalizeUpstreamFormat(format);
-    if (!normalized || seen.has(normalized)) {
-      continue;
-    }
-
-    seen.add(normalized);
-    uniqueFormats.push(normalized);
+    const descriptor = getUpstreamFormatDescriptor(format);
+    if (!descriptor || seen.has(descriptor.format)) continue;
+    seen.add(descriptor.format);
+    descriptors.push(descriptor);
   }
 
-  return uniqueFormats;
+  return descriptors;
 }
 
 module.exports = {
+  getInspectableUpstreamFormatDescriptors,
+  getInspectableUpstreamFormats,
   getSupportedUpstreamFormats,
+  getUpstreamFormatDescriptor,
+  INSPECTABLE_UPSTREAM_FORMAT_DESCRIPTORS,
+  INSPECTABLE_UPSTREAM_FORMATS,
   normalizeUpstreamFormat,
   SUPPORTED_UPSTREAM_FORMATS,
+  UPSTREAM_FORMAT_DESCRIPTORS,
 };

--- a/util/upstreamGapAnalyzer.js
+++ b/util/upstreamGapAnalyzer.js
@@ -1,6 +1,6 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const { canonicalFormat, normalizePackageName } = require("./packageNameNormalizer");
-const { normalizeUpstreamFormat } = require("./upstreamFormats");
+const { getUpstreamFormatDescriptor, normalizeUpstreamFormat } = require("./upstreamFormats");
 const { UpstreamChecker } = require("./upstreamChecker");
 const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
 
@@ -60,7 +60,7 @@ function classifyDependency(dependency, snapshots, options = {}) {
   }
 
   const upstreamFormat = normalizeUpstreamFormat(format);
-  if (!upstreamFormat) {
+  if (!upstreamFormat || !getUpstreamFormatDescriptor(upstreamFormat)?.inspectable) {
     return {
       upstreamStatus: "unreachable",
       upstreamDetail: "Not available through Cloudsmith",
@@ -155,7 +155,7 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
     ? uncoveredDependencies
     : []).map(dependency => normalizeUpstreamFormat(canonicalFormat(
       dependency && (dependency.format || dependency.ecosystem)
-    ))).filter(Boolean))];
+    ))).filter(format => getUpstreamFormatDescriptor(format)?.inspectable))];
 
   if (repositoriesToInspect.length === 0 || formatsToInspect.length === 0) {
     const emptyPatch = buildGapPatch(uncoveredDependencies, [], { repositoriesComplete });
@@ -202,6 +202,9 @@ async function analyzeUpstreamGaps(uncoveredDependencies, workspace, repositorie
       failedFormats: Array.isArray(state?.failedFormats) ? state.failedFormats : [],
       uninspectedFormats: Array.isArray(state?.uninspectedFormats)
         ? state.uninspectedFormats
+        : [],
+      unsupportedFormats: Array.isArray(state?.unsupportedFormats)
+        ? state.unsupportedFormats
         : [],
     });
 

--- a/util/upstreamPresentation.js
+++ b/util/upstreamPresentation.js
@@ -3,9 +3,12 @@
 const MAX_UPSTREAM_URL_LENGTH = 8192;
 const MAX_DISPLAY_TEXT_LENGTH = 500;
 const MAX_ERROR_MESSAGE_LENGTH = 256;
+const MAX_FAILURE_ID_LENGTH = 128;
+const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
 const CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u;
 const DISPLAY_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/gu;
 const DOT_PATH_SEGMENTS = new Set([".", "..", "%2e", ".%2e", "%2e.", "%2e%2e"]);
+const FAILURE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u;
 
 const ERROR_COPY = Object.freeze({
   local: "The local package collection could not be verified.",
@@ -34,6 +37,158 @@ const ERROR_KIND_COPY = Object.freeze({
   timeout: "The upstream request timed out.",
   unauthorized: "Cloudsmith could not authorize the upstream request.",
 });
+
+const FAILURE_CATEGORY_COPY = Object.freeze({
+  authentication: "Authentication is required to inspect this format.",
+  cancelled: "The upstream request was cancelled.",
+  invalid_response: "Cloudsmith returned invalid upstream data.",
+  network: "Cloudsmith could not be reached.",
+  not_found: "The upstream configuration endpoint was not found.",
+  permission: "You do not have permission to inspect this format.",
+  rate_limit: "Cloudsmith rate limited the upstream request. Try again later.",
+  request_limit: "The upstream inspection reached its request limit.",
+  request_rejected: "The upstream request could not be completed.",
+  server: "Cloudsmith could not complete the upstream request.",
+  timeout: "The upstream request timed out.",
+  uninspected: "This format was not inspected.",
+  unknown: "Upstream availability could not be determined.",
+});
+
+const FAILURE_KIND_CATEGORY = Object.freeze({
+  ABORT_ERR: "cancelled",
+  AbortError: "cancelled",
+  abort: "cancelled",
+  auth: "authentication",
+  authentication: "authentication",
+  cancelled: "cancelled",
+  canceled: "cancelled",
+  forbidden: "permission",
+  http_error: "request_rejected",
+  incomplete_collection: "uninspected",
+  invalid_request: "request_rejected",
+  invalid_response: "invalid_response",
+  network: "network",
+  network_error: "network",
+  not_found: "not_found",
+  permission: "permission",
+  rate_limit_circuit: "rate_limit",
+  rate_limited: "rate_limit",
+  redirect_rejected: "request_rejected",
+  rejected: "request_rejected",
+  request_failed: "request_rejected",
+  request_limit: "request_limit",
+  resource_limit: "request_limit",
+  server_error: "server",
+  timeout: "timeout",
+  transport_error: "network",
+  transport_failure: "network",
+  unauthorized: "authentication",
+  uninspected: "uninspected",
+});
+
+/**
+ * Returns fixed public copy for a normalized failure category. Callers must not
+ * substitute transport messages, exception text, or response bodies.
+ */
+function formatUpstreamFailureCategory(category) {
+  return typeof category === "string"
+    && Object.prototype.hasOwnProperty.call(FAILURE_CATEGORY_COPY, category)
+    ? FAILURE_CATEGORY_COPY[category]
+    : FAILURE_CATEGORY_COPY.unknown;
+}
+
+/**
+ * Projects an arbitrary thrown value or transport result into a small public
+ * diagnostic. Every property access can execute caller-owned code, so reads
+ * are isolated and no arbitrary message, cause, stack, headers, diagnostic,
+ * body, or URL is retained.
+ */
+function normalizeUpstreamFailure(value) {
+  const result = isObjectLike(value) ? value : null;
+  const nestedError = safeProperty(result, "error");
+  const error = isObjectLike(nestedError) ? nestedError : result;
+
+  const kind = boundedFailureKind(safeProperty(error, "kind"))
+    || boundedFailureKind(safeProperty(error, "code"))
+    || boundedFailureKind(safeProperty(error, "name"));
+  const httpStatus = firstHttpStatus(
+    safeProperty(error, "httpStatus"),
+    safeProperty(error, "status"),
+    safeProperty(result, "httpStatus"),
+    safeProperty(result, "status")
+  );
+  const category = failureCategory(kind, httpStatus);
+  const retryable = safeProperty(error, "retryable") === true;
+  const retryAfterMs = normalizedRetryAfter(safeProperty(error, "retryAfterMs"));
+  const requestId = normalizedFailureId(safeProperty(error, "requestId"))
+    || normalizedFailureId(safeProperty(result, "requestId"));
+  const serverRequestId = normalizedFailureId(safeProperty(result, "serverRequestId"))
+    || normalizedFailureId(safeProperty(error, "serverRequestId"));
+
+  return Object.freeze({
+    category,
+    message: formatUpstreamFailureCategory(category),
+    httpStatus,
+    retryable,
+    retryAfterMs,
+    requestId,
+    serverRequestId,
+  });
+}
+
+function failureCategory(kind, httpStatus) {
+  if (httpStatus === 401) return "authentication";
+  if (httpStatus === 403) return "permission";
+  if (httpStatus === 404) return "not_found";
+  if (httpStatus === 408) return "timeout";
+  if (httpStatus === 429) return "rate_limit";
+  if (httpStatus !== null && httpStatus >= 500) return "server";
+  if (httpStatus !== null && httpStatus >= 400) return "request_rejected";
+  return kind && Object.prototype.hasOwnProperty.call(FAILURE_KIND_CATEGORY, kind)
+    ? FAILURE_KIND_CATEGORY[kind]
+    : "unknown";
+}
+
+function isObjectLike(value) {
+  return value !== null && (typeof value === "object" || typeof value === "function");
+}
+
+function safeProperty(value, property) {
+  if (!isObjectLike(value)) return null;
+  try {
+    return value[property];
+  } catch {
+    return null;
+  }
+}
+
+function boundedFailureKind(value) {
+  return typeof value === "string" && value.length > 0 && value.length <= 64
+    ? value
+    : null;
+}
+
+function firstHttpStatus(...values) {
+  for (const value of values) {
+    if (Number.isSafeInteger(value) && value >= 100 && value <= 599) return value;
+  }
+  return null;
+}
+
+function normalizedRetryAfter(value) {
+  return Number.isSafeInteger(value) && value >= 0 && value <= MAX_RETRY_AFTER_MS
+    ? value
+    : null;
+}
+
+function normalizedFailureId(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= MAX_FAILURE_ID_LENGTH
+    && FAILURE_ID.test(value)
+    ? value
+    : null;
+}
 
 /**
  * Converts an upstream-domain failure to bounded public copy. This intentionally
@@ -172,7 +327,9 @@ function hasDotPathSegment(rawUrl) {
 
 module.exports = {
   formatUpstreamError,
+  formatUpstreamFailureCategory,
   formatUpstreamOrigin,
   formatUpstreamText,
   getTerraformUpstreamUrl,
+  normalizeUpstreamFailure,
 };

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -16,7 +16,7 @@ const {
 const { canonicalFormat, normalizePackageName } = require("./packageNameNormalizer");
 const { UpstreamChecker } = require("./upstreamChecker");
 const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
-const { normalizeUpstreamFormat } = require("./upstreamFormats");
+const { getUpstreamFormatDescriptor, normalizeUpstreamFormat } = require("./upstreamFormats");
 const {
   captureAccount,
   isAccountCurrent,
@@ -966,13 +966,17 @@ function normalizeRepositoryCollection(value) {
 
 function isRepositoryInspectionCompleteForFormats(state, formats) {
   if (!state || typeof state !== "object") return false;
+  const requested = Array.isArray(formats) ? formats : [];
+  if (requested.some(format => !getUpstreamFormatDescriptor(format)?.inspectable)) return false;
+  if (Array.isArray(state.unsupportedFormats)
+    && requested.some(format => state.unsupportedFormats.includes(format))) return false;
   if (state.complete === true) return true;
   const unavailable = [
     ...(Array.isArray(state.failedFormats) ? state.failedFormats : []),
     ...(Array.isArray(state.uninspectedFormats) ? state.uninspectedFormats : []),
   ];
   if (unavailable.length === 0) return false;
-  return !(Array.isArray(formats) ? formats : []).some(format => unavailable.includes(format));
+  return !requested.some(format => unavailable.includes(format));
 }
 
 function buildRegistryRequestHeaders(headers) {

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -14,7 +14,7 @@ const {
   resolveAndValidateRegistryUrl,
 } = require("./registryEndpoints");
 const { canonicalFormat, normalizePackageName } = require("./packageNameNormalizer");
-const { UpstreamChecker } = require("./upstreamChecker");
+const { sanitizeSafeInventoryUpstream, UpstreamChecker } = require("./upstreamChecker");
 const { UpstreamOperationScheduler } = require("./upstreamOperationScheduler");
 const { getUpstreamFormatDescriptor, normalizeUpstreamFormat } = require("./upstreamFormats");
 const {
@@ -117,8 +117,9 @@ class UpstreamPullService {
         .map((dependency) => normalizeUpstreamFormat(formatForDependency(dependency)))
         .filter(Boolean)
     )];
+    const inspectionFormats = projectFormats.filter(isPullInspectionFormat);
 
-    if (projectFormats.length === 0) {
+    if (inspectionFormats.length === 0) {
       await this._showInformationMessage(
         "Pull-through caching is not available for the uncovered dependency formats in this project."
       );
@@ -140,15 +141,15 @@ class UpstreamPullService {
     const repositorySearch = await this._findMatchingRepositories(
       workspace,
       repositoryCollection.items,
-      projectFormats,
+      inspectionFormats,
       operation
     );
     if (!this._isPreparationCurrent(operation)) return null;
     if (repositorySearch.matches.length === 0) {
       const incomplete = !repositoryCollection.complete || !repositorySearch.complete;
       const message = incomplete
-        ? `Repository upstream inspection was incomplete for ${formatListLabel(projectFormats)}. No matching proxy was found in the repositories that could be inspected.`
-        : `No repositories have upstream proxies configured for the dependency formats in this project (${formatListLabel(projectFormats)}). Configure an upstream proxy in Cloudsmith to enable pull-through caching.`;
+        ? `Repository upstream inspection was incomplete for ${formatListLabel(inspectionFormats)}. No matching proxy was found in the repositories that could be inspected.`
+        : `No repositories have upstream proxies configured for the dependency formats in this project (${formatListLabel(inspectionFormats)}). Configure an upstream proxy in Cloudsmith to enable pull-through caching.`;
       await (incomplete ? this._showWarningMessage(message) : this._showInformationMessage(message));
       return null;
     }
@@ -238,7 +239,7 @@ class UpstreamPullService {
     }
 
     const dependencyFormat = normalizeUpstreamFormat(formatForDependency(normalizedDependency));
-    if (!dependencyFormat) {
+    if (!dependencyFormat || !isPullInspectionFormat(dependencyFormat)) {
       await this._showInformationMessage(
         `Pull-through caching is not available for ${formatDisplayName(normalizedDependency.format)} dependencies.`
       );
@@ -626,7 +627,8 @@ class UpstreamPullService {
             ? state.groupedUpstreams.get(format)
             : [];
           const activeUpstreams = Array.isArray(upstreams)
-            ? upstreams.filter((upstream) => upstream && upstream.is_active !== false)
+            ? upstreams.map(upstream => sanitizeSafeInventoryUpstream(upstream, format))
+              .filter(upstream => upstream && upstream.is_active !== false)
             : [];
           if (activeUpstreams.length > 0) {
             activeUpstreamsByFormat.set(format, activeUpstreams);
@@ -966,17 +968,106 @@ function normalizeRepositoryCollection(value) {
 
 function isRepositoryInspectionCompleteForFormats(state, formats) {
   if (!state || typeof state !== "object") return false;
-  const requested = Array.isArray(formats) ? formats : [];
-  if (requested.some(format => !getUpstreamFormatDescriptor(format)?.inspectable)) return false;
-  if (Array.isArray(state.unsupportedFormats)
-    && requested.some(format => state.unsupportedFormats.includes(format))) return false;
-  if (state.complete === true) return true;
-  const unavailable = [
-    ...(Array.isArray(state.failedFormats) ? state.failedFormats : []),
-    ...(Array.isArray(state.uninspectedFormats) ? state.uninspectedFormats : []),
+  if (!Array.isArray(formats) || formats.length === 0) return false;
+  const descriptors = [];
+  const seen = new Set();
+  for (const format of formats) {
+    const descriptor = getUpstreamFormatDescriptor(format);
+    if (!descriptor) return false;
+    if (!seen.has(descriptor.format)) descriptors.push(descriptor);
+    seen.add(descriptor.format);
+  }
+  if (!hasCanonicalCapabilityLists(state)) return false;
+  const inspectable = descriptors.filter(descriptor => descriptor.inspectable);
+  if (inspectable.length === 0) return true;
+  if (!Array.isArray(state.outcomes)) return false;
+  const outcomes = new Map();
+  for (const outcome of state.outcomes) {
+    if (!isCanonicalFormatOutcome(outcome) || outcomes.has(outcome.format)) return false;
+    outcomes.set(outcome.format, outcome);
+  }
+  const expectedFailed = new Set();
+  const expectedUninspected = new Set();
+  const expectedUnsupported = new Set();
+  for (const outcome of outcomes.values()) {
+    if (outcome.state === "failed") expectedFailed.add(outcome.format);
+    else if (["incomplete", "uninspected", "cancelled"].includes(outcome.state)) {
+      expectedUninspected.add(outcome.format);
+    } else if (outcome.state === "unsupported") expectedUnsupported.add(outcome.format);
+  }
+  if (!sameFormatSet(state.failedFormats, expectedFailed)
+    || !sameFormatSet(state.uninspectedFormats, expectedUninspected)
+    || !sameFormatSet(state.unsupportedFormats, expectedUnsupported)) return false;
+  const globalInspectable = [...outcomes.values()].filter(outcome => outcome.apiFormat !== null);
+  const aggregateComplete = globalInspectable.length > 0 && globalInspectable.every(outcome => (
+    outcome.state === "success" && outcome.authoritative === true
+  ));
+  if (typeof state.complete !== "boolean") return false;
+  if (state.complete === true && !aggregateComplete) return false;
+  if (state.complete === false && aggregateComplete) return false;
+  if (state.incomplete !== undefined && state.incomplete !== !state.complete) return false;
+  if (!hasValidRequestedGroupedUpstreams(state, inspectable)) return false;
+  return inspectable.every((descriptor) => {
+    const outcome = outcomes.get(descriptor.format);
+    return outcome?.apiFormat === descriptor.apiFormat
+      && outcome.state === "success"
+      && outcome.authoritative === true;
+  });
+}
+
+function hasValidRequestedGroupedUpstreams(state, descriptors) {
+  if (!(state.groupedUpstreams instanceof Map)) return false;
+  for (const descriptor of descriptors) {
+    if (!state.groupedUpstreams.has(descriptor.format)) continue;
+    const upstreams = state.groupedUpstreams.get(descriptor.format);
+    if (!Array.isArray(upstreams) || upstreams.some(upstream => (
+      !sanitizeSafeInventoryUpstream(upstream, descriptor.format)
+    ))) return false;
+  }
+  return true;
+}
+
+function sameFormatSet(values, expected) {
+  return values.length === expected.size && values.every(value => expected.has(value));
+}
+
+function isPullInspectionFormat(format) {
+  const descriptor = getUpstreamFormatDescriptor(format);
+  return Boolean(descriptor?.inspectable && !isPullUnsupportedFormat(descriptor.format));
+}
+
+function hasCanonicalCapabilityLists(state) {
+  const lists = [
+    [state.failedFormats, true],
+    [state.uninspectedFormats, true],
+    [state.unsupportedFormats, false],
   ];
-  if (unavailable.length === 0) return false;
-  return !requested.some(format => unavailable.includes(format));
+  const seen = new Set();
+  for (const [list, inspectable] of lists) {
+    if (!Array.isArray(list)) return false;
+    for (const format of list) {
+      const descriptor = getUpstreamFormatDescriptor(format);
+      if (!descriptor || descriptor.format !== format || descriptor.inspectable !== inspectable) {
+        return false;
+      }
+      if (seen.has(format)) return false;
+      seen.add(format);
+    }
+  }
+  return true;
+}
+
+function isCanonicalFormatOutcome(outcome) {
+  if (!outcome || typeof outcome !== "object") return false;
+  const descriptor = getUpstreamFormatDescriptor(outcome.format);
+  if (!descriptor || descriptor.format !== outcome.format) return false;
+  if (outcome.apiFormat !== descriptor.apiFormat) return false;
+  if (descriptor.inspectable) {
+    if (outcome.state === "success") return outcome.authoritative === true;
+    return ["failed", "incomplete", "uninspected", "cancelled"].includes(outcome.state)
+      && outcome.authoritative === false;
+  }
+  return outcome.state === "unsupported" && outcome.authoritative === true;
 }
 
 function buildRegistryRequestHeaders(headers) {

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -484,6 +484,13 @@ class UpstreamDetailProvider {
       line-height: 1.3;
       white-space: nowrap;
     }
+    .status-badges {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
     .status-badge-active {
       color: var(--vscode-testing-iconPassed);
     }
@@ -512,13 +519,11 @@ class UpstreamDetailProvider {
       font-family: var(--vscode-editor-font-family);
       font-size: 0.95em;
     }
-    .trust-value-trusted {
+    .status-badge-trusted {
       color: var(--vscode-textLink-foreground);
-      font-weight: 600;
     }
-    .trust-value-untrusted {
+    .status-badge-untrusted {
       color: var(--vscode-testing-iconPassed);
-      font-weight: 600;
     }
     .empty-state {
       margin: 8px 0 0 0;
@@ -572,7 +577,6 @@ class UpstreamDetailProvider {
       this._renderDetail("Mode", typeof upstream.mode === "string" ? upstream.mode : "", ""),
       this._renderDetail("Priority", this._getPriority(upstream), ""),
       this._renderDetail("SSL verification", this._getSslVerification(upstream), ""),
-      this._renderTrustDetail(upstream),
       this._renderDetail("Indexing", this._getIndexingDisplay(upstream), ""),
       this._renderDetail("Distribution", this._getDistribution(upstream), ""),
       this._renderDetail("Created", this._formatCreatedAt(upstream.created_at), ""),
@@ -581,7 +585,10 @@ class UpstreamDetailProvider {
     return `<article class="upstream-card">
   <div class="card-header">
     <div class="card-title">${this._escape(formatUpstreamText(upstream.name, "Unnamed"))}</div>
-    <span class="status-badge ${statusClass}">${this._escape(statusLabel)}</span>
+    <div class="status-badges">
+      <span class="status-badge ${statusClass}">${this._escape(statusLabel)}</span>
+      ${this._renderTrustBadge(upstream)}
+    </div>
   </div>
   <div class="details-grid">
     ${details}
@@ -597,12 +604,12 @@ class UpstreamDetailProvider {
     return `<div class="detail-label">${label}</div><div class="${className}">${this._escape(displayValue)}</div>`;
   }
 
-  _renderTrustDetail(upstream) {
+  _renderTrustBadge(upstream) {
     if (upstream.trust_level === "Trusted") {
-      return `<div class="detail-label">Trust level</div><div class="detail-value trust-value-trusted">${this._escape(upstream.trust_level)}</div>`;
+      return `<span class="status-badge status-badge-trusted">Trusted</span>`;
     }
     if (upstream.trust_level === "Untrusted") {
-      return `<div class="detail-label">Trust level</div><div class="detail-value trust-value-untrusted">${this._escape(upstream.trust_level)}</div>`;
+      return `<span class="status-badge status-badge-untrusted">Untrusted</span>`;
     }
     return "";
   }

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -520,20 +520,6 @@ class UpstreamDetailProvider {
       color: var(--vscode-testing-iconPassed);
       font-weight: 600;
     }
-    .trust-callout {
-      margin-top: 10px;
-      padding: 10px 12px;
-      border: 1px solid var(--vscode-inputValidation-infoBorder);
-      border-radius: 6px;
-      background: var(--vscode-inputValidation-infoBackground);
-      line-height: 1.4;
-    }
-    .trust-callout-title {
-      display: block;
-      margin-bottom: 2px;
-      font-weight: 600;
-      color: var(--vscode-foreground);
-    }
     .empty-state {
       margin: 8px 0 0 0;
       color: var(--vscode-descriptionForeground);
@@ -592,8 +578,6 @@ class UpstreamDetailProvider {
       this._renderDetail("Created", this._formatCreatedAt(upstream.created_at), ""),
     ].filter(Boolean).join("\n");
 
-    const trustCallout = this._renderTrustCallout(upstream);
-
     return `<article class="upstream-card">
   <div class="card-header">
     <div class="card-title">${this._escape(formatUpstreamText(upstream.name, "Unnamed"))}</div>
@@ -602,7 +586,6 @@ class UpstreamDetailProvider {
   <div class="details-grid">
     ${details}
   </div>
-  ${trustCallout}
 </article>`;
   }
 
@@ -621,24 +604,6 @@ class UpstreamDetailProvider {
     if (upstream.trust_level === "Untrusted") {
       return `<div class="detail-label">Trust level</div><div class="detail-value trust-value-untrusted">${this._escape(upstream.trust_level)}</div>`;
     }
-    return "";
-  }
-
-  _renderTrustCallout(upstream) {
-    if (upstream.trust_level === "Trusted") {
-      return `<div class="trust-callout">
-  <span class="trust-callout-title">Trusted upstream:</span>
-  ${this._escape("This source can serve any package, including versions of packages that exist in a private repository. Packages from this upstream are not blocked by dependency confusion protections.")}
-</div>`;
-    }
-
-    if (upstream.trust_level === "Untrusted") {
-      return `<div class="trust-callout">
-  <span class="trust-callout-title">Untrusted upstream (recommended):</span>
-  ${this._escape("If a package name exists in a private repository or another trusted source, this upstream is blocked from serving versions of that package. This protects against namesquatting and dependency confusion attacks.")}
-</div>`;
-    }
-
     return "";
   }
 

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -321,7 +321,6 @@ class UpstreamDetailProvider {
       uninspectedFormats = [],
       successfulFormats,
       failures = [],
-      unsupportedFormats = [],
     } = fetchState;
     const formatSections = [];
     const hasLoadedUpstreams = groupedUpstreams.size > 0;
@@ -365,9 +364,6 @@ class UpstreamDetailProvider {
   )}
 </div>`
       : "";
-    const unsupportedNotice = unsupportedFormats.length > 0
-      ? `<p class="subtle">Not applicable to this API: ${this._escape(unsupportedFormats.join(", "))}.</p>`
-      : "";
     const refreshNotice = options.refreshing
       ? `<p class="subtle">Refreshing upstreams… Existing results remain visible.</p>`
       : options.refreshFailed
@@ -384,8 +380,8 @@ class UpstreamDetailProvider {
       ? `<p class="subtle">Showing ${renderedCount} of ${loadedCount} loaded upstreams.</p>`
       : "";
     const contentHtml = hasLoadedUpstreams
-      ? `${refreshNotice}${partialWarning}${unsupportedNotice}${displayLimitNotice}${formatSections.join("\n")}${retryButton}`
-      : `${refreshNotice}${this._getEmptyOrErrorState(hasFailures, successfulFormats, failures)}${unsupportedNotice}${retryButton}`;
+      ? `${refreshNotice}${partialWarning}${displayLimitNotice}${formatSections.join("\n")}${retryButton}`
+      : `${refreshNotice}${this._getEmptyOrErrorState(hasFailures, successfulFormats, failures)}${retryButton}`;
     const nonce = crypto.randomBytes(16).toString("base64");
     const script = retryButton ? `<script nonce="${nonce}">
   const vscode = acquireVsCodeApi();

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -1,7 +1,15 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 const vscode = require("vscode");
-const { getAllUpstreamData } = require("../util/upstreamChecker");
-const { SUPPORTED_UPSTREAM_FORMATS } = require("../util/upstreamFormats");
+const crypto = require("crypto");
+const { getAllUpstreamData, getUpstreamDataForFormats } = require("../util/upstreamChecker");
 const {
+  getUpstreamFormatDescriptor,
+  INSPECTABLE_UPSTREAM_FORMATS,
+  SUPPORTED_UPSTREAM_FORMATS,
+} = require("../util/upstreamFormats");
+const {
+  formatUpstreamFailureCategory,
   formatUpstreamOrigin,
   formatUpstreamText,
 } = require("../util/upstreamPresentation");
@@ -9,13 +17,29 @@ const {
 const SUPPORTED_FORMATS = SUPPORTED_UPSTREAM_FORMATS;
 const MAX_RENDERED_UPSTREAMS = 200;
 const MAX_DISTRIBUTION_VERSIONS = 20;
+const FAILURE_CATEGORIES = new Set([
+  "authentication", "cancelled", "invalid_response", "network", "not_found",
+  "permission", "rate_limit", "request_limit", "request_rejected", "server",
+  "timeout", "uninspected", "unknown",
+]);
 
 class UpstreamDetailProvider {
-  constructor(context) {
+  constructor(context, options = {}) {
     this.context = context;
+    this._loadUpstreams = options.loadUpstreams || ((workspace, repoSlug, requestOptions) => (
+      Array.isArray(requestOptions.formats)
+        ? getUpstreamDataForFormats(
+          this.context, workspace, repoSlug, requestOptions.formats, requestOptions
+        )
+        : getAllUpstreamData(this.context, workspace, repoSlug, requestOptions)
+    ));
     this._panel = null;
     this._abortController = null;
     this._requestId = 0;
+    this._loadPromise = null;
+    this._lastSettled = null;
+    this._scope = null;
+    this._messageDisposable = null;
   }
 
   async show(workspace, repoSlug, repoName) {
@@ -24,11 +48,19 @@ class UpstreamDetailProvider {
       return;
     }
 
+    const scope = JSON.stringify([workspace, repoSlug]);
+    if (this._loadPromise && this._scope === scope) {
+      this._panel?.reveal(vscode.ViewColumn.One);
+      return this._loadPromise;
+    }
     this._abortInFlightRequest();
+    if (this._scope !== scope) this._lastSettled = null;
+    this._scope = scope;
     const requestId = ++this._requestId;
     const abortController = new AbortController();
     this._abortController = abortController;
     const panel = this._getOrCreatePanel(repoName);
+    let loadPromise = null;
 
     try {
       if (!this._canRender(panel, requestId)) {
@@ -36,9 +68,20 @@ class UpstreamDetailProvider {
       }
 
       panel.title = `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`;
-      panel.webview.html = this._getLoadingHtml(workspace, repoSlug, repoName);
+      panel.webview.html = this._lastSettled
+        ? this._getHtmlContent(workspace, repoSlug, repoName, this._lastSettled, { refreshing: true })
+        : this._getLoadingHtml(workspace, repoSlug, repoName);
 
-      const fetchState = await this._fetchGroupedUpstreams(workspace, repoSlug, abortController.signal);
+      loadPromise = this._fetchGroupedUpstreams(
+        workspace, repoSlug, abortController.signal, { bypassCache: false }
+      );
+      this._loadPromise = loadPromise;
+      let fetchState;
+      try {
+        fetchState = await loadPromise;
+      } catch {
+        fetchState = failedFetchState();
+      }
 
       if (!fetchState) {
         if (this._canRender(panel, requestId) && !abortController.signal.aborted) {
@@ -58,11 +101,64 @@ class UpstreamDetailProvider {
       }
 
       panel.title = `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`;
+      this._lastSettled = fetchState;
       panel.webview.html = this._getHtmlContent(workspace, repoSlug, repoName, fetchState);
     } finally {
       if (this._abortController === abortController) {
         this._abortController = null;
       }
+      if (this._loadPromise === loadPromise) this._loadPromise = null;
+    }
+  }
+
+  retry() {
+    if (!this._scope || this._loadPromise) return this._loadPromise;
+    const [workspace, repoSlug] = JSON.parse(this._scope);
+    const repoName = this._panel?.title?.replace(/^Upstreams:\s*/, "") || repoSlug;
+    return this._reload(workspace, repoSlug, repoName);
+  }
+
+  async _reload(workspace, repoSlug, repoName) {
+    const retryFormats = getRetryFormats(this._lastSettled);
+    if (retryFormats.length === 0) return;
+    this._abortInFlightRequest();
+    const requestId = ++this._requestId;
+    const abortController = new AbortController();
+    this._abortController = abortController;
+    const panel = this._panel;
+    if (!panel) return;
+    panel.webview.html = this._lastSettled
+      ? this._getHtmlContent(workspace, repoSlug, repoName, this._lastSettled, { refreshing: true })
+      : this._getLoadingHtml(workspace, repoSlug, repoName);
+    const promise = this._fetchGroupedUpstreams(workspace, repoSlug, abortController.signal, {
+      bypassCache: true,
+      formats: retryFormats,
+    });
+    this._loadPromise = promise;
+    try {
+      const result = await promise;
+      if (!result || !this._canRender(panel, requestId) || abortController.signal.aborted) return;
+      const settled = mergeRetryState(this._lastSettled, result, retryFormats);
+      this._lastSettled = settled;
+      panel.webview.html = this._getHtmlContent(
+        workspace,
+        repoSlug,
+        repoName,
+        settled,
+        settled.retainedFormats.length > 0 || result.complete !== true
+          ? { refreshFailed: true }
+          : {}
+      );
+    } catch {
+      if (this._canRender(panel, requestId) && !abortController.signal.aborted) {
+        const result = this._lastSettled || failedFetchState();
+        panel.webview.html = this._getHtmlContent(
+          workspace, repoSlug, repoName, result, { refreshFailed: true }
+        );
+      }
+    } finally {
+      if (this._abortController === abortController) this._abortController = null;
+      if (this._loadPromise === promise) this._loadPromise = null;
     }
   }
 
@@ -77,7 +173,7 @@ class UpstreamDetailProvider {
       `Upstreams: ${formatUpstreamText(repoName, "Unknown repository")}`,
       vscode.ViewColumn.One,
       {
-        enableScripts: false,
+        enableScripts: true,
         localResourceRoots: [],
       }
     );
@@ -88,19 +184,35 @@ class UpstreamDetailProvider {
         this._abortInFlightRequest();
       }
     });
+    this._messageDisposable?.dispose?.();
+    this._messageDisposable = panel.webview.onDidReceiveMessage?.((message) => {
+      let validRetry = false;
+      try {
+        const keys = message && typeof message === "object" && !Array.isArray(message)
+          ? Reflect.ownKeys(message)
+          : [];
+        validRetry = keys.length === 1 && keys[0] === "command" && message.command === "retry";
+      } catch {
+        validRetry = false;
+      }
+      if (!validRetry) return;
+      void this.retry();
+    }) || null;
 
     this._panel = panel;
     return panel;
   }
 
-  async _fetchGroupedUpstreams(workspace, repoSlug, signal) {
-    const upstreamData = await getAllUpstreamData(this.context, workspace, repoSlug, {
+  async _fetchGroupedUpstreams(workspace, repoSlug, signal, options = {}) {
+    const upstreamData = await this._loadUpstreams(workspace, repoSlug, {
       signal,
-      bypassCache: true,
+      bypassCache: options.bypassCache === true,
+      formats: options.formats,
     });
     if (upstreamData === null || signal.aborted) {
       return null;
     }
+    if (!isValidAggregate(upstreamData)) return failedFetchState();
 
     const grouped = new Map();
 
@@ -138,6 +250,15 @@ class UpstreamDetailProvider {
         ? upstreamData.successfulFormats
         : 0,
       complete: upstreamData.complete === true,
+      state: upstreamData.state,
+      failures: Array.isArray(upstreamData.failures) ? upstreamData.failures : [],
+      unsupportedFormats: Array.isArray(upstreamData.unsupportedFormats)
+        ? upstreamData.unsupportedFormats
+        : [],
+      configuredTotal: Number.isSafeInteger(upstreamData.configuredTotal)
+        ? upstreamData.configuredTotal
+        : null,
+      retainedFormats: [],
     };
   }
   _abortInFlightRequest() {
@@ -193,12 +314,14 @@ class UpstreamDetailProvider {
 </html>`;
   }
 
-  _getHtmlContent(workspace, repoSlug, repoName, fetchState) {
+  _getHtmlContent(workspace, repoSlug, repoName, fetchState, options = {}) {
     const {
       groupedUpstreams,
       failedFormats = [],
       uninspectedFormats = [],
       successfulFormats,
+      failures = [],
+      unsupportedFormats = [],
     } = fetchState;
     const formatSections = [];
     const hasLoadedUpstreams = groupedUpstreams.size > 0;
@@ -227,26 +350,57 @@ class UpstreamDetailProvider {
 </section>`);
     }
 
+    const safeFailureList = failures.slice(0, 20).map(failure => (
+      `<li><strong>${this._escape(failure.format)}</strong> — ${this._escape(
+        formatUpstreamFailureCategory(failure.category)
+      )}</li>`
+    )).join("");
+    const retryable = getRetryFormats(fetchState).length > 0;
     const partialWarning = hasLoadedUpstreams && hasFailures
       ? `<div class="error-state">
   <span class="error-state-title">Some upstream data could not be loaded.</span>
-  Loaded upstreams are shown, but configuration for ${this._escape(
-    unavailableFormats.length > 0 ? unavailableFormats.join(", ") : "one or more formats"
-  )} is incomplete.
+  ${this._escape(successfulFormats || 0)} formats loaded. The configured total is not available.
+  ${safeFailureList ? `<ul>${safeFailureList}</ul>` : this._escape(
+    unavailableFormats.length > 0 ? unavailableFormats.join(", ") : "One or more formats were not inspected."
+  )}
 </div>`
+      : "";
+    const unsupportedNotice = unsupportedFormats.length > 0
+      ? `<p class="subtle">Not applicable to this API: ${this._escape(unsupportedFormats.join(", "))}.</p>`
+      : "";
+    const refreshNotice = options.refreshing
+      ? `<p class="subtle">Refreshing upstreams… Existing results remain visible.</p>`
+      : options.refreshFailed
+        ? `<p class="subtle">Refresh failed; showing the previous verified results.${
+          Array.isArray(fetchState.retainedFormats) && fetchState.retainedFormats.length > 0
+            ? ` Previously verified: ${this._escape(fetchState.retainedFormats.join(", "))}.`
+            : ""
+        }</p>`
+        : "";
+    const retryButton = retryable
+      ? `<button id="retry" type="button">${options.refreshing ? "Retrying…" : "Retry"}</button>`
       : "";
     const displayLimitNotice = loadedCount > renderedCount
       ? `<p class="subtle">Showing ${renderedCount} of ${loadedCount} loaded upstreams.</p>`
       : "";
     const contentHtml = hasLoadedUpstreams
-      ? `${partialWarning}${displayLimitNotice}${formatSections.join("\n")}`
-      : this._getEmptyOrErrorState(hasFailures, successfulFormats);
+      ? `${refreshNotice}${partialWarning}${unsupportedNotice}${displayLimitNotice}${formatSections.join("\n")}${retryButton}`
+      : `${refreshNotice}${this._getEmptyOrErrorState(hasFailures, successfulFormats, failures)}${unsupportedNotice}${retryButton}`;
+    const nonce = crypto.randomBytes(16).toString("base64");
+    const script = retryButton ? `<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  const retry = document.getElementById("retry");
+  retry?.addEventListener("click", () => {
+    retry.disabled = true;
+    vscode.postMessage({ command: "retry" });
+  });
+</script>` : "";
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; font-src 'none'; base-uri 'none'; form-action 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src 'none'; font-src 'none'; base-uri 'none'; form-action 'none';">
   <style>
     body {
       margin: 0;
@@ -390,22 +544,29 @@ class UpstreamDetailProvider {
   <h1>${this._escape(repoName)}</h1>
   <p class="repo-meta">${this._escape(workspace)}/${this._escape(repoSlug)}</p>
   ${contentHtml}
+  ${script}
 </body>
 </html>`;
   }
 
-  _getEmptyOrErrorState(hasFailures, successfulFormats) {
+  _getEmptyOrErrorState(hasFailures, successfulFormats, failures = []) {
     if (!hasFailures) {
       return `<p class="empty-state">No upstreams configured for this repository.</p>`;
     }
 
     const detail = successfulFormats > 0
-      ? "Some upstream formats could not be loaded, so the upstream configuration could not be determined."
-      : "The upstream configuration could not be loaded for this repository.";
+      ? "No configured upstream could be verified; some formats were inspected successfully."
+      : "The upstream inventory could not be loaded for this repository.";
+    const lines = failures.slice(0, 20).map(failure => (
+      `<li><strong>${this._escape(failure.format)}</strong> — ${this._escape(
+        formatUpstreamFailureCategory(failure.category)
+      )}</li>`
+    )).join("");
 
     return `<div class="error-state">
   <span class="error-state-title">Could not load upstreams.</span>
   ${this._escape(detail)}
+  ${lines ? `<ul>${lines}</ul>` : ""}
 </div>`;
   }
 
@@ -415,7 +576,13 @@ class UpstreamDetailProvider {
     const statusClass = isActive ? "status-badge-active" : "status-badge-inactive";
 
     const details = [
-      this._renderDetail("Origin", formatUpstreamOrigin(upstream.upstream_url), "mono"),
+      this._renderDetail(
+        "Origin",
+        formatUpstreamOrigin(
+          typeof upstream.origin === "string" && upstream.origin ? upstream.origin : upstream.upstream_url
+        ),
+        "mono"
+      ),
       this._renderDetail("Mode", typeof upstream.mode === "string" ? upstream.mode : "", ""),
       this._renderDetail("Priority", this._getPriority(upstream), ""),
       this._renderDetail("SSL verification", this._getSslVerification(upstream), ""),
@@ -590,12 +757,178 @@ class UpstreamDetailProvider {
       this._panel.dispose();
       this._panel = null;
     }
+    this._messageDisposable?.dispose?.();
+    this._messageDisposable = null;
+    this._lastSettled = null;
+    this._scope = null;
   }
 
 
   resetForAccountChange() {
     this.dispose();
   }
+}
+
+function failedFetchState() {
+  return {
+    groupedUpstreams: new Map(),
+    failedFormats: INSPECTABLE_UPSTREAM_FORMATS,
+    uninspectedFormats: [],
+    unsupportedFormats: [],
+    failures: INSPECTABLE_UPSTREAM_FORMATS.map(format => ({
+      format,
+      message: "Upstream availability could not be determined.",
+    })),
+    successfulFormats: 0,
+    configuredTotal: null,
+    complete: false,
+    state: "failed",
+    retainedFormats: [],
+  };
+}
+
+function getRetryFormats(state) {
+  if (!state || typeof state !== "object") return [];
+  const retryableFailures = Array.isArray(state.failures)
+    ? state.failures.filter(failure => failure?.retryable !== false).map(failure => failure.format)
+    : [];
+  return [...new Set([
+    ...retryableFailures,
+    ...(Array.isArray(state.uninspectedFormats) ? state.uninspectedFormats : []),
+  ].filter(format => getUpstreamFormatDescriptor(format)?.inspectable))];
+}
+
+function mergeRetryState(previous, replacement, retriedFormats) {
+  if (!previous) return { ...replacement, retainedFormats: [] };
+  const retried = new Set(retriedFormats);
+  const replacementUnavailable = new Set([
+    ...replacement.failedFormats,
+    ...replacement.uninspectedFormats,
+  ]);
+  const groupedUpstreams = new Map(previous.groupedUpstreams);
+  const retainedFormats = [];
+  for (const format of retried) {
+    if (replacementUnavailable.has(format)) {
+      if (groupedUpstreams.has(format)) retainedFormats.push(format);
+      else if (replacement.groupedUpstreams.has(format)) {
+        groupedUpstreams.set(format, replacement.groupedUpstreams.get(format));
+      }
+    } else if (replacement.groupedUpstreams.has(format)) {
+      groupedUpstreams.set(format, replacement.groupedUpstreams.get(format));
+    } else {
+      groupedUpstreams.delete(format);
+    }
+  }
+  const mergeFormats = (oldValues, newValues) => [...new Set([
+    ...oldValues.filter(format => !retried.has(format)),
+    ...newValues,
+  ])];
+  const failedFormats = mergeFormats(previous.failedFormats, replacement.failedFormats);
+  const uninspectedFormats = mergeFormats(
+    previous.uninspectedFormats,
+    replacement.uninspectedFormats
+  );
+  const unsupportedFormats = mergeFormats(
+    previous.unsupportedFormats,
+    replacement.unsupportedFormats
+  );
+  const failures = [
+    ...previous.failures.filter(failure => !retried.has(failure.format)),
+    ...replacement.failures,
+  ];
+  const complete = failedFormats.length === 0 && uninspectedFormats.length === 0;
+  const loadedCount = [...groupedUpstreams.values()].reduce((sum, entries) => sum + entries.length, 0);
+  const cancelled = replacement.state === "cancelled";
+  const successfulFormats = complete
+    ? INSPECTABLE_UPSTREAM_FORMATS.length
+    : Math.max(previous.successfulFormats, replacement.successfulFormats);
+  return {
+    groupedUpstreams,
+    failedFormats,
+    uninspectedFormats,
+    unsupportedFormats,
+    failures,
+    successfulFormats,
+    configuredTotal: complete ? loadedCount : null,
+    complete,
+    state: complete
+      ? (loadedCount > 0 ? "complete" : "empty")
+      : cancelled
+        ? "cancelled"
+        : loadedCount > 0 || successfulFormats > 0 ? "partial" : "failed",
+    retainedFormats,
+  };
+}
+
+function isValidAggregate(value) {
+  if (!value || typeof value !== "object" || !Array.isArray(value.upstreams)) return false;
+  if (typeof value.complete !== "boolean") return false;
+  const validStates = new Set(["complete", "empty", "partial", "failed", "cancelled", "unsupported"]);
+  if (!validStates.has(value.state)) return false;
+  const formatLists = [
+    value.failedFormats,
+    value.uninspectedFormats,
+    value.unsupportedFormats,
+  ];
+  if (formatLists.some(list => !Array.isArray(list) || list.some(format => (
+    typeof format !== "string" || !getUpstreamFormatDescriptor(format)
+  )))) return false;
+  if (!Array.isArray(value.failures) || value.failures.some(failure => (
+    !failure || typeof failure !== "object"
+    || typeof failure.format !== "string"
+    || !getUpstreamFormatDescriptor(failure.format)
+    || typeof failure.category !== "string"
+    || !FAILURE_CATEGORIES.has(failure.category)
+    || typeof failure.retryable !== "boolean"
+    || failure.message !== formatUpstreamFailureCategory(failure.category)
+  ))) return false;
+  if (!Number.isSafeInteger(value.successfulFormats)
+    || value.successfulFormats < 0
+    || value.successfulFormats > INSPECTABLE_UPSTREAM_FORMATS.length) return false;
+  if (value.configuredTotal !== null && (
+    !Number.isSafeInteger(value.configuredTotal)
+    || value.configuredTotal < 0
+    || value.configuredTotal !== value.upstreams.length
+  )) return false;
+  if (value.complete === true && (
+    value.configuredTotal === null
+    || value.failedFormats.length > 0
+    || value.uninspectedFormats.length > 0
+  )) return false;
+  if (value.complete === false && value.configuredTotal !== null) return false;
+  if (value.complete !== ["complete", "empty"].includes(value.state)) return false;
+  if (value.state === "empty" && value.upstreams.length !== 0) return false;
+  if (value.state === "complete" && value.upstreams.length === 0) return false;
+  if (value.state === "unsupported" && value.unsupportedFormats.length === 0) return false;
+  const hasUsefulResult = value.upstreams.length > 0 || value.successfulFormats > 0;
+  if (value.state === "partial" && !hasUsefulResult) return false;
+  if (value.state === "failed" && hasUsefulResult) return false;
+  const unavailable = new Set([...value.failedFormats, ...value.uninspectedFormats]);
+  if (value.failures.some(failure => !unavailable.has(failure.format))) return false;
+  if (new Set([
+    ...value.failedFormats,
+    ...value.uninspectedFormats,
+    ...value.unsupportedFormats,
+  ]).size !== value.failedFormats.length
+    + value.uninspectedFormats.length
+    + value.unsupportedFormats.length) return false;
+  const identities = new Set();
+  return value.upstreams.every((upstream) => {
+    if (!upstream || typeof upstream !== "object"
+      || typeof upstream.name !== "string"
+      || !upstream.name
+      || upstream.name.length > 500) return false;
+    const format = typeof upstream._format === "string" ? upstream._format : upstream.format;
+    const descriptor = getUpstreamFormatDescriptor(format);
+    const identity = `${format}\0${upstream.slug_perm || upstream.name}`;
+    if (identities.has(identity)) return false;
+    identities.add(identity);
+    return Boolean(
+      descriptor?.inspectable
+      && upstream._format === upstream.format
+      && (upstream.origin === undefined || formatUpstreamOrigin(upstream.origin) === upstream.origin)
+    );
+  });
 }
 
 module.exports = { UpstreamDetailProvider, SUPPORTED_FORMATS };

--- a/views/upstreamDetailProvider.js
+++ b/views/upstreamDetailProvider.js
@@ -2,7 +2,13 @@
 
 const vscode = require("vscode");
 const crypto = require("crypto");
-const { getAllUpstreamData, getUpstreamDataForFormats } = require("../util/upstreamChecker");
+const { types: { isProxy } } = require("util");
+const {
+  getAllUpstreamData,
+  getUpstreamDataForFormats,
+  isSafeInventoryUpstream,
+  sanitizeSafeInventoryUpstream,
+} = require("../util/upstreamChecker");
 const {
   getUpstreamFormatDescriptor,
   INSPECTABLE_UPSTREAM_FORMATS,
@@ -17,10 +23,20 @@ const {
 const SUPPORTED_FORMATS = SUPPORTED_UPSTREAM_FORMATS;
 const MAX_RENDERED_UPSTREAMS = 200;
 const MAX_DISTRIBUTION_VERSIONS = 20;
+const MAX_VALIDATED_UPSTREAMS = 5000;
+const MAX_VALIDATED_UPSTREAMS_PER_FORMAT = 500;
 const FAILURE_CATEGORIES = new Set([
   "authentication", "cancelled", "invalid_response", "network", "not_found",
   "permission", "rate_limit", "request_limit", "request_rejected", "server",
   "timeout", "uninspected", "unknown",
+]);
+const FAILURE_KEYS = new Set([
+  "apiFormat", "category", "format", "httpStatus", "message", "requestId",
+  "retryable", "retryAfterMs", "serverRequestId", "state",
+]);
+const OUTCOME_FAILURE_KEYS = new Set([
+  "category", "httpStatus", "message", "requestId", "retryable", "retryAfterMs",
+  "serverRequestId",
 ]);
 
 class UpstreamDetailProvider {
@@ -204,6 +220,9 @@ class UpstreamDetailProvider {
   }
 
   async _fetchGroupedUpstreams(workspace, repoSlug, signal, options = {}) {
+    const requestedFormats = Array.isArray(options.formats)
+      ? options.formats
+      : SUPPORTED_UPSTREAM_FORMATS;
     const upstreamData = await this._loadUpstreams(workspace, repoSlug, {
       signal,
       bypassCache: options.bypassCache === true,
@@ -212,11 +231,14 @@ class UpstreamDetailProvider {
     if (upstreamData === null || signal.aborted) {
       return null;
     }
-    if (!isValidAggregate(upstreamData)) return failedFetchState();
+    const aggregate = snapshotAggregateContract(upstreamData);
+    if (!aggregate || !isValidAggregate(aggregate, requestedFormats)) return failedFetchState();
 
     const grouped = new Map();
 
-    for (const upstream of upstreamData.upstreams) {
+    for (const candidate of aggregate.upstreams) {
+      const upstream = sanitizeSafeInventoryUpstream(candidate);
+      if (!upstream) return failedFetchState();
       const format = typeof upstream._format === "string"
         ? upstream._format
         : (typeof upstream.format === "string" ? upstream.format : "");
@@ -240,23 +262,37 @@ class UpstreamDetailProvider {
       });
     }
 
+    const failedFormats = aggregate.failedFormats;
+    const uninspectedFormats = aggregate.uninspectedFormats;
+    const unsupportedFormats = aggregate.unsupportedFormats;
+    const failures = Object.freeze(aggregate.failures.map(failure => Object.freeze({
+      format: failure.format,
+      apiFormat: failure.apiFormat,
+      state: failure.state,
+      category: failure.category,
+      message: failure.message,
+      httpStatus: failure.httpStatus,
+      retryable: failure.retryable,
+      retryAfterMs: failure.retryAfterMs,
+      requestId: failure.requestId,
+      serverRequestId: failure.serverRequestId,
+    })));
+    for (const [format, upstreams] of grouped) {
+      grouped.set(format, Object.freeze(upstreams.slice()));
+    }
     return {
       groupedUpstreams: grouped,
-      failedFormats: Array.isArray(upstreamData.failedFormats) ? upstreamData.failedFormats : [],
-      uninspectedFormats: Array.isArray(upstreamData.uninspectedFormats)
-        ? upstreamData.uninspectedFormats
-        : [],
-      successfulFormats: typeof upstreamData.successfulFormats === "number"
-        ? upstreamData.successfulFormats
+      failedFormats,
+      uninspectedFormats,
+      successfulFormats: typeof aggregate.successfulFormats === "number"
+        ? aggregate.successfulFormats
         : 0,
-      complete: upstreamData.complete === true,
-      state: upstreamData.state,
-      failures: Array.isArray(upstreamData.failures) ? upstreamData.failures : [],
-      unsupportedFormats: Array.isArray(upstreamData.unsupportedFormats)
-        ? upstreamData.unsupportedFormats
-        : [],
-      configuredTotal: Number.isSafeInteger(upstreamData.configuredTotal)
-        ? upstreamData.configuredTotal
+      complete: aggregate.complete === true,
+      state: aggregate.state,
+      failures,
+      unsupportedFormats,
+      configuredTotal: Number.isSafeInteger(aggregate.configuredTotal)
+        ? aggregate.configuredTotal
         : null,
       retainedFormats: [],
     };
@@ -565,9 +601,7 @@ class UpstreamDetailProvider {
     const details = [
       this._renderDetail(
         "Origin",
-        formatUpstreamOrigin(
-          typeof upstream.origin === "string" && upstream.origin ? upstream.origin : upstream.upstream_url
-        ),
+        formatUpstreamOrigin(upstream.origin),
         "mono"
       ),
       this._renderDetail("Mode", typeof upstream.mode === "string" ? upstream.mode : "", ""),
@@ -828,8 +862,112 @@ function mergeRetryState(previous, replacement, retriedFormats) {
   };
 }
 
-function isValidAggregate(value) {
-  if (!value || typeof value !== "object" || !Array.isArray(value.upstreams)) return false;
+function snapshotAggregateContract(value) {
+  const root = snapshotOwnDataRecord(value);
+  if (!root) return null;
+  const upstreams = snapshotOwnDataArray(root.upstreams, MAX_VALIDATED_UPSTREAMS);
+  const failedFormats = snapshotOwnDataArray(root.failedFormats, SUPPORTED_UPSTREAM_FORMATS.length);
+  const uninspectedFormats = snapshotOwnDataArray(
+    root.uninspectedFormats, SUPPORTED_UPSTREAM_FORMATS.length
+  );
+  const unsupportedFormats = snapshotOwnDataArray(
+    root.unsupportedFormats, SUPPORTED_UPSTREAM_FORMATS.length
+  );
+  const rawFailures = snapshotOwnDataArray(root.failures, INSPECTABLE_UPSTREAM_FORMATS.length);
+  const rawOutcomes = snapshotOwnDataArray(root.outcomes, SUPPORTED_UPSTREAM_FORMATS.length);
+  if (!upstreams || !failedFormats || !uninspectedFormats || !unsupportedFormats
+    || !rawFailures || !rawOutcomes) return null;
+
+  const failures = [];
+  for (const value of rawFailures) {
+    const failure = snapshotOwnDataRecord(value);
+    if (!failure) return null;
+    failures.push(failure);
+  }
+  const outcomes = [];
+  for (const value of rawOutcomes) {
+    const outcome = snapshotOwnDataRecord(value);
+    if (!outcome) return null;
+    const entries = snapshotOwnDataArray(
+      outcome.entries, MAX_VALIDATED_UPSTREAMS_PER_FORMAT
+    );
+    const outcomeUpstreams = snapshotOwnDataArray(
+      outcome.upstreams, MAX_VALIDATED_UPSTREAMS_PER_FORMAT
+    );
+    if (!entries || !outcomeUpstreams) return null;
+    let failure = null;
+    if (outcome.failure !== null) {
+      failure = snapshotOwnDataRecord(outcome.failure);
+      if (!failure) return null;
+    }
+    outcomes.push(Object.freeze({
+      ...outcome,
+      entries,
+      upstreams: outcomeUpstreams,
+      failure,
+    }));
+  }
+  return Object.freeze({
+    ...root,
+    upstreams,
+    failedFormats,
+    uninspectedFormats,
+    unsupportedFormats,
+    failures: Object.freeze(failures),
+    outcomes: Object.freeze(outcomes),
+  });
+}
+
+function snapshotOwnDataRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || isProxy(value)) return null;
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const copy = {};
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (typeof key !== "string") return null;
+      const descriptor = descriptors[key];
+      if (!descriptor || descriptor.enumerable !== true
+        || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+      copy[key] = descriptor.value;
+    }
+    return Object.freeze(copy);
+  } catch {
+    return null;
+  }
+}
+
+function snapshotOwnDataArray(value, maximum = MAX_VALIDATED_UPSTREAMS) {
+  if (!Array.isArray(value) || isProxy(value)) return null;
+  try {
+    if (Object.getPrototypeOf(value) !== Array.prototype) return null;
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    const length = lengthDescriptor?.value;
+    if (!Number.isSafeInteger(length) || length < 0 || length > maximum) return null;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const keys = Reflect.ownKeys(descriptors);
+    if (keys.length !== length + 1) return null;
+    const copy = [];
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = descriptors[String(index)];
+      if (!descriptor || descriptor.enumerable !== true
+        || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+      copy.push(descriptor.value);
+    }
+    if (!keys.every(key => key === "length"
+      || (typeof key === "string" && /^(0|[1-9]\d*)$/u.test(key)))) return null;
+    return Object.freeze(copy);
+  } catch {
+    return null;
+  }
+}
+
+function isValidAggregate(value, requestedFormats) {
+  if (!value || typeof value !== "object" || !isOwnDataArray(value.upstreams)) return false;
+  if (value.upstreams.length > MAX_VALIDATED_UPSTREAMS) return false;
+  const requestedDescriptors = getExactRequestedDescriptors(requestedFormats);
+  if (!requestedDescriptors) return false;
   if (typeof value.complete !== "boolean") return false;
   const validStates = new Set(["complete", "empty", "partial", "failed", "cancelled", "unsupported"]);
   if (!validStates.has(value.state)) return false;
@@ -838,17 +976,17 @@ function isValidAggregate(value) {
     value.uninspectedFormats,
     value.unsupportedFormats,
   ];
-  if (formatLists.some(list => !Array.isArray(list) || list.some(format => (
-    typeof format !== "string" || !getUpstreamFormatDescriptor(format)
+  if (formatLists.some(list => !isOwnDataArray(list) || list.some(format => (
+    typeof format !== "string"
+    || getUpstreamFormatDescriptor(format)?.format !== format
   )))) return false;
-  if (!Array.isArray(value.failures) || value.failures.some(failure => (
-    !failure || typeof failure !== "object"
-    || typeof failure.format !== "string"
-    || !getUpstreamFormatDescriptor(failure.format)
-    || typeof failure.category !== "string"
-    || !FAILURE_CATEGORIES.has(failure.category)
-    || typeof failure.retryable !== "boolean"
-    || failure.message !== formatUpstreamFailureCategory(failure.category)
+  if (value.failedFormats.some(format => !getUpstreamFormatDescriptor(format)?.inspectable)
+    || value.uninspectedFormats.some(format => !getUpstreamFormatDescriptor(format)?.inspectable)
+    || value.unsupportedFormats.some(format => getUpstreamFormatDescriptor(format)?.inspectable)) {
+    return false;
+  }
+  if (!isOwnDataArray(value.failures) || value.failures.some(failure => (
+    !isValidAggregateFailure(failure)
   ))) return false;
   if (!Number.isSafeInteger(value.successfulFormats)
     || value.successfulFormats < 0
@@ -880,23 +1018,206 @@ function isValidAggregate(value) {
   ]).size !== value.failedFormats.length
     + value.uninspectedFormats.length
     + value.unsupportedFormats.length) return false;
+  if (!isValidOutcomeScope(value, requestedDescriptors)) return false;
   const identities = new Set();
   return value.upstreams.every((upstream) => {
     if (!upstream || typeof upstream !== "object"
       || typeof upstream.name !== "string"
       || !upstream.name
       || upstream.name.length > 500) return false;
-    const format = typeof upstream._format === "string" ? upstream._format : upstream.format;
-    const descriptor = getUpstreamFormatDescriptor(format);
+    const format = upstream._format;
     const identity = `${format}\0${upstream.slug_perm || upstream.name}`;
     if (identities.has(identity)) return false;
     identities.add(identity);
-    return Boolean(
-      descriptor?.inspectable
-      && upstream._format === upstream.format
-      && (upstream.origin === undefined || formatUpstreamOrigin(upstream.origin) === upstream.origin)
-    );
+    return isSafeInventoryUpstream(upstream);
   });
+}
+
+function getExactRequestedDescriptors(formats) {
+  if (!Array.isArray(formats) || formats.length === 0) return null;
+  const descriptors = [];
+  const seen = new Set();
+  for (const format of formats) {
+    const descriptor = getUpstreamFormatDescriptor(format);
+    if (!descriptor || descriptor.format !== format || seen.has(descriptor.format)) return null;
+    seen.add(descriptor.format);
+    descriptors.push(descriptor);
+  }
+  return descriptors;
+}
+
+function isValidOutcomeScope(value, requestedDescriptors) {
+  if (!isOwnDataArray(value.outcomes)
+    || value.outcomes.length !== requestedDescriptors.length) {
+    return false;
+  }
+  const expected = new Map(requestedDescriptors.map(descriptor => [descriptor.format, descriptor]));
+  const seen = new Set();
+  const failed = [];
+  const uninspected = [];
+  const unsupported = [];
+  let successful = 0;
+  let cancelled = false;
+  const aggregateEntryKeys = [];
+
+  for (const outcome of value.outcomes) {
+    if (!outcome || typeof outcome !== "object" || Array.isArray(outcome)) return false;
+    const descriptor = expected.get(outcome.format);
+    if (!descriptor || seen.has(outcome.format) || outcome.apiFormat !== descriptor.apiFormat) {
+      return false;
+    }
+    seen.add(outcome.format);
+    if (!isOwnDataArray(outcome.entries) || !isOwnDataArray(outcome.upstreams)
+      || outcome.entries.length !== outcome.upstreams.length
+      || outcome.entries.length > MAX_VALIDATED_UPSTREAMS_PER_FORMAT
+      || !Number.isSafeInteger(outcome.pageCount) || outcome.pageCount < 0) return false;
+    const safeEntries = outcome.entries.every((entry, index) => (
+      isSafeInventoryUpstream(entry)
+      && entry.format === descriptor.format
+      && entry._format === descriptor.format
+      && sameInventoryEntry(entry, outcome.upstreams[index])
+    ));
+    if (!safeEntries) return false;
+    aggregateEntryKeys.push(...outcome.entries.map(inventoryEntryKey));
+
+    if (!descriptor.inspectable) {
+      if (outcome.state !== "unsupported" || outcome.authoritative !== true
+        || outcome.entries.length !== 0 || outcome.failure !== null) return false;
+      unsupported.push(outcome.format);
+      continue;
+    }
+    if (outcome.state === "success") {
+      if (outcome.authoritative !== true || outcome.failure !== null) return false;
+      successful += 1;
+      continue;
+    }
+    if (!["failed", "incomplete", "uninspected", "cancelled"].includes(outcome.state)
+      || outcome.authoritative !== false || !isValidOutcomeFailure(outcome.failure)) return false;
+    if (outcome.state === "failed") failed.push(outcome.format);
+    else uninspected.push(outcome.format);
+    if (outcome.state === "cancelled") cancelled = true;
+  }
+
+  if (seen.size !== expected.size
+    || !sameSet(failed, value.failedFormats)
+    || !sameSet(uninspected, value.uninspectedFormats)
+    || !sameSet(unsupported, value.unsupportedFormats)
+    || successful !== value.successfulFormats) return false;
+  const aggregateKeys = value.upstreams.map(inventoryEntryKey);
+  if (!sameMultiset(aggregateEntryKeys, aggregateKeys)) return false;
+  const aggregateComplete = requestedDescriptors.some(descriptor => descriptor.inspectable)
+    && requestedDescriptors.filter(descriptor => descriptor.inspectable)
+      .every(descriptor => !failed.includes(descriptor.format)
+        && !uninspected.includes(descriptor.format));
+  if (value.complete !== aggregateComplete) return false;
+  if (cancelled !== (value.state === "cancelled")) return false;
+
+  const failureByFormat = new Map();
+  for (const failure of value.failures) {
+    if (failureByFormat.has(failure.format)) return false;
+    failureByFormat.set(failure.format, failure);
+  }
+  const unavailable = [...failed, ...uninspected];
+  if (!sameSet([...failureByFormat.keys()], unavailable)) return false;
+  return value.outcomes.every((outcome) => {
+    if (!unavailable.includes(outcome.format)) return true;
+    const failure = failureByFormat.get(outcome.format);
+    return failure.apiFormat === outcome.apiFormat
+      && failure.state === outcome.state
+      && failure.category === outcome.failure.category
+      && failure.message === outcome.failure.message
+      && failure.retryable === outcome.failure.retryable
+      && failure.httpStatus === outcome.failure.httpStatus
+      && failure.retryAfterMs === outcome.failure.retryAfterMs
+      && failure.requestId === outcome.failure.requestId
+      && failure.serverRequestId === outcome.failure.serverRequestId;
+  });
+}
+
+function isValidOutcomeFailure(failure) {
+  return hasExactDataKeys(failure, OUTCOME_FAILURE_KEYS)
+    && typeof failure.category === "string"
+    && FAILURE_CATEGORIES.has(failure.category)
+    && failure.message === formatUpstreamFailureCategory(failure.category)
+    && typeof failure.retryable === "boolean"
+    && isValidFailureMetadata(failure);
+}
+
+function isValidAggregateFailure(failure) {
+  if (!hasExactDataKeys(failure, FAILURE_KEYS)) return false;
+  const descriptor = getUpstreamFormatDescriptor(failure.format);
+  return descriptor?.inspectable === true
+    && descriptor.format === failure.format
+    && failure.apiFormat === descriptor.apiFormat
+    && ["failed", "incomplete", "uninspected", "cancelled"].includes(failure.state)
+    && FAILURE_CATEGORIES.has(failure.category)
+    && failure.message === formatUpstreamFailureCategory(failure.category)
+    && typeof failure.retryable === "boolean"
+    && isValidFailureMetadata(failure);
+}
+
+function isValidFailureMetadata(failure) {
+  return (failure.httpStatus === null
+      || (Number.isSafeInteger(failure.httpStatus)
+        && failure.httpStatus >= 100 && failure.httpStatus <= 599))
+    && (failure.retryAfterMs === null
+      || (Number.isSafeInteger(failure.retryAfterMs)
+        && failure.retryAfterMs >= 0 && failure.retryAfterMs <= 86_400_000))
+    && isValidFailureId(failure.requestId)
+    && isValidFailureId(failure.serverRequestId);
+}
+
+function isValidFailureId(value) {
+  return value === null || (typeof value === "string" && value.length <= 128
+    && /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(value));
+}
+
+function hasExactDataKeys(value, expectedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || isProxy(value)) return false;
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== expectedKeys.size
+      || keys.some(key => typeof key !== "string" || !expectedKeys.has(key))) return false;
+    return keys.every((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      return descriptor && Object.prototype.hasOwnProperty.call(descriptor, "value")
+        && descriptor.enumerable === true;
+    });
+  } catch {
+    return false;
+  }
+}
+
+function isOwnDataArray(value) {
+  return snapshotOwnDataArray(value) !== null;
+}
+
+function inventoryEntryKey(entry) {
+  return `${entry.format}\0${entry.slug_perm || entry.name}\0${JSON.stringify(entry)}`;
+}
+
+function sameInventoryEntry(left, right) {
+  return isSafeInventoryUpstream(right) && inventoryEntryKey(left) === inventoryEntryKey(right);
+}
+
+function sameSet(left, right) {
+  return left.length === right.length && new Set(left).size === left.length
+    && left.every(value => right.includes(value));
+}
+
+function sameMultiset(left, right) {
+  if (left.length !== right.length) return false;
+  const remaining = new Map();
+  for (const value of left) remaining.set(value, (remaining.get(value) || 0) + 1);
+  for (const value of right) {
+    const count = remaining.get(value) || 0;
+    if (count === 0) return false;
+    if (count === 1) remaining.delete(value);
+    else remaining.set(value, count - 1);
+  }
+  return remaining.size === 0;
 }
 
 module.exports = { UpstreamDetailProvider, SUPPORTED_FORMATS };

--- a/views/upstreamPreviewProvider.js
+++ b/views/upstreamPreviewProvider.js
@@ -1,7 +1,10 @@
 // Upstream resolution preview WebView panel.
 // Shows a "what if I pull this?" dry run for packages that don't exist locally.
 
+const { types: { isProxy } } = require("util");
 const vscode = require("vscode");
+const { sanitizeSafeInventoryUpstream } = require("../util/upstreamChecker");
+const { getUpstreamFormatDescriptor } = require("../util/upstreamFormats");
 const {
   formatUpstreamError,
   formatUpstreamOrigin,
@@ -42,39 +45,62 @@ class UpstreamPreviewProvider {
   }
 
   _getHtmlContent(result) {
-    const local = result.local && typeof result.local === "object" ? result.local : {};
-    const upstreamState = result.upstreams && typeof result.upstreams === "object"
-      ? result.upstreams
+    const formatDescriptor = getUpstreamFormatDescriptor(ownDataValue(result, "format"));
+    const canonicalFormat = formatDescriptor?.inspectable ? formatDescriptor.format : null;
+    const localValue = ownDataValue(result, "local");
+    const local = localValue && typeof localValue === "object" ? localValue : {};
+    const upstreamValue = ownDataValue(result, "upstreams");
+    const upstreamState = upstreamValue && typeof upstreamValue === "object"
+      ? upstreamValue
       : {};
-    const upstreamData = upstreamState.data && typeof upstreamState.data === "object"
-      ? upstreamState.data
+    const upstreamDataValue = ownDataValue(upstreamState, "data");
+    const upstreamData = upstreamDataValue && typeof upstreamDataValue === "object"
+      ? upstreamDataValue
       : {};
-    const rawConfigs = Array.isArray(upstreamData.configs) ? upstreamData.configs : [];
-    const boundedConfigs = rawConfigs.slice(0, MAX_PREVIEW_UPSTREAMS);
-    const configs = boundedConfigs.filter(isPreviewUpstreamConfig);
-    const metadataConsistent = rawConfigs.length <= MAX_PREVIEW_UPSTREAMS
+    const rawConfigState = snapshotOwnDataArray(
+      ownDataValue(upstreamData, "configs"),
+      MAX_PREVIEW_UPSTREAMS
+    );
+    const rawConfigs = rawConfigState.values;
+    const sanitizedConfigs = canonicalFormat
+      ? rawConfigs.map(config => sanitizeSafeInventoryUpstream(config, canonicalFormat))
+      : [];
+    const configs = sanitizedConfigs.filter(Boolean);
+    const metadataConsistent = canonicalFormat !== null
+      && rawConfigState.valid
       && configs.length === rawConfigs.length
-      && upstreamData.total === configs.length
-      && upstreamData.active === configs.filter(config => config.is_active !== false).length;
+      && ownDataValue(upstreamData, "total") === configs.length
+      && ownDataValue(upstreamData, "active")
+        === configs.filter(config => config.is_active !== false).length;
     const displayedConfigs = configs
       .slice(0, MAX_RENDERED_UPSTREAMS);
     const loadedTotal = configs.length;
     const activeTotal = configs.filter(config => config.is_active !== false).length;
-    const localError = local.errorMessage == null
+    const localErrorValue = ownDataValue(local, "errorMessage");
+    const localData = ownDataValue(local, "data");
+    const localComplete = ownDataValue(local, "complete");
+    const upstreamErrorValue = ownDataValue(upstreamState, "errorMessage");
+    const upstreamCompleteValue = ownDataValue(upstreamState, "complete");
+    const repository = ownDataValue(result, "repo");
+    const localError = localErrorValue == null
       ? null
-      : formatUpstreamError(local.errorMessage, "local");
-    const upstreamError = upstreamState.errorMessage == null
+      : formatUpstreamError(localErrorValue, "local");
+    const upstreamError = upstreamErrorValue == null
       ? null
-      : formatUpstreamError(upstreamState.errorMessage, "upstream");
-    const upstreamComplete = upstreamState.complete === true
+      : formatUpstreamError(upstreamErrorValue, "upstream");
+    const upstreamComplete = upstreamCompleteValue === true
       && metadataConsistent
       && upstreamError === null;
     const localStatus = localError
       ? `<span class="status-error">Could not verify local package data: ${this._escapeHtml(localError)}</span>`
-      : local.data
-        ? `<span class="status-found">Found in ${this._escapeHtml(formatUpstreamText(result.repo))} (${this._escapeHtml(formatUpstreamText(local.data.status_str, "Unknown"))})</span>`
-        : local.complete === true
-          ? `<span class="status-missing">Not found in ${this._escapeHtml(formatUpstreamText(result.repo))}</span>`
+      : localData
+        ? `<span class="status-found">Found in ${this._escapeHtml(formatUpstreamText(
+          repository
+        ))} (${this._escapeHtml(formatUpstreamText(
+          ownDataValue(localData, "status_str"), "Unknown"
+        ))})</span>`
+        : localComplete === true
+          ? `<span class="status-missing">Not found in ${this._escapeHtml(formatUpstreamText(repository))}</span>`
           : '<span class="status-error">Local package status is incomplete.</span>';
 
     let upstreamHtml = "";
@@ -95,7 +121,7 @@ class UpstreamPreviewProvider {
         const statusLabel = active ? "Active" : "Inactive";
         upstreamHtml += `<tr>
           <td>${this._escapeHtml(formatUpstreamText(u.name, "Unnamed"))}</td>
-          <td class="mono">${this._escapeHtml(formatUpstreamOrigin(u.upstream_url))}</td>
+          <td class="mono">${this._escapeHtml(formatUpstreamOrigin(u.origin))}</td>
           <td class="${statusClass}">${statusLabel}</td>
         </tr>`;
       }
@@ -145,9 +171,11 @@ class UpstreamPreviewProvider {
 <body>
   <h2>Upstream resolution preview</h2>
   <dl class="header-info">
-    <dt>Package</dt><dd>${this._escapeHtml(formatUpstreamText(result.name, "Unknown"))}</dd>
-    <dt>Format</dt><dd>${this._escapeHtml(formatUpstreamText(result.format, "Unknown"))}</dd>
-    <dt>Target repository</dt><dd>${this._escapeHtml(formatUpstreamText(result.workspace, "Unknown"))}/${this._escapeHtml(formatUpstreamText(result.repo, "Unknown"))}</dd>
+    <dt>Package</dt><dd>${this._escapeHtml(formatUpstreamText(ownDataValue(result, "name"), "Unknown"))}</dd>
+    <dt>Format</dt><dd>${this._escapeHtml(formatUpstreamText(canonicalFormat, "Unknown"))}</dd>
+    <dt>Target repository</dt><dd>${this._escapeHtml(formatUpstreamText(
+      ownDataValue(result, "workspace"), "Unknown"
+    ))}/${this._escapeHtml(formatUpstreamText(ownDataValue(result, "repo"), "Unknown"))}</dd>
     <dt>Local status</dt><dd>${localStatus}</dd>
   </dl>
 
@@ -180,14 +208,46 @@ class UpstreamPreviewProvider {
   }
 }
 
-function isPreviewUpstreamConfig(value) {
-  return Boolean(value)
-    && typeof value === "object"
-    && !Array.isArray(value)
-    && typeof value.name === "string"
-    && value.name.length > 0
-    && (value.is_active === undefined || typeof value.is_active === "boolean")
-    && (value.upstream_url === undefined || typeof value.upstream_url === "string");
+function ownDataValue(value, property) {
+  if (!value || typeof value !== "object" || isProxy(value)) return null;
+  try {
+    if (Array.isArray(value)) return null;
+    const descriptor = Object.getOwnPropertyDescriptor(value, property);
+    return descriptor && Object.prototype.hasOwnProperty.call(descriptor, "value")
+      ? descriptor.value
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function snapshotOwnDataArray(value, maximum) {
+  if (isProxy(value)) return { valid: false, values: [] };
+  let descriptors;
+  try {
+    if (!Array.isArray(value)) return { valid: false, values: [] };
+    if (Object.getPrototypeOf(value) !== Array.prototype) return { valid: false, values: [] };
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    return { valid: false, values: [] };
+  }
+  const lengthDescriptor = descriptors.length;
+  const length = lengthDescriptor?.value;
+  if (!Number.isSafeInteger(length) || length < 0 || length > maximum) {
+    return { valid: false, values: [] };
+  }
+  if (Reflect.ownKeys(descriptors).some(key => (
+    typeof key !== "string" || (key !== "length" && !/^(0|[1-9]\d*)$/u.test(key))
+  ))) return { valid: false, values: [] };
+  const values = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, "value")) {
+      return { valid: false, values: [] };
+    }
+    values.push(descriptor.value);
+  }
+  return { valid: true, values };
 }
 
 module.exports = { UpstreamPreviewProvider };


### PR DESCRIPTION
## Summary

- Corrected upstream format and response handling so configured upstreams load through the production repository path.
- Preserved successful upstream data when individual formats fail and surfaced safe per-format failure states without exposing gaps for unsupported formats.
- Simplified upstream trust presentation to compact Trusted or Untrusted status badges.
- Added bounded pagination, concurrency, targeted Retry, cache safeguards, and production-path regression coverage.

## Validation

- `npm run check` - passed
- `npm test` - passed
- `npm audit --omit=dev` - passed
- `npm run audit:runtime` - passed
- `npm run audit:dev` - passed
- `npm run package` and `npm run package:verify` - passed
- Release gate - passed
