### PR TITLE
perf: make broad search first page reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The extension exposes several settings under `cloudsmith-vsc.*`:
 | `cloudsmith-vsc.resolveTransitiveDependencies` | Parse lockfiles to resolve transitive dependencies. When disabled, only direct manifest dependencies are shown. Default: `true`. |
 | `cloudsmith-vsc.dependencyTreeDefaultView` | Default view mode for the Dependency Health panel: `direct`, `flat`, or `tree`. Default: `flat`. |
 | `cloudsmith-vsc.maxDependenciesToScan` | Maximum number of dependencies to display. Pull operations always process all dependencies regardless of this limit. Default: `10000`. |
-| `cloudsmith-vsc.searchPageSize` | Number of results per page when searching packages (10–100). Default: `50`. |
+| `cloudsmith-vsc.searchPageSize` | Results per repository for Advanced Search across selected repositories (10–100). Workspace and single-repository searches request at most 10 per page. Default: `50`. |
 | `cloudsmith-vsc.recentSearches` | Number of recent searches to remember (0–50). Default: `10`. |
 
 ### Commands

--- a/models/loadMoreNode.js
+++ b/models/loadMoreNode.js
@@ -12,7 +12,7 @@ class LoadMoreNode {
 
     getTreeItem() {
         const progress = Number.isSafeInteger(this.totalCount) && this.totalCount >= 0
-            ? `page ${this.currentPage} of ${this.totalPages}, ${this.totalCount} total`
+            ? `${Number.isSafeInteger(this.loadedCount) ? this.loadedCount : 0} of ${this.totalCount} loaded; page ${this.currentPage} of ${this.totalPages}`
             : `${Number.isSafeInteger(this.loadedCount) ? this.loadedCount : 0} loaded; page ${this.currentPage} of ${this.totalPages}`;
         return {
             label: `Load more results (${progress})`,

--- a/package.json
+++ b/package.json
@@ -810,7 +810,7 @@
           "default": 50,
           "minimum": 10,
           "maximum": 100,
-          "description": "Number of results per page when searching packages."
+          "description": "Number of results per repository for Advanced Search across selected repositories. Workspace and single-repository searches request at most 10 results per page."
         },
         "cloudsmith-vsc.recentSearches": {
           "type": "integer",

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -1,7 +1,10 @@
 const assert = require("assert");
 const { createAPI, liveFixture } = require("./setup");
 const { apiEndpoint } = require("../../util/apiEndpoint");
+const { CloudsmithAPI } = require("../../util/cloudsmithAPI");
+const { PaginatedFetch } = require("../../util/paginatedFetch");
 const { SearchQueryBuilder } = require("../../util/searchQueryBuilder");
+const { SearchProvider } = require("../../views/searchProvider");
 
 suite("Live integration: controlled package search", function () {
   this.timeout(15000);
@@ -53,4 +56,83 @@ suite("Live integration: controlled package search", function () {
     assert.ok(result.data.length > 0, "Controlled repository has no quarantined fixture");
     for (const pkg of result.data) assert.strictEqual(pkg.status_str, "Quarantined");
   });
+
+  test("broad workspace search commits one bounded production page", async function () {
+    this.timeout(45000);
+    const query = liveSearchQuery();
+    let dispatchCount = 0;
+    const typedApi = new CloudsmithAPI({}, {
+      credentialManager: { async getApiKey() { return liveFixture.apiKey; } },
+      fetchImpl: (url, options) => {
+        dispatchCount += 1;
+        return fetch(url, options);
+      },
+    });
+    const provider = new SearchProvider({}, {
+      connectionManager: connectedManager(),
+      createCloudsmithAPI: () => typedApi,
+      createPaginatedFetch: currentApi => new PaginatedFetch(currentApi),
+      withProgress: (_options, task) => task(
+        { report() {} },
+        { isCancellationRequested: false, onCancellationRequested() { return { dispose() {} }; } }
+      ),
+      notifications: { error() {}, information() {}, warning() {} },
+    });
+
+    try {
+      await provider.search(liveFixture.workspace, query);
+      assert.strictEqual(provider.state.failure, null);
+      assert(provider.state.committed, "Broad workspace page did not commit");
+      assert.strictEqual(provider.state.committed.descriptor.query, query);
+      assert.strictEqual(provider.state.committed.pagination.page, 1);
+      assert.strictEqual(provider.state.committed.pagination.pageSize, 10);
+      assert(provider.searchResults.length > 0 && provider.searchResults.length <= 10);
+      assert.strictEqual(provider.state.committed.diagnostics.requestCount, 1);
+      assert(dispatchCount >= 1 && dispatchCount <= 2);
+      assert.strictEqual(new Set(provider.state.committed.resultKeys).size, provider.searchResults.length);
+      if (provider.state.committed.pageable) {
+        const firstKeys = new Set(provider.state.committed.resultKeys);
+        const dispatchesBeforePageTwo = dispatchCount;
+        const first = provider.loadNextPage();
+        const duplicate = provider.loadNextPage();
+        assert.strictEqual(first, duplicate);
+        await first;
+        assert.strictEqual(provider.state.failure, null);
+        assert.strictEqual(provider.state.committed.pagination.page, 2);
+        assert.strictEqual(provider.state.committed.diagnostics.requestCount, 2);
+        assert(dispatchCount - dispatchesBeforePageTwo >= 1);
+        assert(dispatchCount - dispatchesBeforePageTwo <= 2);
+        assert.strictEqual(new Set(provider.state.committed.resultKeys).size, provider.searchResults.length);
+        assert(provider.state.committed.resultKeys.some(key => !firstKeys.has(key)));
+      }
+    } finally {
+      provider.dispose();
+    }
+  });
 });
+
+function connectedManager() {
+  const state = Object.freeze({
+    activationId: "live-search",
+    accountEpoch: 1,
+    sessionConnected: true,
+    status: "connected",
+  });
+  return {
+    getState: () => state,
+    onDidChange: () => ({ dispose() {} }),
+  };
+}
+
+function liveSearchQuery() {
+  const value = process.env.CLOUDSMITH_TEST_SEARCH_QUERY || "format:python";
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > 2048
+    || /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error("CLOUDSMITH_TEST_SEARCH_QUERY is invalid");
+  }
+  return value;
+}

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -1,5 +1,7 @@
 const assert = require("assert");
 const { SearchProvider } = require("../views/searchProvider");
+const { CloudsmithAPI } = require("../util/cloudsmithAPI");
+const { PaginatedFetch } = require("../util/paginatedFetch");
 
 suite("SearchProvider atomic search state", () => {
   let providers;
@@ -239,7 +241,24 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.state.failure.descriptor.query, "replacement");
     assert.strictEqual(messages.error.length, 1);
     const children = await provider.getChildren();
-    assert(children.some(node => node.getTreeItem().label === "Search failed"));
+    assert(children.some(node => node.getTreeItem().label === "Search failed for: replacement"));
+  });
+
+  test("typed first-page timeout is a failure for the requested query, never an empty result", async () => {
+    const { provider, messages } = createProvider({
+      fetchPage: async () => failedPage("timeout"),
+    });
+
+    await provider.search("workspace-a", "format:python");
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.pending, null);
+    assert.strictEqual(provider.state.failure.kind, "timeout");
+    assert.match(provider.state.failure.message, /timed out/);
+    assert.strictEqual(messages.information.length, 0);
+    const item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Search failed for: format:python");
+    assert.doesNotMatch(item.description, /0 packages/);
   });
 
   test("cancellation preserves the committed snapshot without a failure notification", async () => {
@@ -1075,6 +1094,54 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.searchResults.length, 3);
   });
 
+  test("typed continuation timeout retains validated results and the exact retry target", async () => {
+    let pageTwoCalls = 0;
+    const { provider } = createProvider({
+      fetchPage: async (_endpoint, requestedPage) => {
+        if (requestedPage === 1) {
+          return page([pkg("one"), pkg("two")], { pageTotal: 2, count: 3, pageSize: 2 });
+        }
+        pageTwoCalls += 1;
+        return pageTwoCalls === 1
+          ? failedPage("timeout", 2, 2)
+          : page([pkg("three")], { requestedPage: 2, pageTotal: 2, count: 3, pageSize: 2 });
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    await provider.loadNextPage();
+    assert.strictEqual(provider.currentPage, 1);
+    assert.strictEqual(provider.searchResults.length, 2);
+    assert.strictEqual(provider.state.failure.kind, "timeout");
+    assert.strictEqual(provider.state.committed.pageable, true);
+    assert.strictEqual(provider.state.pending, null);
+
+    await provider.loadNextPage();
+    assert.strictEqual(pageTwoCalls, 2);
+    assert.strictEqual(provider.currentPage, 2);
+    assert.strictEqual(provider.searchResults.length, 3);
+  });
+
+  test("a thrown continuation releases its guard and terminates without an unhandled rejection", async () => {
+    const { provider } = createProvider({
+      fetchPage: async (_endpoint, requestedPage) => {
+        if (requestedPage === 1) {
+          return page([pkg("one"), pkg("two")], { pageTotal: 2, count: 3, pageSize: 2 });
+        }
+        throw new Error("unexpected continuation failure");
+      },
+    });
+    await provider.search("workspace-a", "name:artifact");
+
+    await provider.loadNextPage();
+
+    assert.strictEqual(provider.currentPage, 1);
+    assert.strictEqual(provider.searchResults.length, 2);
+    assert.strictEqual(provider.state.pending, null);
+    assert.strictEqual(provider.state.failure.kind, "unexpected");
+    assert.strictEqual(provider.state.committed.pageable, false);
+  });
+
   test("a new root search prevents an older page from appending", async () => {
     const oldPage = deferred();
     const { provider } = createProvider({
@@ -1100,6 +1167,55 @@ suite("SearchProvider atomic search state", () => {
     assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["new"]);
   });
 
+  test("an in-flight old continuation cannot publish success or failure after a new root owns the view", async () => {
+    for (const lateOutcome of ["success", "failure"]) {
+      const oldPage = deferred();
+      let oldPageSignal = null;
+      const { provider, messages } = createProvider({
+        fetchPage: async (_endpoint, requestedPage, _size, query, options) => {
+          if (query === "A" && requestedPage === 1) {
+            return page([pkg("A-one"), pkg("A-two")], {
+              pageTotal: 2, count: 3, pageSize: 2,
+            });
+          }
+          if (query === "A") {
+            oldPageSignal = options.signal;
+            return oldPage.promise;
+          }
+          return page([pkg("B-one")], { pageSize: 10 });
+        },
+      });
+      let refreshCount = 0;
+      provider.onDidChangeTreeData(() => { refreshCount += 1; });
+
+      await provider.search("workspace-a", "A");
+      const loadingA2 = provider.loadNextPage();
+      while (!oldPageSignal) await nextTurn();
+      const searchB = provider.search("workspace-a", "B");
+      assert.strictEqual(oldPageSignal.aborted, true);
+      let items = (await provider.getChildren()).map(node => node.getTreeItem());
+      assert.strictEqual(items[0].label, "Results for: A");
+      assert(items.some(item => item.description === "Searching for: B"));
+      await searchB;
+      const refreshAfterB = refreshCount;
+
+      oldPage.resolve(lateOutcome === "success"
+        ? page([pkg("A-late")], { requestedPage: 2, pageTotal: 2, count: 3, pageSize: 2 })
+        : failedPage("server_error", 2, 2));
+      await loadingA2;
+
+      assert.strictEqual(provider.currentQuery, "B");
+      assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["B-one"]);
+      assert.strictEqual(provider.state.failure, null);
+      assert.strictEqual(provider.state.committed.pagination.page, 1);
+      assert.strictEqual(provider.state.committed.resultKeys.length, 1);
+      assert.strictEqual(refreshCount, refreshAfterB);
+      assert.deepStrictEqual(messages.error, []);
+      items = (await provider.getChildren()).map(node => node.getTreeItem());
+      assert.strictEqual(items[0].label, "Results for: B");
+    }
+  });
+
   test("stops single-scope pagination at the cumulative page limit", async function () {
     this.timeout(5000);
     let calls = 0;
@@ -1107,14 +1223,14 @@ suite("SearchProvider atomic search state", () => {
       pageSize: 100,
       fetchPage: async (_endpoint, requestedPage) => {
         calls += 1;
-        const data = Array.from({ length: 100 }, (_, index) => (
+        const data = Array.from({ length: 10 }, (_, index) => (
           pkg(`artifact-${requestedPage}-${index}`)
         ));
         return page(data, {
           requestedPage,
           pageTotal: 51,
-          count: 5100,
-          pageSize: 100,
+          count: 510,
+          pageSize: 10,
         });
       },
     });
@@ -1125,7 +1241,7 @@ suite("SearchProvider atomic search state", () => {
     }
 
     assert.strictEqual(calls, 20);
-    assert.strictEqual(provider.searchResults.length, 2000);
+    assert.strictEqual(provider.searchResults.length, 200);
     assert.strictEqual(provider.currentPage, 20);
     assert.strictEqual(provider.state.committed.pageable, false);
     assert.strictEqual(provider.state.committed.diagnostics.capReached, true);
@@ -1186,6 +1302,391 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.state.committed.pageable, false);
   });
 
+  test("workspace and repository searches use a fixed ten-item request independent of aggregation configuration", async () => {
+    const calls = [];
+    const { provider } = createProvider({
+      pageSize: 100,
+      fetchPage: async (endpoint, requestedPage, requestedPageSize, query, options) => {
+        calls.push({ endpoint, requestedPage, requestedPageSize, query, retry: options.retry });
+        if (query === "workspace-query" && requestedPage === 1) {
+          return page(Array.from({ length: 10 }, (_, index) => pkg(`workspace-${index}`, {
+            repository: "repo-b",
+          })), { pageTotal: 2, count: 11, pageSize: 10 });
+        }
+        if (query === "workspace-query") {
+          return page([pkg("workspace-final", { repository: "repo-b" })], {
+            requestedPage: 2, pageTotal: 2, count: 11, pageSize: 10,
+          });
+        }
+        return page([pkg(query, {
+          repository: endpoint.includes("/repo-a/") ? "repo-a" : "repo-b",
+        })], { pageSize: 10 });
+      },
+    });
+
+    await provider.search("workspace-a", "workspace-query");
+    await provider.loadNextPage();
+    await provider.search("workspace-a", "repository-query", 1, "repo-a");
+
+    assert.deepStrictEqual(calls.map(call => call.requestedPageSize), [10, 10, 10]);
+    assert.deepStrictEqual(calls.map(call => call.requestedPage), [1, 2, 1]);
+    assert.deepStrictEqual(calls.map(call => call.retry), ["never", "never", "never"]);
+    assert(calls[0].endpoint.endsWith("packages/workspace-a/"));
+    assert(calls[1].endpoint.endsWith("packages/workspace-a/"));
+    assert(calls[2].endpoint.endsWith("packages/workspace-a/repo-a/"));
+  });
+
+  test("composes SearchProvider, PaginatedFetch, and CloudsmithAPI into one encoded first-page dispatch", async () => {
+    const urls = [];
+    const api = new CloudsmithAPI({}, {
+      credentialManager: { async getApiKey() { return "csa_test_search_transport"; } },
+      randomUUID: () => "search-request-id",
+      fetchImpl: async (url, request) => {
+        urls.push(String(url));
+        assert.strictEqual(request.method, "GET");
+        assert.strictEqual(request.redirect, "manual");
+        return new Response(JSON.stringify(Array.from(
+          { length: 10 },
+          (_, index) => pkg(`python-package-${index}`)
+        )), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-pagination-page": "1",
+            "x-pagination-pagetotal": "2",
+            "x-pagination-pagesize": "10",
+            "x-pagination-count": "11",
+          },
+        });
+      },
+    });
+    const provider = new SearchProvider({}, {
+      connectionManager: createConnectionManager(),
+      createCloudsmithAPI: () => api,
+      createPaginatedFetch: typedApi => new PaginatedFetch(typedApi),
+      withProgress: (_options, task) => task({ report() {} }, cancellationToken()),
+      notifications: { error() {}, information() {}, warning() {} },
+      getAggregationPageSize: () => 100,
+    });
+    providers.push(provider);
+
+    await provider.search("workspace-a", "format:python");
+
+    assert.deepStrictEqual(urls, [
+      "https://api.cloudsmith.io/v1/packages/workspace-a/?page=1&page_size=10&query=format%3Apython",
+    ]);
+    assert.strictEqual(provider.state.committed.diagnostics.requestCount, 1);
+    assert.strictEqual(provider.state.committed.pagination.page, 1);
+    assert.strictEqual(provider.state.committed.pagination.count, 11);
+    assert.strictEqual(provider.state.committed.pageable, true);
+  });
+
+  test("a composed transport request is aborted by clear and cannot publish", async () => {
+    let dispatchCount = 0;
+    let transportAborted = false;
+    const api = new CloudsmithAPI({}, {
+      credentialManager: { async getApiKey() { return "csa_test_search_transport"; } },
+      randomUUID: () => "search-request-id",
+      fetchImpl: (_url, request) => new Promise((_resolve, reject) => {
+        dispatchCount += 1;
+        request.signal.addEventListener("abort", () => {
+          transportAborted = true;
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        }, { once: true });
+      }),
+    });
+    const provider = new SearchProvider({}, {
+      connectionManager: createConnectionManager(),
+      createCloudsmithAPI: () => api,
+      createPaginatedFetch: typedApi => new PaginatedFetch(typedApi),
+      withProgress: (_options, task) => task({ report() {} }, cancellationToken()),
+      notifications: { error() {}, information() {}, warning() {} },
+    });
+    providers.push(provider);
+
+    const search = provider.search("workspace-a", "format:python");
+    while (dispatchCount === 0) await nextTurn();
+    provider.clear();
+    await search;
+
+    assert.strictEqual(dispatchCount, 1);
+    assert.strictEqual(transportAborted, true);
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.pending, null);
+    assert.strictEqual(provider.state.failure, null);
+  });
+
+  test("post-response cancellation suppresses single, multi-repository, and continuation publication", async () => {
+    const rootToken = cancellationToken();
+    const root = createProvider({
+      withProgress: async (_options, task) => {
+        const result = await task({ report() {} }, rootToken);
+        rootToken.cancel();
+        return result;
+      },
+      fetchPage: async () => page([pkg("root-result")]),
+    });
+    await root.provider.search("workspace-a", "root-query");
+    assert.strictEqual(root.provider.state.committed, null);
+    assert.strictEqual(root.provider.state.failure, null);
+    assert.deepStrictEqual(root.messages.error, []);
+
+    const multiToken = cancellationToken();
+    const multi = createProvider({
+      withProgress: async (_options, task) => {
+        const result = await task({ report() {} }, multiToken);
+        multiToken.cancel();
+        return result;
+      },
+      fetchPage: async () => page([pkg("multi-result")]),
+    });
+    await multi.provider.searchRepos("workspace-a", ["repo-a"], "multi-query");
+    assert.strictEqual(multi.provider.state.committed, null);
+    assert.strictEqual(multi.provider.state.failure, null);
+    assert.deepStrictEqual(multi.messages.error, []);
+
+    let invocation = 0;
+    const pageToken = cancellationToken();
+    const continuation = createProvider({
+      withProgress: async (_options, task) => {
+        invocation += 1;
+        const token = invocation === 1 ? cancellationToken() : pageToken;
+        const result = await task({ report() {} }, token);
+        if (invocation === 2) token.cancel();
+        return result;
+      },
+      fetchPage: async (_endpoint, requestedPage) => requestedPage === 1
+        ? page(Array.from({ length: 10 }, (_, index) => pkg(`first-${index}`)), {
+          pageTotal: 2, count: 11, pageSize: 10,
+        })
+        : page([pkg("late")], { requestedPage: 2, pageTotal: 2, count: 11, pageSize: 10 }),
+    });
+    await continuation.provider.search("workspace-a", "page-query");
+    const prior = continuation.provider.state.committed;
+    await continuation.provider.loadNextPage();
+    assert.strictEqual(continuation.provider.state.committed.results.length, 10);
+    assert.strictEqual(continuation.provider.state.committed.pagination.page, 1);
+    assert.strictEqual(continuation.provider.state.pending, null);
+    assert.strictEqual(continuation.provider.state.failure, null);
+    assert.notStrictEqual(continuation.provider.state.committed, prior);
+    assert.deepStrictEqual(continuation.messages.error, []);
+  });
+
+  test("pre-cancelled progress performs no root or continuation page dispatch", async () => {
+    const rootToken = cancellationToken();
+    rootToken.cancel();
+    let rootCalls = 0;
+    const root = createProvider({
+      cancellationToken: rootToken,
+      fetchPage: async () => {
+        rootCalls += 1;
+        return page([]);
+      },
+    });
+    await root.provider.search("workspace-a", "cancel-before-root");
+    assert.strictEqual(rootCalls, 0);
+    assert.strictEqual(root.provider.state.failure, null);
+
+    let invocation = 0;
+    let pageCalls = 0;
+    const continuation = createProvider({
+      withProgress: (_options, task) => {
+        invocation += 1;
+        const token = cancellationToken();
+        if (invocation === 2) token.cancel();
+        return task({ report() {} }, token);
+      },
+      fetchPage: async (_endpoint, requestedPage) => {
+        pageCalls += 1;
+        return requestedPage === 1
+          ? page(Array.from({ length: 10 }, (_, index) => pkg(`first-${index}`)), {
+            pageTotal: 2, count: 11, pageSize: 10,
+          })
+          : page([pkg("unexpected")], { requestedPage: 2, pageTotal: 2, count: 11, pageSize: 10 });
+      },
+    });
+    await continuation.provider.search("workspace-a", "cancel-before-page");
+    await continuation.provider.loadNextPage();
+    assert.strictEqual(pageCalls, 1);
+    assert.strictEqual(continuation.provider.state.committed.pagination.page, 1);
+    assert.strictEqual(continuation.provider.state.committed.diagnostics.requestCount, 1);
+    assert.strictEqual(continuation.provider.state.failure, null);
+  });
+
+  test("clear aborts an in-flight continuation and late completion cannot restore state", async () => {
+    const latePage = deferred();
+    let continuationSignal = null;
+    const { provider } = createProvider({
+      fetchPage: async (_endpoint, requestedPage, _size, _query, options) => {
+        if (requestedPage === 1) {
+          return page(Array.from({ length: 10 }, (_, index) => pkg(`first-${index}`)), {
+            pageTotal: 2, count: 11, pageSize: 10,
+          });
+        }
+        continuationSignal = options.signal;
+        return latePage.promise;
+      },
+    });
+    await provider.search("workspace-a", "clear-page");
+    const loading = provider.loadNextPage();
+    while (!continuationSignal) await nextTurn();
+
+    provider.clear();
+    assert.strictEqual(continuationSignal.aborted, true);
+    latePage.resolve(page([pkg("late")], {
+      requestedPage: 2, pageTotal: 2, count: 11, pageSize: 10,
+    }));
+    await loading;
+
+    assert.strictEqual(provider.state.committed, null);
+    assert.strictEqual(provider.state.pending, null);
+    assert.strictEqual(provider.state.failure, null);
+  });
+
+  test("pending and failed replacement rows visibly preserve old and new query identity", async () => {
+    const replacement = deferred();
+    const { provider } = createProvider({
+      fetchPage: async (_endpoint, _page, _size, query) => {
+        if (query === "old") return page([pkg("old-result")]);
+        return replacement.promise;
+      },
+    });
+    await provider.search("workspace-a", "old");
+    const searching = provider.search("workspace-a", "new");
+    await nextTurn();
+
+    let items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.strictEqual(items[0].label, "Results for: old");
+    assert(items.some(item => item.description === "Searching for: new"));
+    assert.strictEqual(items.some(item => item.contextValue === "loadMore"), false);
+
+    replacement.resolve(failedPage("timeout"));
+    await searching;
+    items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.strictEqual(items[0].label, "Results for: old");
+    assert(items.some(item => item.label === "Search failed for: new"));
+    assert(items.some(item => String(item.tooltip).includes("Query: new")));
+  });
+
+  test("a first search visibly names its pending query", async () => {
+    const response = deferred();
+    const { provider } = createProvider({ fetchPage: async () => response.promise });
+    const search = provider.search("workspace-a", "format:python");
+    await nextTurn();
+
+    const item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Searching packages...");
+    assert.strictEqual(item.description, "Searching for: format:python");
+
+    response.resolve(page([]));
+    await search;
+  });
+
+  test("Load More is hidden while a page is pending and final completion stays truthful", async () => {
+    const nextPage = deferred();
+    const { provider } = createProvider({
+      fetchPage: async (_endpoint, requestedPage) => requestedPage === 1
+        ? page(Array.from({ length: 10 }, (_, index) => pkg(`first-${index}`)), {
+          pageTotal: 2, count: 11, pageSize: 10,
+        })
+        : nextPage.promise,
+    });
+    await provider.search("workspace-a", "artifact");
+    let items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert(items.some(item => item.label === "Load more results (10 of 11 loaded; page 1 of 2)"));
+
+    const loading = provider.loadNextPage();
+    await nextTurn();
+    items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.strictEqual(items.some(item => item.contextValue === "loadMore"), false);
+    assert(items.some(item => item.description === "Loading page 2..."));
+
+    nextPage.resolve(page([pkg("final")], {
+      requestedPage: 2, pageTotal: 2, count: 11, pageSize: 10,
+    }));
+    await loading;
+    items = (await provider.getChildren()).map(node => node.getTreeItem());
+    assert.strictEqual(items.some(item => item.contextValue === "loadMore"), false);
+    assert.match(items[0].description, /11 packages/);
+  });
+
+  test("setup failures release root ownership and allow the next search", async () => {
+    for (const boundary of ["api", "paginator", "progress"]) {
+      let fail = true;
+      const options = { fetchPage: async () => page([pkg(`${boundary}-success`)]) };
+      if (boundary === "api") {
+        options.createCloudsmithAPI = () => {
+          if (fail) throw new Error("api setup failed");
+          return {};
+        };
+      }
+      if (boundary === "paginator") {
+        options.createPaginatedFetch = () => {
+          if (fail) throw new Error("paginator setup failed");
+          return { fetchPage: options.fetchPage };
+        };
+      }
+      if (boundary === "progress") {
+        options.withProgress = (_progressOptions, task) => {
+          if (fail) throw new Error("progress setup failed");
+          return task({ report() {} }, cancellationToken());
+        };
+      }
+      const { provider } = createProvider(options);
+      await provider.search("workspace-a", `${boundary}-failure`);
+      assert.strictEqual(provider.state.pending, null, boundary);
+      assert.strictEqual(provider.state.failure.kind, "unexpected", boundary);
+
+      fail = false;
+      await provider.search("workspace-a", `${boundary}-success`);
+      assert.strictEqual(provider.currentQuery, `${boundary}-success`, boundary);
+    }
+  });
+
+  test("aggregation configuration failure is identity-safe and a subsequent selected-repository search succeeds", async () => {
+    let fail = true;
+    const messages = { error: [], information: [], warning: [] };
+    const provider = new SearchProvider({}, {
+      connectionManager: createConnectionManager(),
+      createCloudsmithAPI: () => ({}),
+      createPaginatedFetch: () => ({ fetchPage: async () => page([pkg("success")]) }),
+      withProgress: (_options, task) => task({ report() {} }, cancellationToken()),
+      getAggregationPageSize: () => {
+        if (fail) throw new Error("configuration unavailable");
+        return 10;
+      },
+      notifications: {
+        error(message) { messages.error.push(message); },
+        information(message) { messages.information.push(message); },
+        warning(message) { messages.warning.push(message); },
+      },
+    });
+    providers.push(provider);
+
+    await provider.searchRepos("workspace-a", ["repo-a"], "failure");
+    assert.strictEqual(provider.state.pending, null);
+    assert.strictEqual(provider.state.failure.kind, "unexpected");
+    fail = false;
+    await provider.searchRepos("workspace-a", ["repo-a"], "success");
+    assert.strictEqual(provider.currentQuery, "success");
+  });
+
+  test("same package names and versions in different repositories retain distinct canonical identities", async () => {
+    const { provider } = createProvider({
+      fetchPage: async () => page([
+        pkg("shared", { repository: "repo-a", slug_perm: "shared-perm" }),
+        pkg("shared", { repository: "repo-b", slug_perm: "shared-perm" }),
+      ]),
+    });
+
+    await provider.search("workspace-a", "name:shared");
+
+    assert.deepStrictEqual(provider.searchResults.map(node => node.repository), ["repo-a", "repo-b"]);
+    assert.strictEqual(new Set(provider.state.committed.resultKeys).size, 2);
+  });
+
   test("clear invalidates a pending root and publishes no later result", async () => {
     const pending = deferred();
     const { provider } = createProvider({ fetchPage: async () => pending.promise });
@@ -1219,21 +1720,21 @@ suite("SearchProvider atomic search state", () => {
       {},
       {
         connectionManager,
-        createCloudsmithAPI: () => ({}),
-        createPaginatedFetch: () => ({ fetchPage }),
-        withProgress: (_progressOptions, task) => task(
+        createCloudsmithAPI: options.createCloudsmithAPI || (() => ({})),
+        createPaginatedFetch: options.createPaginatedFetch || (() => ({ fetchPage })),
+        withProgress: options.withProgress || ((_progressOptions, task) => task(
           { report() {} },
           options.cancellationToken || {
             isCancellationRequested: false,
             onCancellationRequested() { return { dispose() {} }; },
           }
-        ),
+        )),
         notifications: {
           error(message) { messages.error.push(message); },
           information(message) { messages.information.push(message); },
           warning(message) { messages.warning.push(message); },
         },
-        getPageSize: () => options.pageSize || 50,
+        getAggregationPageSize: () => options.pageSize || 50,
       }
     );
     providers.push(provider);
@@ -1295,13 +1796,13 @@ function page(data, options = {}) {
       pageTotal,
       count: hasCount ? options.count : data.length,
       ...(hasCountAuthority ? { countAuthoritative: options.countAuthoritative } : {}),
-      pageSize: options.pageSize || 50,
+      pageSize: options.pageSize || 10,
     },
     error: null,
   };
 }
 
-function failedPage(kind, requestedPage = 1, pageSize = 50) {
+function failedPage(kind, requestedPage = 1, pageSize = 10) {
   return {
     data: [],
     pagination: { page: requestedPage, pageTotal: requestedPage, count: 0, pageSize },
@@ -1309,7 +1810,7 @@ function failedPage(kind, requestedPage = 1, pageSize = 50) {
       kind,
       status: kind === "rate_limited" ? 429 : null,
       retryable: kind === "rate_limited",
-      message: `Failure: ${kind}`,
+      message: kind === "timeout" ? "The Cloudsmith API request timed out." : `Failure: ${kind}`,
       requestId: null,
       retryAfterMs: null,
       outcomeUnknown: false,
@@ -1326,6 +1827,22 @@ function deferred() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+function cancellationToken() {
+  const listeners = new Set();
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested(listener) {
+      listeners.add(listener);
+      return { dispose() { listeners.delete(listener); } };
+    },
+    cancel() {
+      if (this.isCancellationRequested) return;
+      this.isCancellationRequested = true;
+      for (const listener of [...listeners]) listener();
+    },
+  };
 }
 
 function repositoryFromEndpoint(endpoint) {

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -36,6 +36,10 @@ const MAX_MULTI_REPO_PAGES = 20;
 const MAX_SINGLE_SEARCH_PAGES = 20;
 const MAX_SINGLE_SEARCH_REQUESTS = 24;
 const MAX_FAILURE_DETAILS = 20;
+// Broad package queries can exceed the transport deadline at larger page sizes.
+// Keep the interactive workspace/repository path small and predictable; the
+// configurable size remains available only to bounded selected-repository runs.
+const INTERACTIVE_SEARCH_PAGE_SIZE = 10;
 
 class SearchProvider {
     constructor(context, options = {}) {
@@ -51,7 +55,7 @@ class SearchProvider {
             information: message => vscode.window.showInformationMessage(message),
             warning: message => vscode.window.showWarningMessage(message),
         };
-        this._getPageSize = options.getPageSize || (() => {
+        this._getAggregationPageSize = options.getAggregationPageSize || (() => {
             const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
             return config.get("searchPageSize");
         });
@@ -173,11 +177,22 @@ class SearchProvider {
             this._failRoot(operation, operation.validationError, null, "invalid_request");
             return;
         }
-        if (operation.descriptor.kind === "repositories") {
-            await this._executeRepositorySearch(operation);
-            return;
+        try {
+            if (operation.descriptor.kind === "repositories") {
+                await this._executeRepositorySearch(operation);
+                return;
+            }
+            await this._executeSingleSearch(operation);
+        } catch {
+            if (this._isCurrentRoot(operation)) {
+                this._failRoot(
+                    operation,
+                    "Could not search packages. The operation failed unexpectedly. Retry the search.",
+                    null,
+                    "unexpected"
+                );
+            }
         }
-        await this._executeSingleSearch(operation);
     }
 
     /** Execute a workspace or single-repository root search. */
@@ -206,7 +221,7 @@ class SearchProvider {
 
     async _executeSingleSearch(operation) {
         const { descriptor } = operation;
-        const pageSize = clampPageSize(this._getPageSize());
+        const pageSize = INTERACTIVE_SEARCH_PAGE_SIZE;
         let endpoint;
         try {
             endpoint = descriptor.kind === "repository"
@@ -218,14 +233,17 @@ class SearchProvider {
         }
 
         let result;
+        let progressToken = null;
         try {
             const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
             if (!this._isCurrentRoot(operation)) {
                 this._discardRoot(operation);
                 return;
             }
-            result = await this._withProgress(progressOptions(), (_progress, token) => (
-                paginatedFetch.fetchPage(
+            result = await this._withProgress(progressOptions(), (_progress, token) => {
+                progressToken = token;
+                if (token?.isCancellationRequested) return null;
+                return paginatedFetch.fetchPage(
                     endpoint,
                     descriptor.page,
                     pageSize,
@@ -236,20 +254,15 @@ class SearchProvider {
                         signal: operation.controller.signal,
                         validate: isPackageSearchArray,
                     }
-                )
-            ));
+                );
+            });
         } catch (error) {
-            if (!this._isCurrentRoot(operation)) {
-                return;
-            }
+            if (!this._continueRoot(operation, progressToken)) return;
             this._failRoot(operation, `Could not search packages. ${safeErrorMessage(error)}`, null, "unexpected");
             return;
         }
 
-        if (!this._isCurrentRoot(operation)) {
-            this._discardRoot(operation);
-            return;
-        }
+        if (!this._continueRoot(operation, progressToken)) return;
         if (result?.error) {
             if (result.error.kind === "cancelled") {
                 this._cancelRoot(operation);
@@ -282,6 +295,7 @@ class SearchProvider {
             return;
         }
 
+        if (!this._continueRoot(operation, progressToken)) return;
         let builtRoot;
         try {
             builtRoot = buildUniqueNodes(
@@ -294,9 +308,7 @@ class SearchProvider {
             this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
             return;
         }
-        if (!this._isCurrentRoot(operation)) {
-            return;
-        }
+        if (!this._continueRoot(operation, progressToken)) return;
         if (builtRoot.duplicateCount > 0) {
             this._failRoot(
                 operation,
@@ -318,7 +330,7 @@ class SearchProvider {
         const pageLimitReached = successfulPageCount >= MAX_SINGLE_SEARCH_PAGES
             && pagination.page < pagination.pageTotal;
         const capReached = resultLimitReached || pageLimitReached;
-        this._commitRoot(operation, {
+        const committed = this._commitRoot(operation, {
             descriptor,
             results: keptNodes,
             pagination,
@@ -335,15 +347,15 @@ class SearchProvider {
                 pageCount: successfulPageCount,
                 pageLimitReached,
             },
-        });
-        if (keptNodes.length === 0) {
+        }, progressToken);
+        if (committed && keptNodes.length === 0) {
             this._notify("information", `No packages found for "${descriptor.query}".`);
         }
     }
 
     async _executeRepositorySearch(operation) {
         const { descriptor } = operation;
-        const pageSize = clampPageSize(this._getPageSize());
+        const pageSize = clampPageSize(this._getAggregationPageSize());
         const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
         if (!this._isCurrentRoot(operation)) {
             this._discardRoot(operation);
@@ -351,8 +363,10 @@ class SearchProvider {
         }
 
         let collection;
+        let progressToken = null;
         try {
             const outcome = await this._withProgress(progressOptions(), async (_progress, token) => {
+                progressToken = token;
                 const run = createRepositorySearchRun(descriptor);
                 await runRepositorySearchWorkers({
                     run,
@@ -368,25 +382,20 @@ class SearchProvider {
                     stale: run.stale,
                 };
             });
-            if (!this._isCurrentRoot(operation)) {
-                return;
-            }
+            if (!this._continueRoot(operation, progressToken)) return;
             if (outcome.cancelled || outcome.stale) {
                 this._cancelRoot(operation);
                 return;
             }
+            if (!this._continueRoot(operation, progressToken)) return;
             collection = finalizeRepositorySearchRun(outcome.run);
         } catch (error) {
-            if (!this._isCurrentRoot(operation)) {
-                return;
-            }
+            if (!this._continueRoot(operation, progressToken)) return;
             this._failRoot(operation, `Could not search packages. ${safeErrorMessage(error)}`, null, "unexpected");
             return;
         }
 
-        if (!this._isCurrentRoot(operation)) {
-            return;
-        }
+        if (!this._continueRoot(operation, progressToken)) return;
         if (collection.successfulPageCount === 0) {
             const detail = collection.failureDetails.length > 0
                 ? ` ${collection.failureDetails[0].message}`
@@ -400,6 +409,7 @@ class SearchProvider {
             return;
         }
 
+        if (!this._continueRoot(operation, progressToken)) return;
         let built;
         try {
             const nodes = buildUniqueNodes(
@@ -417,12 +427,10 @@ class SearchProvider {
             this._failRoot(operation, `Could not display search results. ${safeErrorMessage(error)}`, null, "invalid_response");
             return;
         }
-        if (!this._isCurrentRoot(operation)) {
-            return;
-        }
+        if (!this._continueRoot(operation, progressToken)) return;
 
         const partial = !collection.complete || built.droppedResultCount > 0;
-        this._commitRoot(operation, {
+        const committed = this._commitRoot(operation, {
             descriptor,
             results: built.nodes,
             pagination: null,
@@ -447,16 +455,16 @@ class SearchProvider {
                 requestLimitReached: collection.requestLimitReached,
                 pageLimitReached: collection.pageLimitReached,
             },
-        });
+        }, progressToken);
 
-        if (collection.failedRepositoryCount > 0) {
+        if (committed && collection.failedRepositoryCount > 0) {
             const names = collection.failureDetails.map(detail => detail.repository);
             const suffix = collection.failedRepositoryCount > names.length
                 ? `, and ${collection.failedRepositoryCount - names.length} more`
                 : "";
             this._notify("warning", `Could not search some repositories: ${names.join(", ")}${suffix}.`);
         }
-        if (built.nodes.length === 0 && !partial) {
+        if (committed && built.nodes.length === 0 && !partial) {
             this._notify("information", `No packages found for "${descriptor.query}".`);
         }
     }
@@ -494,7 +502,7 @@ class SearchProvider {
             targetPage,
             account,
             controller: new AbortController(),
-            attemptRequestCount: committed.diagnostics.requestCount + 1,
+            requestAttempt: { started: false },
         });
         const promise = Promise.resolve()
             .then(() => this._executePage(operation))
@@ -527,7 +535,7 @@ class SearchProvider {
         }
         const { committed, targetPage } = operation;
         const { descriptor } = committed;
-        const pageSize = committed.pagination.pageSize || clampPageSize(this._getPageSize());
+        const pageSize = committed.pagination.pageSize || INTERACTIVE_SEARCH_PAGE_SIZE;
         let endpoint;
         try {
             endpoint = descriptor.kind === "repository"
@@ -545,14 +553,18 @@ class SearchProvider {
         }
 
         let result;
+        let progressToken = null;
         try {
             const paginatedFetch = this._createPaginatedFetch(this._createCloudsmithAPI());
             if (!this._isCurrentPage(operation)) {
                 this._discardPage(operation);
                 return;
             }
-            result = await this._withProgress(progressOptions("Loading more packages..."), (_progress, token) => (
-                paginatedFetch.fetchPage(
+            result = await this._withProgress(progressOptions("Loading more packages..."), (_progress, token) => {
+                progressToken = token;
+                if (token?.isCancellationRequested) return null;
+                operation.requestAttempt.started = true;
+                return paginatedFetch.fetchPage(
                     endpoint,
                     targetPage,
                     pageSize,
@@ -563,12 +575,10 @@ class SearchProvider {
                         signal: operation.controller.signal,
                         validate: isPackageSearchArray,
                     }
-                )
-            ));
+                );
+            });
         } catch (error) {
-            if (!this._isCurrentPage(operation)) {
-                return;
-            }
+            if (!this._continuePage(operation, progressToken)) return;
             this._failPage(
                 operation,
                 `Could not load more packages. ${safeErrorMessage(error)}`,
@@ -579,10 +589,7 @@ class SearchProvider {
             return;
         }
 
-        if (!this._isCurrentPage(operation)) {
-            this._discardPage(operation);
-            return;
-        }
+        if (!this._continuePage(operation, progressToken)) return;
         if (result?.error) {
             if (result.error.kind === "cancelled") {
                 this._cancelPage(operation);
@@ -628,6 +635,7 @@ class SearchProvider {
             return;
         }
 
+        if (!this._continuePage(operation, progressToken)) return;
         let built;
         try {
             const seen = new Set(committed.resultKeys);
@@ -657,16 +665,14 @@ class SearchProvider {
             );
             return;
         }
-        if (!this._isCurrentPage(operation)) {
-            return;
-        }
+        if (!this._continuePage(operation, progressToken)) return;
 
         const available = Math.max(0, MAX_RESULTS - committed.results.length);
         const appended = built.nodes.slice(0, available);
         const results = [...committed.results, ...appended];
         const pagination = freezePagination(result.pagination);
         const pageDropped = built.nodes.length - appended.length;
-        const requestCount = operation.attemptRequestCount;
+        const requestCount = committed.diagnostics.requestCount + 1;
         const pageCount = committed.diagnostics.pageCount + 1;
         const resultLimitReached = results.length >= MAX_RESULTS
             && pagination.page < pagination.pageTotal;
@@ -693,13 +699,14 @@ class SearchProvider {
                 pageLimitReached,
             },
         });
+        if (!this._continuePage(operation, progressToken)) return;
         this._state = freezeState({ committed: nextCommitted, pending: null, failure: null });
         this.refresh();
     }
 
-    _commitRoot(operation, value) {
-        if (!this._isCurrentRoot(operation)) {
-            return;
+    _commitRoot(operation, value, progressToken = null) {
+        if (!this._continueRoot(operation, progressToken)) {
+            return false;
         }
         const resultKeys = value.results.map(packageKeyFromNode);
         const committed = freezeCommitted({
@@ -717,6 +724,7 @@ class SearchProvider {
         this._activeRoot = null;
         this._state = freezeState({ committed, pending: null, failure: null });
         this.refresh();
+        return true;
     }
 
     _cancelRoot(operation) {
@@ -809,6 +817,24 @@ class SearchProvider {
         );
     }
 
+    _continueRoot(operation, progressToken = null) {
+        if (!this._isCurrentRoot(operation)) return false;
+        if (progressToken?.isCancellationRequested) {
+            this._cancelRoot(operation);
+            return false;
+        }
+        return true;
+    }
+
+    _continuePage(operation, progressToken = null) {
+        if (!this._isCurrentPage(operation)) return false;
+        if (progressToken?.isCancellationRequested) {
+            this._cancelPage(operation);
+            return false;
+        }
+        return true;
+    }
+
     _readConnectedAccount() {
         return normalizeConnectedAccount(this.connectionManager.getState?.());
     }
@@ -899,7 +925,7 @@ class SearchProvider {
             if (pending) {
                 return [new InfoNode(
                     "Searching packages...",
-                    "The current search is still running.",
+                    `Searching for: ${pending.descriptor.query || ""}`,
                     `Query: ${pending.descriptor.query || ""}`,
                     "loading~spin"
                 )];
@@ -929,7 +955,7 @@ class SearchProvider {
         }
         children.push(...diagnosticNodes(committed));
         children.push(...committed.results);
-        if (committed.pageable) {
+        if (committed.pageable && !pending) {
             children.push(new LoadMoreNode(
                 committed.pagination.page,
                 committed.pagination.pageTotal,
@@ -1307,10 +1333,8 @@ function freezeCommitted(value) {
 
 function commitPageAttempt(operation, { terminal = false } = {}) {
     const committed = operation.committed;
-    const requestCount = Math.max(
-        committed.diagnostics.requestCount,
-        operation.attemptRequestCount
-    );
+    const requestCount = committed.diagnostics.requestCount
+        + (operation.requestAttempt.started ? 1 : 0);
     const requestLimitReached = requestCount >= MAX_SINGLE_SEARCH_REQUESTS;
     const pageLimitReached = committed.diagnostics.pageCount >= MAX_SINGLE_SEARCH_PAGES;
     const hardLimitReached = requestLimitReached || pageLimitReached;
@@ -1884,9 +1908,9 @@ function summaryNode(committed) {
 
 function failureNode(failure) {
     return new InfoNode(
-        "Search failed",
+        `Search failed for: ${failure.descriptor.query}`,
         failure.message,
-        failure.message,
+        `Query: ${failure.descriptor.query}\n${failure.message}`,
         "error"
     );
 }


### PR DESCRIPTION
## Summary

- Bounded workspace and single-repository searches to an interactive page of at most 10 results while preserving validated server pagination.
- Hardened cancellation, supersession, setup-failure cleanup, and truthful pending, failure, and Load More states.
- Added composed transport, pagination, scale, race, timeout, cancellation, and optional live regression coverage.

## Validation

- `npm run lint` - passed
- `npm test` - passed
- `npm run check` - passed
- `npm audit --omit=dev` - passed
- `npm run audit:runtime` - passed
- `npm run audit:dev` - passed
- `npm run package` - passed
- `npm run package:verify -- out/development/cloudsmith-vsc-2.2.0.vsix` - passed
