### PR TITLE
fix: make quarantine policy trace reliable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -294,10 +294,13 @@ async function pickInstallCommandVariant(result) {
  * Prompt user to select from recently interacted packages.
  * Returns a package-like object or null if no selection made.
  */
-async function pickRecentPackage() {
-  const recent = recentPackages.getAll();
+async function pickRecentPackage(options = {}) {
+  const predicate = typeof options.predicate === "function" ? options.predicate : () => true;
+  const recent = recentPackages.getAll().filter(predicate);
   if (recent.length === 0) {
-    vscode.window.showInformationMessage("No recent packages. Run this command from a package context menu.");
+    vscode.window.showInformationMessage(
+      options.emptyMessage || "No recent packages. Run this command from a package context menu."
+    );
     return null;
   }
   const selected = await vscode.window.showQuickPick(
@@ -306,7 +309,7 @@ async function pickRecentPackage() {
       description: `${p.version || ""} — ${p.repository || ""}`,
       _pkg: p,
     })),
-    { placeHolder: "Select a package" }
+    { placeHolder: options.placeHolder || "Select a package" }
   );
   if (!selected) {
     return null;
@@ -2109,7 +2112,11 @@ async function activateOwned(context, own) {
     // Register explain quarantine command — opens WebView panel with policy trace
     vscode.commands.registerCommand("cloudsmith-vsc.explainQuarantine", async (item) => {
       if (!item) {
-        item = await pickRecentPackage();
+        item = await pickRecentPackage({
+          predicate: isQuarantinedPackage,
+          emptyMessage: "No recent quarantined packages. Run this command from a quarantined package context menu.",
+          placeHolder: "Select a quarantined package",
+        });
         if (!item) return;
       }
       recentPackages.add(item);

--- a/test/integration/policyDecisionLogs.test.js
+++ b/test/integration/policyDecisionLogs.test.js
@@ -1,0 +1,71 @@
+const assert = require("assert");
+const { apiEndpoint } = require("../../util/apiEndpoint");
+const {
+  fetchPackageDecisionLogs,
+  selectCausalDecision,
+} = require("../../util/policyDecisionLogs");
+const { SearchQueryBuilder } = require("../../util/searchQueryBuilder");
+const { createAPI, liveFixture } = require("./setup");
+
+suite("Live integration: policy decision trace", function () {
+  this.timeout(30000);
+
+  test("retrieves a bounded exact trace for the controlled quarantined package", async function () {
+    const api = createAPI();
+    const packageResult = await api.get(apiEndpoint([
+      "packages", liveFixture.workspace, liveFixture.repository,
+    ], {
+      query: {
+        query: new SearchQueryBuilder()
+          .name(liveFixture.quarantinedPackageName)
+          .status("quarantined")
+          .build(),
+        page_size: 10,
+      },
+    }), { apiKey: liveFixture.apiKey, responseType: "array" });
+    assert.strictEqual(packageResult.ok, true, packageResult.error && packageResult.error.message);
+    const pkg = packageResult.data.find(value => (
+      value.name === liveFixture.quarantinedPackageName
+      && value.status_str === "Quarantined"
+    ));
+    assert.ok(pkg, "Configured quarantined package was not found");
+    assert.strictEqual(typeof pkg.slug_perm, "string");
+    assert.strictEqual(typeof pkg.uploaded_at, "string");
+
+    let requests = 0;
+    const authenticated = {
+      async getV2(endpoint, options) {
+        requests += 1;
+        return api.getV2(endpoint, { ...options, apiKey: liveFixture.apiKey });
+      },
+    };
+    const locator = {
+      workspace: liveFixture.workspace,
+      repository: liveFixture.repository,
+      packageSlugPerm: pkg.slug_perm,
+    };
+    const collection = await fetchPackageDecisionLogs(
+      authenticated,
+      locator,
+      pkg.uploaded_at
+    );
+    assert(requests > 0 && requests <= 20, "Decision-log request count escaped its bound");
+    assert.strictEqual(collection.failures.length, 0);
+    for (const entry of collection.items) {
+      assert.strictEqual(entry.packageSlugPerm, pkg.slug_perm);
+      assert.strictEqual(entry.repositorySlug, liveFixture.repository);
+    }
+    if (collection.items.length === 0) {
+      this.skip();
+      return;
+    }
+    const selected = selectCausalDecision(collection.items);
+    if (!selected) {
+      this.skip();
+      return;
+    }
+    assert.strictEqual(selected.match, true);
+    assert.strictEqual(typeof selected.policySlugPerm, "string");
+    assert.strictEqual(selected.action, "Quarantined");
+  });
+});

--- a/test/policyDecisionLogs.test.js
+++ b/test/policyDecisionLogs.test.js
@@ -1,14 +1,18 @@
 const assert = require("assert");
 const {
   MAX_POLICY_STATUS_REASON_LENGTH,
+  createQuarantineLocator,
+  fetchDecisionLogDetail,
   fetchPackageDecisionLogs,
+  hasQuarantineAction,
   normalizePolicyStatusReason,
   parsePolicyStatusReason,
+  selectCausalDecision,
 } = require("../util/policyDecisionLogs");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 suite("Policy decision log collection", () => {
-  function page(data, pageNumber, pageTotal, count = 101) {
+  function page(data, pageNumber = 1, pageTotal = 1, count = data.length) {
     return apiSuccess({ results: data }, {
       headers: {
         "x-pagination-page": String(pageNumber),
@@ -19,133 +23,396 @@ suite("Policy decision log collection", () => {
     });
   }
 
-  function log(index, packageIdentifier = "other-package") {
+  function summary(index, overrides = {}) {
     return {
-      slug_perm: `decision-${index}`,
-      package: { identifier: packageIdentifier },
-      policy_name: "Policy",
+      id: String(index).padStart(26, "0"),
+      actions: { action_type: "SetPackageState", package_state: "QUARANTINED" },
+      correlation_id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      ended_at: `2026-08-13T12:${String(index % 60).padStart(2, "0")}:01.000Z`,
+      match: true,
+      package_format: "NPM",
+      package_name: "artifact",
+      package_slug: "artifact",
+      package_slug_perm: "package-a",
+      package_version: "1.0.0",
+      policy_is_terminal: true,
+      policy_name: "Quarantine policy",
+      policy_precedence: 1,
+      policy_slug_perm: "policy-a",
+      policy_version: 1,
+      repository_name: "Repository A",
+      repository_slug: "repo-a",
+      repository_slug_perm: "repo-perm-a",
+      started_at: `2026-08-13T12:${String(index % 60).padStart(2, "0")}:00.000Z`,
+      ...overrides,
     };
   }
 
-  test("finds a package decision on a later page without returning unrelated entries", async () => {
+  const locator = Object.freeze({
+    workspace: "workspace-a",
+    repository: "repo-a",
+    packageSlugPerm: "package-a",
+  });
+  const createdAfter = "2026-08-13T10:00:00.000Z";
+
+  test("uses the current filtered endpoint and exact bounded query", async () => {
     const calls = [];
-    const firstPage = Array.from({ length: 100 }, (_, index) => log(index));
     const api = {
       async getV2(endpoint, options) {
-        calls.push(endpoint);
-        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
-        const response = pageNumber === 1
-          ? page(firstPage, 1, 2)
-          : page([log(100, "target-package")], 2, 2);
-        assert.strictEqual(options.validate(response.data), true);
-        return response;
+        calls.push({ endpoint, options });
+        return page([summary(1)]);
       },
     };
-
-    const result = await fetchPackageDecisionLogs(api, "workspace-a", "target-package");
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter, {
+      policySlug: "policy-a",
+      repositorySlugPerm: "repo-perm-a",
+    });
 
     assert.strictEqual(result.complete, true);
-    assert.strictEqual(result.pageCount, 2);
-    assert.deepStrictEqual(result.items.map(item => item.slug_perm), ["decision-100"]);
-    assert.strictEqual(result.items[0].matched, null);
-    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(result.items.length, 1);
+    const url = new URL(calls[0].endpoint, "https://api.invalid/");
+    assert.strictEqual(url.pathname, "/workspaces/workspace-a/policies/decision-logs-v1/");
+    assert.deepStrictEqual([...url.searchParams.keys()].sort(), [
+      "created_after", "match", "package_slug_perm", "page", "page_size",
+      "policy_slug_perm", "repository_slug_perm", "sort",
+    ].sort());
+    assert.strictEqual(url.searchParams.get("created_after"), createdAfter);
+    assert.strictEqual(url.searchParams.get("package_slug_perm"), "package-a");
+    assert.strictEqual(url.searchParams.get("repository_slug_perm"), "repo-perm-a");
+    assert.strictEqual(url.searchParams.get("match"), "true");
+    assert.strictEqual(url.searchParams.get("sort"), "-id");
+    assert.strictEqual(calls[0].options.retry, "never");
   });
 
-  test("preserves matching decisions from successful pages and marks later failure partial", async () => {
-    const firstPage = [log(0, "target-package"), ...Array.from(
-      { length: 99 },
-      (_, index) => log(index + 1)
-    )];
+  test("finds a causal record on a later numeric page", async () => {
+    const first = Array.from({ length: 100 }, (_, index) => summary(index + 1, {
+      actions: {},
+    }));
+    const calls = [];
     const api = {
       async getV2(endpoint) {
-        const pageNumber = Number(new URL(endpoint, "https://example.invalid").searchParams.get("page"));
+        const pageNumber = Number(new URL(endpoint, "https://api.invalid/").searchParams.get("page"));
+        calls.push(pageNumber);
         return pageNumber === 1
-          ? page(firstPage, 1, 2)
-          : apiFailure("rate_limited", { status: 429, retryable: true });
+          ? page(first, 1, 2, 101)
+          : page([summary(101)], 2, 2, 101);
       },
     };
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
+    const selected = selectCausalDecision(result.items);
 
-    const result = await fetchPackageDecisionLogs(api, "workspace-a", "target-package");
+    assert.strictEqual(result.complete, true);
+    assert.deepStrictEqual(calls, [1, 2]);
+    assert.strictEqual(selected.id, summary(101).id);
+  });
 
+  test("selects the newest exact quarantine decision deterministically", () => {
+    const records = [summary(2), summary(3, { policy_slug_perm: "policy-b" }), summary(1)]
+      .map(value => ({
+        id: value.id,
+        match: value.match,
+        action: "Quarantined",
+        policySlugPerm: value.policy_slug_perm,
+      }));
+    assert.strictEqual(selectCausalDecision(records).id, summary(3).id);
+    assert.strictEqual(selectCausalDecision(records, "policy-a").id, summary(2).id);
+  });
+
+  test("does not turn an incomplete empty collection into an authoritative match", async () => {
+    const api = {
+      async getV2() { return apiFailure("rate_limited", { status: 429, retryable: true }); },
+    };
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
     assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.incomplete, true);
+    assert.strictEqual(selectCausalDecision(result.items), null);
+  });
+
+  test("retains representative typed HTTP failures without retrying", async () => {
+    for (const [kind, status] of [
+      ["authentication", 401],
+      ["permission", 403],
+      ["not_found", 404],
+      ["rate_limited", 429],
+      ["server_error", 500],
+      ["server_error", 503],
+    ]) {
+      let calls = 0;
+      const result = await fetchPackageDecisionLogs({
+        async getV2(_endpoint, options) {
+          calls += 1;
+          assert.strictEqual(options.retry, "never");
+          return apiFailure(kind, { status, retryable: status === 429 || status >= 500 });
+        },
+      }, locator, createdAfter);
+      assert.strictEqual(calls, 1);
+      assert.strictEqual(result.complete, false);
+      assert.strictEqual(result.failures[0].error.kind, kind);
+      assert.strictEqual(result.failures[0].error.status, status);
+    }
+  });
+
+  test("preserves an earlier page and marks a later failure partial", async () => {
+    const first = [summary(1), ...Array.from({ length: 99 }, (_, index) => summary(index + 2, {
+      actions: {},
+    }))];
+    const api = {
+      async getV2(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://api.invalid/").searchParams.get("page"));
+        return pageNumber === 1
+          ? page(first, 1, 2, 101)
+          : apiFailure("server", { status: 503, retryable: true });
+      },
+    };
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
     assert.strictEqual(result.partial, true);
     assert.strictEqual(result.failureCount, 1);
-    assert.deepStrictEqual(result.items.map(item => item.slug_perm), ["decision-0"]);
+    assert.strictEqual(selectCausalDecision(result.items).id, summary(1).id);
   });
 
-  test("bounds status reasons before parsing policy text", () => {
-    const hostile = `Quarantined by Policy. ${"x".repeat(10000)} (Policy: policy-a)`;
-    const normalized = normalizePolicyStatusReason(hostile);
-    const parsed = parsePolicyStatusReason(hostile);
-
-    assert.strictEqual(normalized.length, MAX_POLICY_STATUS_REASON_LENGTH);
-    assert.ok(parsed);
-    assert.ok(JSON.stringify(parsed).length <= MAX_POLICY_STATUS_REASON_LENGTH + 100);
-  });
-
-  test("rejects a decision log slug beyond the shared identity bound", async () => {
-    const result = await fetchPackageDecisionLogs({
-      async getV2(_endpoint, options) {
-        const data = {
-          results: [{
-            slug_perm: "x".repeat(513),
-            package: { identifier: "target-package" },
-          }],
-        };
-        assert.strictEqual(options.validate(data), false);
-        return apiFailure("invalid_response", { status: 200 });
+  test("duplicate IDs across pages terminate incomplete", async () => {
+    const first = Array.from({ length: 100 }, (_, index) => summary(index + 1));
+    const api = {
+      async getV2(endpoint) {
+        const pageNumber = Number(new URL(endpoint, "https://api.invalid/").searchParams.get("page"));
+        return pageNumber === 1
+          ? page(first, 1, 2, 101)
+          : page([summary(1)], 2, 2, 101);
       },
-    }, "workspace-a", "target-package");
-
+    };
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
     assert.strictEqual(result.complete, false);
-    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+    assert.strictEqual(result.incomplete, true);
+    assert.strictEqual(result.items.length, 100);
   });
 
-  test("rejects an overlong requested package reference before dispatch", async () => {
+  test("malformed pagination metadata fails closed", async () => {
+    const api = {
+      async getV2() {
+        return apiSuccess({ results: [summary(1)] }, {
+          headers: {
+            "x-pagination-page": "2",
+            "x-pagination-pagetotal": "1",
+            "x-pagination-pagesize": "100",
+            "x-pagination-count": "1",
+          },
+        });
+      },
+    };
+    const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.items.length, 0);
+  });
+
+  test("cancellation prevents dispatch", async () => {
+    const controller = new AbortController();
+    controller.abort();
     let calls = 0;
     const result = await fetchPackageDecisionLogs({
       async getV2() { calls += 1; throw new Error("must not dispatch"); },
-    }, "workspace-a", "x".repeat(513));
-
+    }, locator, createdAfter, { signal: controller.signal });
     assert.strictEqual(calls, 0);
     assert.strictEqual(result.complete, false);
+  });
+
+  test("rejects invalid time boundaries and path identities before dispatch", async () => {
+    let calls = 0;
+    const api = { async getV2() { calls += 1; throw new Error("must not dispatch"); } };
+    for (const boundary of [null, "yesterday", " 2026-08-13T10:00:00Z", "x".repeat(129)]) {
+      const result = await fetchPackageDecisionLogs(api, locator, boundary);
+      assert.strictEqual(result.termination, "invalid_request");
+    }
+    const invalidLocator = { ...locator, repository: "repo%2Fa" };
+    const result = await fetchPackageDecisionLogs(api, invalidLocator, createdAfter);
     assert.strictEqual(result.termination, "invalid_request");
+    assert.strictEqual(calls, 0);
   });
 
-  test("rejects conflicting package reference aliases instead of attributing the decision", async () => {
-    const conflicting = {
-      slug_perm: "decision-conflicting",
-      package_slug_perm: "target-package",
-      package: { identifier: "different-package" },
+  test("rejects malformed current summary fields", async () => {
+    for (const malformed of [
+      { id: "not-a-ulid" },
+      { correlation_id: "not-a-uuid" },
+      { match: "true" },
+      { repository_slug: {} },
+      { policy_slug_perm: [] },
+      { started_at: "not-a-date" },
+      { actions: [] },
+    ]) {
+      const api = {
+        async getV2(_endpoint, options) {
+          const data = { results: [{ ...summary(1), ...malformed }] };
+          assert.strictEqual(options.validate(data), false);
+          return apiFailure("invalid_response", { status: 200 });
+        },
+      };
+      const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
+      assert.strictEqual(result.complete, false);
+      assert.deepStrictEqual(result.items, []);
+    }
+  });
+
+  test("rejects every character excluded from the canonical ULID alphabet", async () => {
+    for (const excluded of ["I", "L", "O", "U"]) {
+      const api = {
+        async getV2(_endpoint, options) {
+          const data = { results: [summary(1, { id: `${"0".repeat(25)}${excluded}` })] };
+          assert.strictEqual(options.validate(data), false);
+          return apiFailure("invalid_response", { status: 200 });
+        },
+      };
+      const result = await fetchPackageDecisionLogs(api, locator, createdAfter);
+      assert.strictEqual(result.complete, false);
+      assert.deepStrictEqual(result.items, []);
+    }
+  });
+
+  test("fetches and reconciles only the selected decision detail", async () => {
+    const selected = {
+      ...selectCausalDecision([{
+        id: summary(1).id,
+        correlationId: summary(1).correlation_id,
+        match: true,
+        action: "Quarantined",
+        policySlugPerm: "policy-a",
+        policyName: "Quarantine policy",
+        startedAt: summary(1).started_at,
+        endedAt: summary(1).ended_at,
+      }]),
     };
-    const result = await fetchPackageDecisionLogs({
-      async getV2(_endpoint, options) {
-        const data = { results: [conflicting] };
-        assert.strictEqual(options.validate(data), false);
-        return apiFailure("invalid_response", { status: 200 });
+    const calls = [];
+    const api = {
+      async getV2(endpoint, options) {
+        calls.push(endpoint);
+        const data = detail(selected);
+        assert.strictEqual(options.validate(data), true);
+        return apiSuccess(data);
       },
-    }, "workspace-a", "target-package");
-
-    assert.strictEqual(result.complete, false);
-    assert.deepStrictEqual(result.items, []);
-    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+    };
+    const result = await fetchDecisionLogDetail(api, locator, selected);
+    assert.strictEqual(result.action, "Quarantined");
+    assert.strictEqual(result.reason, "Dependency rule matched.");
+    assert.match(calls[0], new RegExp(`/decision-logs-v1/${selected.id}/`));
   });
 
-  test("rejects a malformed matched decision instead of normalizing it to false", async () => {
-    const result = await fetchPackageDecisionLogs({
-      async getV2(_endpoint, options) {
-        const data = { results: [{
-          slug_perm: "decision-malformed-match",
-          package_slug_perm: "target-package",
-          matched: "false",
-        }] };
-        assert.strictEqual(options.validate(data), false);
-        return apiFailure("invalid_response", { status: 200 });
-      },
-    }, "workspace-a", "target-package");
-
-    assert.strictEqual(result.complete, false);
-    assert.deepStrictEqual(result.items, []);
-    assert.strictEqual(result.failures[0].error.kind, "invalid_response");
+  test("rejects mismatched detail identities and unproven invoked actions", async () => {
+    const selected = {
+      id: summary(1).id,
+      correlationId: summary(1).correlation_id,
+      policySlugPerm: "policy-a",
+      policyName: "Quarantine policy",
+      startedAt: summary(1).started_at,
+      endedAt: summary(1).ended_at,
+    };
+    for (const mutate of [
+      value => { value.policy.slug_perm = "policy-b"; },
+      value => { value.policy_input.v0.workspace.slug = "workspace-b"; },
+      value => { value.policy_input.v0.repository.slug = "repo-b"; },
+      value => { value.policy_input.v0.package.slug_perm = "package-b"; },
+      value => { value.ended_at = "2026-08-13T12:00:02.000Z"; },
+      value => { value.parsed_actions = []; },
+    ]) {
+      const data = detail(selected);
+      mutate(data);
+      const result = await fetchDecisionLogDetail({
+        async getV2(_endpoint, options) {
+          if (!options.validate(data)) return apiFailure("invalid_response", { status: 200 });
+          return apiSuccess(data);
+        },
+      }, locator, selected);
+      assert.strictEqual(result, null);
+    }
   });
+
+  test("canonical locator requires exact agreement between like aliases", () => {
+    assert.deepStrictEqual(createQuarantineLocator({
+      namespace: "workspace-a",
+      cloudsmithWorkspace: "workspace-a",
+      repository: "repo-a",
+      cloudsmithRepo: "repo-a",
+      slug_perm: { value: "package-a" },
+      slug_perm_raw: "package-a",
+    }), locator);
+    assert.strictEqual(createQuarantineLocator({
+      namespace: "workspace-a",
+      cloudsmithWorkspace: "workspace-b",
+      repository: "repo-a",
+      slug_perm_raw: "package-a",
+    }), null);
+    assert.strictEqual(createQuarantineLocator({
+      namespace: "workspace-a",
+      repository: "repo-a",
+      slug_perm: { value: {} },
+      slug_perm_raw: "package-a",
+    }), null);
+
+    let reads = 0;
+    const accessor = {};
+    Object.defineProperty(accessor, "value", {
+      enumerable: true,
+      get() { reads += 1; return "package-a"; },
+    });
+    assert.strictEqual(createQuarantineLocator({
+      namespace: "workspace-a",
+      repository: "repo-a",
+      slug_perm: accessor,
+    }), null);
+    assert.strictEqual(reads, 0);
+
+    class PackageLikeNode {
+      constructor() {
+        this.namespace = "workspace-a";
+        this.repository = "repo-a";
+        this.slug_perm = { value: "package-a" };
+        this.slug_perm_raw = "package-a";
+      }
+    }
+    assert.deepStrictEqual(createQuarantineLocator(new PackageLikeNode()), locator);
+  });
+
+  test("bounds status reasons and extracts a canonical policy slug", () => {
+    const hostile = `Quarantined by Policy. ${"x".repeat(10000)} (Policy: policy-a)`;
+    assert.strictEqual(normalizePolicyStatusReason(hostile).length, MAX_POLICY_STATUS_REASON_LENGTH);
+    const parsed = parsePolicyStatusReason(
+      "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)"
+    );
+    assert.strictEqual(parsed.policyName, "Dependency policy");
+    assert.strictEqual(parsed.policySlug, "policy-a");
+    assert.strictEqual(normalizePolicyStatusReason("Rule\u202e spoofed\nAction"), "Rule  spoofed Action");
+  });
+
+  test("accepts only direct action evidence and rejects nested examples", () => {
+    assert.strictEqual(hasQuarantineAction({
+      action_type: "SetPackageState",
+      package_state: "QUARANTINED",
+    }), true);
+    assert.strictEqual(hasQuarantineAction([{
+      action_type: "SetPackageState",
+      package_state: "QUARANTINED",
+    }]), true);
+    assert.strictEqual(hasQuarantineAction({
+      example: {
+        action_type: "SetPackageState",
+        package_state: "QUARANTINED",
+      },
+    }), false);
+  });
+
+  function detail(selected) {
+    return {
+      id: selected.id,
+      correlation_id: selected.correlationId,
+      policy: { slug_perm: selected.policySlugPerm },
+      started_at: selected.startedAt,
+      ended_at: selected.endedAt,
+      policy_input: {
+        v0: {
+          workspace: { slug: "workspace-a", slug_perm: "workspace-perm-a" },
+          repository: { slug: "repo-a", slug_perm: "repo-perm-a" },
+          package: { slug: "artifact", slug_perm: "package-a" },
+        },
+      },
+      policy_output: { reason: "Dependency rule matched." },
+      parsed_actions: [{ action_type: "SetPackageState", package_state: "QUARANTINED" }],
+    };
+  }
 });

--- a/test/policyDecisionLogs.test.js
+++ b/test/policyDecisionLogs.test.js
@@ -1,10 +1,8 @@
 const assert = require("assert");
 const {
-  MAX_POLICY_STATUS_REASON_LENGTH,
   createQuarantineLocator,
   fetchDecisionLogDetail,
   fetchPackageDecisionLogs,
-  hasQuarantineAction,
   normalizePolicyStatusReason,
   parsePolicyStatusReason,
   selectCausalDecision,
@@ -371,7 +369,7 @@ suite("Policy decision log collection", () => {
 
   test("bounds status reasons and extracts a canonical policy slug", () => {
     const hostile = `Quarantined by Policy. ${"x".repeat(10000)} (Policy: policy-a)`;
-    assert.strictEqual(normalizePolicyStatusReason(hostile).length, MAX_POLICY_STATUS_REASON_LENGTH);
+    assert.strictEqual(normalizePolicyStatusReason(hostile).length, 4096);
     const parsed = parsePolicyStatusReason(
       "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)"
     );
@@ -380,21 +378,24 @@ suite("Policy decision log collection", () => {
     assert.strictEqual(normalizePolicyStatusReason("Rule\u202e spoofed\nAction"), "Rule  spoofed Action");
   });
 
-  test("accepts only direct action evidence and rejects nested examples", () => {
-    assert.strictEqual(hasQuarantineAction({
-      action_type: "SetPackageState",
-      package_state: "QUARANTINED",
-    }), true);
-    assert.strictEqual(hasQuarantineAction([{
-      action_type: "SetPackageState",
-      package_state: "QUARANTINED",
-    }]), true);
-    assert.strictEqual(hasQuarantineAction({
-      example: {
-        action_type: "SetPackageState",
-        package_state: "QUARANTINED",
+  test("selects only direct action evidence through the collection contract", async () => {
+    const direct = summary(1);
+    const nestedExample = summary(2, {
+      actions: {
+        example: {
+          action_type: "SetPackageState",
+          package_state: "QUARANTINED",
+        },
       },
-    }), false);
+    });
+    const result = await fetchPackageDecisionLogs({
+      async getV2() { return page([direct, nestedExample]); },
+    }, locator, createdAfter);
+
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.items[0].action, "Quarantined");
+    assert.strictEqual(result.items[1].action, null);
+    assert.strictEqual(selectCausalDecision(result.items).id, direct.id);
   });
 
   function detail(selected) {

--- a/test/quarantineExplainProvider.test.js
+++ b/test/quarantineExplainProvider.test.js
@@ -1,91 +1,362 @@
 const assert = require("assert");
 const { QuarantineExplainProvider } = require("../views/quarantineExplainProvider");
+const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 const { createWebviewPanelHarness } = require("./helpers/webviewPanelHarness");
 
-suite("QuarantineExplainProvider policy completeness", () => {
-  function render(trace) {
-    const provider = new QuarantineExplainProvider({});
-    return provider._getHtmlContent(
-      "nonce",
-      "artifact",
-      "1.0.0",
-      "npm",
-      "workspace-a",
-      "repo-a",
-      "package-a",
-      "Quarantined by Policy. Rule matched. (Policy: policy-a)",
-      null,
-      trace
-    );
+suite("QuarantineExplainProvider", () => {
+  function trace(overrides = {}) {
+    return {
+      current: {
+        confirmed: true,
+        format: "npm",
+        name: "artifact",
+        packageSlugPerm: "package-a",
+        repository: "repo-a",
+        status: "Quarantined",
+        statusReason: "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)",
+        uploadedAt: "2026-08-13T10:00:00.000Z",
+        version: "1.0.0",
+        workspace: "workspace-a",
+      },
+      decision: null,
+      error: null,
+      packageUrl: "https://app.cloudsmith.com/workspace-a/repo-a/packages/detail/npm/artifact/1.0.0/a=package-a/",
+      parsedReason: {
+        description: "Dependency rule matched.",
+        policyName: "Dependency policy",
+        policySlug: "policy-a",
+      },
+      policyDescription: null,
+      refreshed: true,
+      ...overrides,
+    };
   }
 
-  test("does not claim a non-vulnerability quarantine when policy history is incomplete", () => {
-    const html = render({
-      parsedReason: null,
-      decisionLogs: [],
-      decisionLogsComplete: false,
-      decisionLogsPartial: true,
-      policyDetail: null,
-    });
+  function render(overrides = {}) {
+    const provider = new QuarantineExplainProvider({});
+    return provider._getHtmlContent("nonce", trace(overrides));
+  }
 
-    assert.match(html, /Policy decision log history is incomplete/);
-    assert.doesNotMatch(html, /not a specific vulnerability/);
+  test("renders a focused status-reason explanation without backend-gap copy", () => {
+    const html = render();
+    assert.match(html, /<h1>artifact 1\.0\.0<\/h1>/);
+    assert.match(html, />Quarantined</);
+    assert.match(html, /<dt>Policy<\/dt><dd>Dependency policy<\/dd>/);
+    assert.match(html, /Dependency rule matched/);
+    assert.match(html, /<dt>Action<\/dt><dd>Quarantined<\/dd>/);
+    assert.doesNotMatch(html, /incomplete|additional entries|not a specific vulnerability/i);
+    assert.doesNotMatch(html, /Decision log entries|<table|Unknown|Matched/);
   });
 
-  test("allows a non-vulnerability conclusion only after complete policy history", () => {
+  test("renders a decision-only explanation from reconciled evidence", () => {
+    const current = { ...trace().current, statusReason: null };
     const html = render({
+      current,
       parsedReason: null,
-      decisionLogs: [],
-      decisionLogsComplete: true,
-      decisionLogsPartial: false,
-      policyDetail: null,
+      decision: {
+        policyName: "Quarantine policy",
+        policySlugPerm: "policy-a",
+        reason: "Unsafe dependency matched.",
+        endedAt: "2026-08-13T12:00:00.000Z",
+      },
     });
-
-    assert.match(html, /not a specific vulnerability/);
-    assert.doesNotMatch(html, /Policy decision log history is incomplete/);
+    assert.match(html, /Quarantine policy/);
+    assert.match(html, /Unsafe dependency matched/);
+    assert.match(html, /Decision recorded/);
   });
 
-  test("renders a missing policy match flag as unknown rather than no", () => {
+  test("current status reason takes precedence over conflicting decision text", () => {
     const html = render({
-      parsedReason: null,
-      decisionLogs: [{ policy_name: "Policy", matched: null }],
-      decisionLogsComplete: true,
-      decisionLogsPartial: false,
-      policyDetail: null,
+      decision: {
+        policyName: "Other policy",
+        reason: "Contradictory reason.",
+        endedAt: "2026-08-13T12:00:00.000Z",
+      },
     });
-
-    assert.match(html, /<td>Unknown<\/td>/);
-    assert.doesNotMatch(html, /<td>No<\/td>/);
+    assert.match(html, /Dependency policy/);
+    assert.match(html, /Dependency rule matched/);
+    assert.doesNotMatch(html, /Other policy|Contradictory reason/);
   });
 
-  test("account reset aborts stale policy loading before it can render", async () => {
-    let state = {
-      activationId: "account-a",
-      accountEpoch: 1,
-      sessionConnected: true,
-    };
+  test("policy description is optional, escaped, and does not expose the slug", () => {
+    const html = render({ policyDescription: "Use <safe> dependencies & signed sources." });
+    assert.match(html, /About this policy/);
+    assert.match(html, /Use &lt;safe&gt; dependencies &amp; signed sources/);
+    assert.doesNotMatch(html, />policy-a</);
+  });
+
+  test("shows accessible loading, stale, and actionable failure states", () => {
+    const loading = render({
+      current: { ...trace().current, status: null },
+      parsedReason: null,
+      refreshed: false,
+    });
+    assert.match(loading, /role="status" aria-live="polite"/);
+    assert.doesNotMatch(loading, /⛔|Find safe version/);
+
+    const noReason = render({
+      current: { ...trace().current, statusReason: null },
+      parsedReason: null,
+      refreshed: false,
+    });
+    assert.match(noReason, /Loading quarantine details/);
+    assert.doesNotMatch(noReason, /⛔|<dt>Action/);
+
+    const stale = render({ current: { ...trace().current, status: "Available" }, error: "stale" });
+    assert.match(stale, /no longer quarantined/);
+    assert.doesNotMatch(stale, /Find safe version|Copy report/);
+
+    const failed = render({ current: null, error: "load" });
+    assert.match(failed, /Could not load quarantine details/);
+    assert.match(failed, /data-command="retry"/);
+  });
+
+  test("renders primary explanation before optional policy description settles", async () => {
     const panelHarness = createWebviewPanelHarness();
-    let resolveFetch;
-    const gate = new Promise(resolve => { resolveFetch = resolve; });
-    let signal;
-    const provider = new QuarantineExplainProvider({}, {
-      connectionManager: { getState() { return { ...state }; } },
-      createWebviewPanel: panelHarness.createWebviewPanel,
-      createNonce: () => "fixed-nonce",
+    let resolvePolicy;
+    const policyGate = new Promise(resolve => { resolvePolicy = resolve; });
+    const calls = [];
+    const provider = providerWith(panelHarness, {
+      async get(endpoint) {
+        calls.push(endpoint);
+        return apiSuccess(freshPackage());
+      },
+      async getV2(endpoint) {
+        calls.push(endpoint);
+        if (endpoint.includes("/policies/policy-a/")) return policyGate;
+        return emptyDecisionPage();
+      },
     });
-    provider._fetchPolicyDecisionTrace = async (_api, _workspace, _slug, _reason, requestSignal) => {
-      signal = requestSignal;
-      await gate;
-      return {
-        parsedReason: null,
-        decisionLogs: [],
-        decisionLogsComplete: true,
-        policyDetail: null,
-      };
-    };
 
     const pending = provider.show(packageItem());
-    await new Promise(resolve => setImmediate(resolve));
+    await tick();
+    await tick();
+    assert.match(panelHarness.panel.webview.html, /Dependency rule matched/);
+    assert.match(panelHarness.panel.webview.html, /Find safe version/);
+    assert.doesNotMatch(panelHarness.panel.webview.html, /About this policy/);
+    resolvePolicy(apiSuccess({ slug_perm: "policy-a", description: "Blocks unsafe dependencies." }));
+    await pending;
+    assert.match(panelHarness.panel.webview.html, /About this policy/);
+    assert.strictEqual(calls.filter(value => value.includes("decision-logs-v1")).length, 1);
+    assert.strictEqual(calls.filter(value => value.includes("/policies/policy-a/")).length, 1);
+  });
+
+  test("optional policy failure preserves the useful primary explanation", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const provider = providerWith(panelHarness, {
+      async get() { return apiSuccess(freshPackage()); },
+      async getV2(endpoint) {
+        return endpoint.includes("/policies/policy-a/")
+          ? apiFailure("permission", { status: 403 })
+          : emptyDecisionPage();
+      },
+    });
+    await provider.show(packageItem());
+    const html = panelHarness.panel.webview.html;
+    assert.match(html, /Dependency rule matched/);
+    assert.doesNotMatch(html, /permission|403|incomplete|Could not load/);
+  });
+
+  test("production path renders a decision-only trace after exact detail reconciliation", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const provider = providerWith(panelHarness, {
+      async get() {
+        return apiSuccess(freshPackage({ status_reason: null }));
+      },
+      async getV2(endpoint) {
+        if (/decision-logs-v1\/\d{26}\//.test(endpoint)) {
+          return apiSuccess(decisionDetail());
+        }
+        if (endpoint.includes("decision-logs-v1")) {
+          return decisionPage([decisionSummary()]);
+        }
+        return apiSuccess({ slug_perm: "policy-a", description: "Blocks unsafe dependencies." });
+      },
+    });
+    await provider.show(packageItem({ status_reason: null }));
+    const html = panelHarness.panel.webview.html;
+    assert.match(html, /Quarantine policy/);
+    assert.match(html, /Dependency rule matched/);
+    assert.match(html, /Decision recorded/);
+    assert.doesNotMatch(html, /\[object Object\]|incomplete|decision log/i);
+  });
+
+  test("a tautological quarantine status reason does not suppress decision evidence", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    let decisionCalls = 0;
+    const provider = providerWith(panelHarness, {
+      async get() { return apiSuccess(freshPackage({ status_reason: "Quarantined" })); },
+      async getV2(endpoint) {
+        if (/decision-logs-v1\/\d{26}\//.test(endpoint)) return apiSuccess(decisionDetail());
+        if (endpoint.includes("decision-logs-v1")) {
+          decisionCalls += 1;
+          return decisionPage([decisionSummary()]);
+        }
+        return apiFailure("not_found", { status: 404 });
+      },
+    });
+    await provider.show(packageItem({ status_reason: "Quarantined" }));
+    assert.strictEqual(decisionCalls, 1);
+    assert.match(panelHarness.panel.webview.html, /Dependency rule matched/);
+  });
+
+  test("fresh status reason replaces provisional caller text", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const provider = providerWith(panelHarness, {
+      async get() {
+        return apiSuccess(freshPackage({
+          status_reason: "Quarantined by Current policy. Current rule matched. (Policy: current-policy)",
+        }));
+      },
+      async getV2(endpoint) {
+        return endpoint.includes("/policies/current-policy/")
+          ? apiFailure("not_found", { status: 404 })
+          : emptyDecisionPage();
+      },
+    });
+    await provider.show(packageItem({
+      status_reason: "Quarantined by Stale policy. Stale rule matched. (Policy: stale-policy)",
+    }));
+    const html = panelHarness.panel.webview.html;
+    assert.match(html, /Current policy/);
+    assert.match(html, /Current rule matched/);
+    assert.doesNotMatch(html, /Stale policy|Stale rule matched/);
+  });
+
+  test("wrong policy detail identity is omitted", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const provider = providerWith(panelHarness, {
+      async get() { return apiSuccess(freshPackage()); },
+      async getV2(endpoint) {
+        return endpoint.includes("/policies/policy-a/")
+          ? apiSuccess({ slug_perm: "policy-b", description: "Wrong workspace policy." })
+          : emptyDecisionPage();
+      },
+    });
+    await provider.show(packageItem());
+    assert.doesNotMatch(panelHarness.panel.webview.html, /Wrong workspace policy/);
+  });
+
+  test("conflicting or malformed locator aliases fail before panel and API dispatch", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    let calls = 0;
+    const warnings = [];
+    const provider = providerWith(panelHarness, {
+      async get() { calls += 1; throw new Error("must not dispatch"); },
+      async getV2() { calls += 1; throw new Error("must not dispatch"); },
+    }, { warning: async value => { warnings.push(value); } });
+    await provider.show(packageItem({ cloudsmithWorkspace: "workspace-b" }));
+    await provider.show(packageItem({ slug_perm: { value: {} } }));
+    assert.strictEqual(calls, 0);
+    assert.strictEqual(panelHarness.panelCalls.length, 0);
+    assert.strictEqual(warnings.length, 2);
+  });
+
+  test("fresh identity drift fails closed and never enables commands", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const effects = [];
+    const provider = providerWith(panelHarness, {
+      async get() { return apiSuccess(freshPackage({ repository: "repo-b" })); },
+      async getV2() { throw new Error("must not dispatch"); },
+    }, {}, { executeCommand: async (...args) => { effects.push(args); } });
+    await provider.show(packageItem());
+    assert.match(panelHarness.panel.webview.html, /Could not load quarantine details/);
+    await panelHarness.send({ command: "findSafeVersion" });
+    assert.deepStrictEqual(effects, []);
+  });
+
+  test("fresh package 404 renders a stable unavailable state without enrichment", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    let v2Calls = 0;
+    const provider = providerWith(panelHarness, {
+      async get() { return apiFailure("not_found", { status: 404 }); },
+      async getV2() { v2Calls += 1; throw new Error("must not dispatch"); },
+    });
+    await provider.show(packageItem());
+    assert.match(panelHarness.panel.webview.html, /no longer available/);
+    assert.doesNotMatch(panelHarness.panel.webview.html, /Quarantined|Find safe version/);
+    assert.strictEqual(v2Calls, 0);
+  });
+
+  test("routes only exact messages after refresh and produces a causal report", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const effects = { commands: [], clipboard: [], external: [], information: [], warning: [] };
+    const provider = providerWith(panelHarness, {
+      async get() { return apiSuccess(freshPackage()); },
+      async getV2(endpoint) {
+        return endpoint.includes("/policies/policy-a/")
+          ? apiSuccess({ slug_perm: "policy-a", description: "Blocks unsafe dependencies." })
+          : emptyDecisionPage();
+      },
+    }, {
+      information: async value => { effects.information.push(value); },
+      warning: async value => { effects.warning.push(value); },
+    }, {
+      executeCommand: async (...args) => { effects.commands.push(args); },
+      openExternal: async value => { effects.external.push(value); },
+      writeClipboard: async value => { effects.clipboard.push(value); },
+    });
+    await provider.show(packageItem());
+
+    for (const command of ["findSafeVersion", "showVulnerabilities", "openInCloudsmith", "copyReport"]) {
+      await panelHarness.send({ command });
+    }
+    assert.deepStrictEqual(effects.commands.map(value => value[0]), [
+      "cloudsmith-vsc.findSafeVersion",
+      "cloudsmith-vsc.showVulnerabilities",
+    ]);
+    assert.strictEqual(effects.external.length, 1);
+    assert.match(effects.external[0], /^https:\/\/app\.cloudsmith\.com\//);
+    assert.strictEqual(effects.clipboard.length, 1);
+    assert.match(effects.clipboard[0], /^Quarantine report\n/);
+    assert.match(effects.clipboard[0], /Status: Quarantined/);
+    assert.doesNotMatch(effects.clipboard[0], /incomplete|decision log|policy-a/i);
+    assert.deepStrictEqual(effects.information, ["Quarantine report copied."]);
+
+    for (const message of [
+      null,
+      [],
+      Object.create({ command: "copyReport" }),
+      { command: "unknown" },
+      { command: "copyReport", extra: true },
+      { command: "openInCloudsmith", url: "https://evil.example" },
+    ]) await panelHarness.send(message);
+    assert.strictEqual(effects.clipboard.length, 1);
+    assert.strictEqual(effects.external.length, 1);
+  });
+
+  test("report normalizes controls and formula-leading dynamic lines", () => {
+    const provider = new QuarantineExplainProvider({});
+    const value = trace({
+      current: {
+        ...trace().current,
+        name: "=SUM(A1)\nStatus: Available",
+        statusReason: "Reason\r\nAction: Available",
+      },
+      parsedReason: null,
+    });
+    const report = provider._buildPlainTextReport(value);
+    assert.doesNotMatch(report, /\r/);
+    assert.doesNotMatch(report, /\nStatus: Available/);
+    assert.doesNotMatch(report, /\nAction: Available/);
+  });
+
+  test("account reset aborts stale loading before it can render", async () => {
+    let state = { activationId: "account-a", accountEpoch: 1, sessionConnected: true };
+    const panelHarness = createWebviewPanelHarness();
+    let resolveFetch;
+    let signal;
+    const gate = new Promise(resolve => { resolveFetch = resolve; });
+    const provider = providerWith(panelHarness, {
+      async get(_endpoint, options) {
+        signal = options.signal;
+        await gate;
+        return apiSuccess(freshPackage());
+      },
+      async getV2() { throw new Error("must not dispatch"); },
+    }, {}, { connectionManager: { getState() { return { ...state }; } } });
+    const pending = provider.show(packageItem());
+    await tick();
     state = { ...state, activationId: "account-b", accountEpoch: 2 };
     provider.resetForAccountChange();
     assert.strictEqual(signal.aborted, true);
@@ -93,113 +364,199 @@ suite("QuarantineExplainProvider policy completeness", () => {
     await pending;
     assert.strictEqual(panelHarness.htmlWrites.length, 1);
     assert.strictEqual(panelHarness.stats.panelDisposals, 1);
-    assert.strictEqual(panelHarness.stats.disposeDisposals, 1);
-    assert.strictEqual(panelHarness.activeDisposeListenerCount(), 0);
+    assert.strictEqual(panelHarness.activeMessageListenerCount(), 0);
   });
 
-  test("routes only exact own-data messages and cleans up stale listeners", async () => {
-    const panelHarness = createWebviewPanelHarness();
-    const effects = { commands: [], clipboard: [], external: [], information: [], warning: [] };
-    let requestSignal;
+  test("a superseding package selection blocks the older completion", async () => {
+    const harnesses = [createWebviewPanelHarness(), createWebviewPanelHarness()];
+    let panelIndex = 0;
+    let resolveFirst;
+    const firstGate = new Promise(resolve => { resolveFirst = resolve; });
     const provider = new QuarantineExplainProvider({}, {
+      cloudsmithAPI: {
+        async get(endpoint) {
+          if (endpoint.includes("package-a")) {
+            await firstGate;
+            return apiSuccess(freshPackage());
+          }
+          return apiSuccess(freshPackage({
+            slug_perm: "package-b",
+            name: "artifact-b",
+            status_reason: "Quarantined by Policy B. Rule B matched. (Policy: policy-b)",
+          }));
+        },
+        async getV2(endpoint) {
+          if (endpoint.includes("/policies/policy-b/")) {
+            return apiFailure("not_found", { status: 404 });
+          }
+          return emptyDecisionPage();
+        },
+      },
       connectionManager: connectedManager(),
-      createWebviewPanel: panelHarness.createWebviewPanel,
       createNonce: () => "fixed-nonce",
-      executeCommand: async (...args) => { effects.commands.push(args); },
-      writeClipboard: async value => { effects.clipboard.push(value); },
-      openExternal: async value => { effects.external.push(value); },
+      createWebviewPanel: (...args) => harnesses[panelIndex++].createWebviewPanel(...args),
+      notifications: { information: async () => {}, warning: async () => {} },
+    });
+    const first = provider.show(packageItem());
+    await tick();
+    const second = provider.show(packageItem({
+      name: "artifact-b",
+      slug_perm: "package-b",
+      slug_perm_raw: "package-b",
+      status_reason: "Quarantined by Policy B. Rule B matched. (Policy: policy-b)",
+    }));
+    await second;
+    resolveFirst();
+    await first;
+    assert.match(harnesses[1].panel.webview.html, /artifact-b/);
+    assert.match(harnesses[1].panel.webview.html, /Policy B/);
+    assert.doesNotMatch(harnesses[1].panel.webview.html, /Dependency policy/);
+  });
+
+  test("commands remain inert until current identity and status are confirmed", async () => {
+    const panelHarness = createWebviewPanelHarness();
+    const commands = [];
+    let resolveFetch;
+    const gate = new Promise(resolve => { resolveFetch = resolve; });
+    const provider = providerWith(panelHarness, {
+      async get() { await gate; return apiSuccess(freshPackage()); },
+      async getV2(endpoint) {
+        return endpoint.includes("/policies/policy-a/")
+          ? apiFailure("not_found", { status: 404 })
+          : emptyDecisionPage();
+      },
+    }, {}, { executeCommand: async (...args) => { commands.push(args); } });
+    const pending = provider.show(packageItem());
+    await tick();
+    await panelHarness.send({ command: "findSafeVersion" });
+    assert.deepStrictEqual(commands, []);
+    resolveFetch();
+    await pending;
+    await panelHarness.send({ command: "findSafeVersion" });
+    assert.strictEqual(commands.length, 1);
+  });
+
+  function providerWith(panelHarness, cloudsmithAPI, notifications = {}, overrides = {}) {
+    return new QuarantineExplainProvider({}, {
+      cloudsmithAPI,
+      connectionManager: connectedManager(),
+      createNonce: () => "fixed-nonce",
+      createWebviewPanel: panelHarness.createWebviewPanel,
       notifications: {
-        information: async value => { effects.information.push(value); },
-        warning: async value => { effects.warning.push(value); },
+        information: notifications.information || (async () => {}),
+        warning: notifications.warning || (async () => {}),
+      },
+      ...overrides,
+    });
+  }
+
+  function freshPackage(overrides = {}) {
+    return {
+      namespace: "workspace-a",
+      repository: "repo-a",
+      slug_perm: "package-a",
+      name: "artifact",
+      version: "1.0.0",
+      format: "npm",
+      status_str: "Quarantined",
+      status_reason: "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)",
+      uploaded_at: "2026-08-13T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  function emptyDecisionPage() {
+    return apiSuccess({ results: [] }, {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "100",
+        "x-pagination-count": "0",
       },
     });
-    provider._fetchPolicyDecisionTrace = async (_api, _workspace, _slug, _reason, signal) => {
-      requestSignal = signal;
-      return {
-        parsedReason: null,
-        decisionLogs: [{ policy_name: "Policy", reason: "CVE-2026-5001" }],
-        decisionLogsComplete: true,
-        decisionLogsPartial: false,
-        policyDetail: null,
-      };
+  }
+
+  function decisionPage(results) {
+    return apiSuccess({ results }, {
+      headers: {
+        "x-pagination-page": "1",
+        "x-pagination-pagetotal": "1",
+        "x-pagination-pagesize": "100",
+        "x-pagination-count": String(results.length),
+      },
+    });
+  }
+
+  function decisionSummary() {
+    return {
+      id: "00000000000000000000000001",
+      actions: { action_type: "SetPackageState", package_state: "QUARANTINED" },
+      correlation_id: "00000000-0000-4000-8000-000000000001",
+      ended_at: "2026-08-13T12:00:01.000Z",
+      match: true,
+      package_format: "NPM",
+      package_name: "artifact",
+      package_slug: "artifact",
+      package_slug_perm: "package-a",
+      package_version: "1.0.0",
+      policy_is_terminal: true,
+      policy_name: "Quarantine policy",
+      policy_precedence: 1,
+      policy_slug_perm: "policy-a",
+      policy_version: 1,
+      repository_name: "Repository A",
+      repository_slug: "repo-a",
+      repository_slug_perm: "repo-perm-a",
+      started_at: "2026-08-13T12:00:00.000Z",
     };
+  }
 
-    await provider.show(packageItem());
-
-    assert.deepStrictEqual(panelHarness.panelCalls[0][3], {
-      enableScripts: true,
-      localResourceRoots: [],
-    });
-    assert.match(panelHarness.panel.webview.html, /nonce="fixed-nonce"/);
-    await panelHarness.send({ command: "findSafeVersion" });
-    await panelHarness.send({ command: "showVulnerabilities" });
-    await panelHarness.send({ command: "openInCloudsmith" });
-    await panelHarness.send({ command: "copyReport" });
-    assert.deepStrictEqual(effects.commands.map(call => call[0]), [
-      "cloudsmith-vsc.findSafeVersion",
-      "cloudsmith-vsc.showVulnerabilities",
-    ]);
-    assert.strictEqual(effects.clipboard.length, 1);
-    assert.deepStrictEqual(effects.information, ["Quarantine report copied."]);
-    assert.strictEqual(effects.external.length, 1);
-    assert.match(effects.external[0], /^https:\/\/app\.cloudsmith\.com\//);
-
-    let accessorReads = 0;
-    const accessorMessage = {};
-    Object.defineProperty(accessorMessage, "command", {
-      enumerable: true,
-      get() { accessorReads += 1; return "copyReport"; },
-    });
-    for (const message of [
-      null,
-      [],
-      accessorMessage,
-      Object.create({ command: "copyReport" }),
-      { command: "unknown" },
-      { command: "copyReport", extra: "unexpected" },
-      { command: "openInCloudsmith", url: "https://evil.example/" },
-      { command: "x".repeat(65) },
-    ]) {
-      await panelHarness.send(message);
-    }
-    assert.strictEqual(accessorReads, 0);
-    assert.strictEqual(effects.commands.length, 2);
-    assert.strictEqual(effects.clipboard.length, 1);
-    assert.strictEqual(effects.external.length, 1);
-    assert.deepStrictEqual(effects.warning, []);
-
-    provider.dispose();
-    provider.dispose();
-    assert.strictEqual(requestSignal.aborted, true);
-    assert.strictEqual(panelHarness.stats.panelDisposals, 1);
-    assert.strictEqual(panelHarness.stats.messageDisposals, 1);
-    assert.strictEqual(panelHarness.stats.disposeDisposals, 1);
-    assert.strictEqual(panelHarness.activeMessageListenerCount(), 0);
-    assert.strictEqual(panelHarness.activeDisposeListenerCount(), 0);
-    await panelHarness.sendToStaleListener({ command: "copyReport" });
-    assert.strictEqual(effects.clipboard.length, 1);
-  });
+  function decisionDetail() {
+    return {
+      id: "00000000000000000000000001",
+      correlation_id: "00000000-0000-4000-8000-000000000001",
+      policy: { slug_perm: "policy-a" },
+      started_at: "2026-08-13T12:00:00.000Z",
+      ended_at: "2026-08-13T12:00:01.000Z",
+      policy_input: {
+        v0: {
+          workspace: { slug: "workspace-a", slug_perm: "workspace-perm-a" },
+          repository: { slug: "repo-a", slug_perm: "repo-perm-a" },
+          package: { slug: "artifact", slug_perm: "package-a" },
+        },
+      },
+      policy_output: { reason: "Dependency rule matched." },
+      parsed_actions: [{ action_type: "SetPackageState", package_state: "QUARANTINED" }],
+    };
+  }
 });
 
 function connectedManager() {
   return {
     getState() {
-      return {
-        activationId: "account-a",
-        accountEpoch: 1,
-        sessionConnected: true,
-      };
+      return { activationId: "account-a", accountEpoch: 1, sessionConnected: true };
     },
   };
 }
 
-function packageItem() {
+function packageItem(overrides = {}) {
   return {
     namespace: "workspace-a",
+    cloudsmithWorkspace: "workspace-a",
     repository: "repo-a",
+    cloudsmithRepo: "repo-a",
     name: "artifact",
     format: "npm",
+    slug_perm: "package-a",
     slug_perm_raw: "package-a",
     version: "1.0.0",
+    status_str_raw: "Quarantined",
+    status_reason: "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)",
+    uploaded_at: "2026-08-13T10:00:00.000Z",
+    ...overrides,
   };
+}
+
+function tick() {
+  return new Promise(resolve => setImmediate(resolve));
 }

--- a/test/quarantineExplainProvider.test.js
+++ b/test/quarantineExplainProvider.test.js
@@ -1,4 +1,7 @@
 const assert = require("assert");
+const DependencyHealthNode = require("../models/dependencyHealthNode");
+const PackageNode = require("../models/packageNode");
+const SearchResultNode = require("../models/searchResultNode");
 const { QuarantineExplainProvider } = require("../views/quarantineExplainProvider");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 const { createWebviewPanelHarness } = require("./helpers/webviewPanelHarness");
@@ -250,6 +253,60 @@ suite("QuarantineExplainProvider", () => {
     assert.strictEqual(calls, 0);
     assert.strictEqual(panelHarness.panelCalls.length, 0);
     assert.strictEqual(warnings.length, 2);
+  });
+
+  test("production entry normalizes package, search, dependency, and legacy callers", async () => {
+    const payload = nodePackagePayload();
+    const nodeCases = [
+      new PackageNode(payload, {}),
+      new SearchResultNode(payload, {}),
+      new DependencyHealthNode({
+        name: payload.name,
+        version: payload.version,
+        format: payload.format,
+        devDependency: false,
+      }, payload, {}),
+      packageItem({
+        slug_perm_raw: null,
+        slug_perm: { value: { value: "package-a" } },
+        status_str_raw: null,
+        status_str: { value: { value: "Quarantined" } },
+        uploaded_at: { value: { value: payload.uploaded_at } },
+        version: { value: { value: payload.version } },
+      }),
+    ];
+
+    for (const item of nodeCases) {
+      const panelHarness = createWebviewPanelHarness();
+      const packageEndpoints = [];
+      let resolveCurrent;
+      const currentPackage = new Promise(resolve => { resolveCurrent = resolve; });
+      const provider = providerWith(panelHarness, {
+        async get(endpoint) {
+          packageEndpoints.push(endpoint);
+          return currentPackage;
+        },
+        async getV2(endpoint) {
+          return endpoint.includes("/policies/policy-a/")
+            ? apiFailure("not_found", { status: 404 })
+            : emptyDecisionPage();
+        },
+      });
+
+      const pending = provider.show(item);
+
+      assert.strictEqual(panelHarness.panelCalls.length, 1);
+      assert.match(packageEndpoints[0], /^packages\/workspace-a\/repo-a\/package-a\//);
+      assert.match(panelHarness.panel.webview.html, /<h1>artifact 1\.0\.0<\/h1>/);
+      assert.match(panelHarness.panel.webview.html, /Dependency rule matched/);
+      assert.match(panelHarness.panel.webview.html, /Refreshing current package status/);
+
+      resolveCurrent(apiSuccess(freshPackage()));
+      await pending;
+      assert.match(panelHarness.panel.webview.html, /<h1>artifact 1\.0\.0<\/h1>/);
+      assert.match(panelHarness.panel.webview.html, /Dependency rule matched/);
+      assert.doesNotMatch(panelHarness.panel.webview.html, /Refreshing current package status/);
+    }
   });
 
   test("fresh identity drift fails closed and never enables commands", async () => {
@@ -554,6 +611,23 @@ function packageItem(overrides = {}) {
     status_reason: "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)",
     uploaded_at: "2026-08-13T10:00:00.000Z",
     ...overrides,
+  };
+}
+
+function nodePackagePayload() {
+  return {
+    downloads: 0,
+    format: "npm",
+    name: "artifact",
+    namespace: "workspace-a",
+    repository: "repo-a",
+    slug: "artifact-1.0.0",
+    slug_perm: "package-a",
+    status_reason: "Quarantined by Dependency policy. Dependency rule matched. (Policy: policy-a)",
+    status_str: "Quarantined",
+    tags: {},
+    uploaded_at: "2026-08-13T10:00:00.000Z",
+    version: "1.0.0",
   };
 }
 

--- a/test/recentPackages.test.js
+++ b/test/recentPackages.test.js
@@ -30,6 +30,8 @@ suite("RecentPackages Test Suite", () => {
       version: { id: "Version", value: "1.25" },
       namespace: "workspace-a",
       repository: "containers",
+      slug_perm: "package-nginx",
+      slug_perm_raw: "package-nginx",
       checksum_sha256: "abc123",
       version_digest: "digest123",
       cdn_url: "https://cdn.example.com/nginx.tar",
@@ -65,6 +67,7 @@ suite("RecentPackages Test Suite", () => {
       version: "1.0.0",
       namespace: "workspace-a",
       repository: "downloads",
+      slug_perm: "package-shared",
     });
     recentPackages.add({
       name: "shared-lib",
@@ -72,6 +75,7 @@ suite("RecentPackages Test Suite", () => {
       version: "1.0.0",
       namespace: "workspace-b",
       repository: "downloads",
+      slug_perm: "package-shared",
     });
 
     const all = recentPackages.getAll();
@@ -117,12 +121,7 @@ suite("RecentPackages Test Suite", () => {
       is_copyable: "false",
     });
 
-    const [stored] = recentPackages.getAll();
-    assert.strictEqual(stored.namespace, null);
-    assert.strictEqual(stored.cloudsmithWorkspace, null);
-    assert.strictEqual(stored.slug_perm, null);
-    assert.strictEqual(stored.slug_perm_raw, null);
-    assert.strictEqual(stored.is_copyable, null);
+    assert.deepStrictEqual(recentPackages.getAll(), []);
   });
 
   test("repository and workspace alias inversions share one recent-package identity", () => {
@@ -209,35 +208,40 @@ suite("RecentPackages Test Suite", () => {
       recentPackages.add(identityPackage(overrides));
 
       const all = recentPackages.getAll();
-      assert.strictEqual(all.length, 2);
+      assert.strictEqual(all.length, 1);
       assert.strictEqual(all.filter(pkg => (
         pkg.namespace === "workspace" && pkg.repository === "source"
-      )).length, 1);
-      assert.strictEqual(all.filter(pkg => (
-        pkg.namespace === null || pkg.repository === null
       )).length, 1);
     }
   });
 
   test("structured recent identities cannot collide through delimiters", () => {
-    recentPackages.add(identityPackage({ name: "artifact:1", version: "2" }));
-    recentPackages.add(identityPackage({ name: "artifact", version: "1:2" }));
+    recentPackages.add(identityPackage({ name: "artifact:1", version: "2", slug_perm: "package:1", slug_perm_raw: "package:1" }));
+    recentPackages.add(identityPackage({ name: "artifact", version: "1:2", slug_perm: "package", slug_perm_raw: "package" }));
 
     assert.strictEqual(recentPackages.getAll().length, 2);
   });
 
-  test("distinct workspace, repository, package, and version coordinates remain distinct", () => {
+  test("exact workspace, repository, and package identifiers remain distinct", () => {
     for (const record of [
       identityPackage(),
       identityPackage({ cloudsmithWorkspace: "other-workspace", namespace: "other-workspace" }),
       identityPackage({ cloudsmithRepo: "other-source", repository: "other-source" }),
-      identityPackage({ name: "other-artifact" }),
-      identityPackage({ version: "2.0.0" }),
+      identityPackage({ slug_perm: "other-package", slug_perm_raw: "other-package" }),
     ]) {
       recentPackages.add(record);
     }
 
-    assert.strictEqual(recentPackages.getAll().length, 5);
+    assert.strictEqual(recentPackages.getAll().length, 4);
+  });
+
+  test("same package identity updates display metadata without creating a duplicate", () => {
+    recentPackages.add(identityPackage({ name: "old-name", version: "1.0.0" }));
+    recentPackages.add(identityPackage({ name: "new-name", version: "2.0.0" }));
+    const [stored] = recentPackages.getAll();
+    assert.strictEqual(recentPackages.getAll().length, 1);
+    assert.strictEqual(stored.name, "new-name");
+    assert.strictEqual(stored.version, "2.0.0");
   });
 
   test("malformed identities cannot remove valid entries or collapse into false equality", () => {
@@ -253,9 +257,8 @@ suite("RecentPackages Test Suite", () => {
     }));
 
     const all = recentPackages.getAll();
-    assert.strictEqual(all.length, 3);
+    assert.strictEqual(all.length, 1);
     assert.strictEqual(all.filter(pkg => pkg.repository === "source").length, 1);
-    assert.strictEqual(all.filter(pkg => pkg.repository === null).length, 2);
   });
 
   test("re-adding a valid identity collapses every historical duplicate and moves it first", () => {
@@ -276,5 +279,17 @@ suite("RecentPackages Test Suite", () => {
     const all = recentPackages.getAll();
     assert.deepStrictEqual(all.map(pkg => pkg.name), ["artifact", "first"]);
     assert.strictEqual(all[0].repository, "source");
+  });
+
+  test("preserves the current quarantine reason and upload boundary", () => {
+    recentPackages.add(identityPackage({
+      status_str_raw: "Quarantined",
+      status_reason: "Quarantined by Policy. Rule matched. (Policy: policy-a)",
+      uploaded_at: { value: "2026-08-13T10:00:00.000Z" },
+    }));
+    const [stored] = recentPackages.getAll();
+    assert.strictEqual(stored.status_str, "Quarantined");
+    assert.strictEqual(stored.status_reason, "Quarantined by Policy. Rule matched. (Policy: policy-a)");
+    assert.strictEqual(stored.uploaded_at, "2026-08-13T10:00:00.000Z");
   });
 });

--- a/test/testInventories.js
+++ b/test/testInventories.js
@@ -83,6 +83,7 @@ const VSCODE_SMOKE_TESTS = Object.freeze([
 ]);
 
 const LIVE_TESTS = Object.freeze([
+  "test/integration/policyDecisionLogs.test.js",
   "test/integration/search.test.js",
   "test/integration/upstreams.test.js",
   "test/integration/vulnerabilities.test.js",

--- a/util/policyDecisionLogs.js
+++ b/util/policyDecisionLogs.js
@@ -382,15 +382,9 @@ function failedCollection(message) {
 }
 
 module.exports = {
-  MAX_POLICY_DECISION_LOG_ITEMS,
-  MAX_POLICY_DECISION_LOG_PAGES,
-  MAX_POLICY_STATUS_REASON_LENGTH,
-  POLICY_DECISION_LOG_PAGE_SIZE,
   createQuarantineLocator,
   fetchDecisionLogDetail,
   fetchPackageDecisionLogs,
-  hasQuarantineAction,
-  isDecisionLogResponse,
   normalizePolicyStatusReason,
   parsePolicyStatusReason,
   selectCausalDecision,

--- a/util/policyDecisionLogs.js
+++ b/util/policyDecisionLogs.js
@@ -1,33 +1,84 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 
-const { apiEndpoint } = require("./apiEndpoint");
+const { apiEndpoint, encodeApiPathSegment } = require("./apiEndpoint");
 const {
   PaginatedFetch,
   collectionFailureResult,
   replaceCollectionItems,
 } = require("./paginatedFetch");
-const {
-  MAX_COLLECTION_IDENTITY_PART_LENGTH,
-  exactIdentityPart,
-} = require("./collectionIdentity");
+const { exactIdentityPart } = require("./collectionIdentity");
 
 const POLICY_DECISION_LOG_PAGE_SIZE = 100;
 const MAX_POLICY_DECISION_LOG_PAGES = 20;
 const MAX_POLICY_DECISION_LOG_ITEMS = POLICY_DECISION_LOG_PAGE_SIZE * MAX_POLICY_DECISION_LOG_PAGES;
-const MAX_POLICY_PACKAGE_ID_LENGTH = MAX_COLLECTION_IDENTITY_PART_LENGTH;
 const MAX_POLICY_STATUS_REASON_LENGTH = 4096;
-const MAX_POLICY_LOG_DISPLAY_LENGTH = 4096;
-const MAX_POLICY_ACTIONS = 50;
+const MAX_DISPLAY_LENGTH = 4096;
+const MAX_PATH_IDENTITY_LENGTH = 512;
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CONTROL_PATTERN = /[\u0000-\u001f\u007f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
+const DISPLAY_CONTROL_PATTERN = /[\u0000-\u001f\u007f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/g;
+const ENCODED_SEPARATOR_PATTERN = /%(?:2f|5c)/i;
 
-async function fetchPackageDecisionLogs(api, workspace, packageIdentifier, options = {}) {
-  const normalizedPackageIdentifier = boundedString(packageIdentifier, MAX_POLICY_PACKAGE_ID_LENGTH);
-  if (!api || typeof api.getV2 !== "function" || !normalizedPackageIdentifier) {
+function createQuarantineLocator(item) {
+  if (!isObjectRecord(item)) return null;
+  const nestedMatch = ownData(item, "cloudsmithMatch");
+  const match = isObjectRecord(nestedMatch) ? nestedMatch : {};
+  const workspace = canonicalAliases([
+    ownData(item, "namespace"),
+    ownData(item, "cloudsmithWorkspace"),
+    ownData(match, "namespace"),
+    ownData(match, "cloudsmithWorkspace"),
+  ]);
+  const repository = canonicalAliases([
+    ownData(item, "repository"),
+    ownData(item, "cloudsmithRepo"),
+    ownData(match, "repository"),
+    ownData(match, "cloudsmithRepo"),
+  ]);
+  const packageSlugPerm = canonicalAliases([
+    ownData(item, "slug_perm_raw"),
+    ownData(item, "slug_perm"),
+    ownData(match, "slug_perm_raw"),
+    ownData(match, "slug_perm"),
+  ]);
+  if (!workspace || !repository || !packageSlugPerm) return null;
+  return Object.freeze({ workspace, repository, packageSlugPerm });
+}
+
+async function fetchPackageDecisionLogs(api, locator, createdAfter, options = {}) {
+  if (!api || typeof api.getV2 !== "function" || !isLocator(locator)) {
     return failedCollection("The policy decision log identity was invalid.");
+  }
+  const createdAfterValue = canonicalDateTime(createdAfter);
+  if (!createdAfterValue) {
+    return failedCollection("The policy decision log time boundary was invalid.");
   }
 
   let endpoint;
   try {
-    endpoint = apiEndpoint(["workspaces", workspace, "policies", "decision", "logs"]);
+    const query = {
+      created_after: createdAfterValue,
+      package_slug_perm: locator.packageSlugPerm,
+      match: true,
+      sort: "-id",
+    };
+    const policySlug = pathIdentity(options.policySlug);
+    const repositorySlugPerm = pathIdentity(options.repositorySlugPerm);
+    if (options.policySlug != null && !policySlug) {
+      return failedCollection("The policy decision log policy identity was invalid.");
+    }
+    if (options.repositorySlugPerm != null && !repositorySlugPerm) {
+      return failedCollection("The policy decision log repository identity was invalid.");
+    }
+    if (policySlug) query.policy_slug_perm = policySlug;
+    if (repositorySlugPerm) query.repository_slug_perm = repositorySlugPerm;
+    endpoint = apiEndpoint([
+      "workspaces",
+      locator.workspace,
+      "policies",
+      "decision-logs-v1",
+    ], { query });
   } catch {
     return failedCollection("The policy decision log endpoint was invalid.");
   }
@@ -41,7 +92,7 @@ async function fetchPackageDecisionLogs(api, workspace, packageIdentifier, optio
     maxRequests: MAX_POLICY_DECISION_LOG_PAGES,
     maxItems: MAX_POLICY_DECISION_LOG_ITEMS,
     canonicalIdentity: decisionLogIdentity,
-    descriptor: `policy-decision-logs:${workspace}`,
+    descriptor: "policy-decision-logs",
     responseType: "json",
     validateResponse: isDecisionLogResponse,
     extractItems: extractDecisionLogs,
@@ -50,41 +101,95 @@ async function fetchPackageDecisionLogs(api, workspace, packageIdentifier, optio
     cancellationToken: options.cancellationToken,
   });
 
-  return replaceCollectionItems(
-    collection,
-    collection.items.filter(entry => (
-      decisionLogMatchesPackage(entry, normalizedPackageIdentifier)
-    )).map(normalizeDecisionLog)
-  );
+  return replaceCollectionItems(collection, collection.items.map(normalizeDecisionLog));
+}
+
+async function fetchDecisionLogDetail(api, locator, summary, options = {}) {
+  if (
+    !api
+    || typeof api.getV2 !== "function"
+    || !isLocator(locator)
+    || !summary
+    || !ULID_PATTERN.test(summary.id || "")
+  ) {
+    return null;
+  }
+  let endpoint;
+  try {
+    endpoint = apiEndpoint([
+      "workspaces",
+      locator.workspace,
+      "policies",
+      "decision-logs-v1",
+      summary.id,
+    ], {
+      query: {
+        fields: "id,correlation_id,policy,started_at,ended_at,policy_input,policy_output,parsed_actions",
+      },
+    });
+  } catch {
+    return null;
+  }
+  try {
+    const result = await api.getV2(endpoint, {
+      responseType: "object",
+      validate: value => isDecisionLogDetail(value, locator, summary),
+      retry: "never",
+      signal: options.signal,
+    });
+    if (!result.ok) return null;
+    return normalizeDecisionLogDetail(result.data, summary);
+  } catch {
+    return null;
+  }
+}
+
+function selectCausalDecision(items, policySlug = null) {
+  const exactPolicySlug = policySlug == null ? null : pathIdentity(policySlug);
+  if (policySlug != null && !exactPolicySlug) return null;
+  const candidates = (Array.isArray(items) ? items : []).filter(entry => (
+    entry
+    && entry.match === true
+    && entry.action === "Quarantined"
+    && (!exactPolicySlug || entry.policySlugPerm === exactPolicySlug)
+  ));
+  candidates.sort((left, right) => (left.id === right.id ? 0 : left.id < right.id ? 1 : -1));
+  return candidates[0] || null;
 }
 
 function normalizeDecisionLog(entry) {
-  const normalized = {
-    slug_perm: decisionLogIdentity(entry),
-    package_slug_perm: decisionLogPackageReference(entry),
-    policy_name: displayString(
-      entry.policy_name || entry.name || (entry.policy && entry.policy.name),
-      512
-    ),
-    matched: typeof entry.matched === "boolean" ? entry.matched : null,
-    action: normalizeActions(entry.action, entry.actions_taken),
-    reason: displayString(entry.reason, MAX_POLICY_LOG_DISPLAY_LENGTH),
-    created_at: displayString(entry.created_at, 128),
-  };
-  return Object.freeze(normalized);
+  return Object.freeze({
+    id: entry.id,
+    correlationId: entry.correlation_id,
+    packageSlugPerm: entry.package_slug_perm,
+    repositorySlug: entry.repository_slug,
+    repositorySlugPerm: entry.repository_slug_perm,
+    policySlugPerm: entry.policy_slug_perm,
+    policyName: displayString(entry.policy_name, 512),
+    policyPrecedence: entry.policy_precedence,
+    policyIsTerminal: entry.policy_is_terminal,
+    match: entry.match,
+    action: hasQuarantineAction(entry.actions) ? "Quarantined" : null,
+    startedAt: entry.started_at,
+    endedAt: entry.ended_at,
+  });
 }
 
-function normalizeActions(action, actionsTaken) {
-  const direct = displayString(action, MAX_POLICY_LOG_DISPLAY_LENGTH);
-  if (direct) return direct;
-  if (!Array.isArray(actionsTaken)) return null;
-  const summaries = actionsTaken.slice(0, MAX_POLICY_ACTIONS).map(value => {
-    if (!isRecord(value)) return null;
-    const type = displayString(value.action_type, 256);
-    const state = displayString(value.package_state, 256);
-    return [type, state].filter(Boolean).join(": ") || null;
-  }).filter(Boolean);
-  return summaries.length > 0 ? summaries.join("; ") : null;
+function normalizeDecisionLogDetail(entry, summary) {
+  if (!hasQuarantineAction(entry.parsed_actions)) return null;
+  const policyOutput = isRecord(entry.policy_output) ? entry.policy_output : null;
+  const reason = policyOutput
+    ? displayString(policyOutput.reason || policyOutput.message || policyOutput.detail, MAX_DISPLAY_LENGTH)
+    : displayString(entry.policy_output, MAX_DISPLAY_LENGTH);
+  return Object.freeze({
+    id: summary.id,
+    policySlugPerm: summary.policySlugPerm,
+    policyName: summary.policyName,
+    action: "Quarantined",
+    reason,
+    startedAt: summary.startedAt,
+    endedAt: summary.endedAt,
+  });
 }
 
 function normalizePolicyStatusReason(value) {
@@ -92,34 +197,18 @@ function normalizePolicyStatusReason(value) {
   const bounded = value.length <= MAX_POLICY_STATUS_REASON_LENGTH
     ? value
     : `${value.slice(0, MAX_POLICY_STATUS_REASON_LENGTH - 1)}…`;
-  const normalized = bounded.trim();
-  if (!normalized) return null;
-  return normalized;
+  return bounded.replace(DISPLAY_CONTROL_PATTERN, " ").trim() || null;
 }
 
 function parsePolicyStatusReason(value) {
   const normalized = normalizePolicyStatusReason(value);
   if (!normalized) return null;
-
   const match = /^Quarantined by ([^.]+)\.\s*(.*?)(?:\s*\(Policy:\s*([^()]+)\))?$/.exec(normalized);
-  if (!match) return { raw: normalized };
-  return {
-    policyName: match[1].trim(),
-    description: match[2].trim(),
-    policySlug: match[3] ? match[3].trim() : null,
-  };
-}
-
-function decisionLogIdentity(entry) {
-  try {
-    return exactIdentityPart(entry && entry.slug_perm, "policy decision log");
-  } catch {
-    return null;
-  }
-}
-
-function decisionLogMatchesPackage(entry, packageIdentifier) {
-  return decisionLogPackageReference(entry) === packageIdentifier;
+  if (!match) return Object.freeze({ raw: normalized });
+  const policyName = displayString(match[1], 512);
+  const description = displayString(match[2], MAX_POLICY_STATUS_REASON_LENGTH);
+  const policySlug = match[3] ? pathIdentity(match[3].trim()) : null;
+  return Object.freeze({ policyName, description, policySlug, raw: normalized });
 }
 
 function isDecisionLogResponse(value) {
@@ -127,62 +216,155 @@ function isDecisionLogResponse(value) {
   return items !== null && items.every(isDecisionLogRecord);
 }
 
-function extractDecisionLogs(value) {
-  if (Array.isArray(value)) return value;
-  if (!isRecord(value) || !Array.isArray(value.results)) return null;
-  return value.results;
-}
-
 function isDecisionLogRecord(value) {
   return isRecord(value)
-    && Boolean(decisionLogIdentity(value))
-    && Boolean(decisionLogPackageReference(value))
-    && (
-      !Object.prototype.hasOwnProperty.call(value, "matched")
-      || typeof value.matched === "boolean"
-    );
+    && ULID_PATTERN.test(value.id || "")
+    && UUID_PATTERN.test(value.correlation_id || "")
+    && typeof value.match === "boolean"
+    && Boolean(pathIdentity(value.package_slug_perm))
+    && Boolean(pathIdentity(value.repository_slug))
+    && Boolean(pathIdentity(value.repository_slug_perm))
+    && Boolean(pathIdentity(value.policy_slug_perm))
+    && Boolean(displayString(value.policy_name, 512))
+    && Number.isInteger(value.policy_precedence)
+    && typeof value.policy_is_terminal === "boolean"
+    && Boolean(canonicalDateTime(value.started_at))
+    && Boolean(canonicalDateTime(value.ended_at))
+    && isRecord(value.actions);
 }
 
-function decisionLogPackageReference(entry) {
-  if (!isRecord(entry)) return null;
-  const aliases = [];
-
-  if (Object.prototype.hasOwnProperty.call(entry, "package_slug_perm")) {
-    aliases.push(entry.package_slug_perm);
+function isDecisionLogDetail(value, locator, summary) {
+  if (!isRecord(value) || value.id !== summary.id || value.correlation_id !== summary.correlationId) {
+    return false;
   }
+  if (!isRecord(value.policy) || value.policy.slug_perm !== summary.policySlugPerm) return false;
+  if (!isRecord(value.policy_input) || !isRecord(value.policy_input.v0)) return false;
+  const input = value.policy_input.v0;
+  const workspace = input.workspace;
+  const repository = input.repository;
+  const pkg = input.package;
+  if (!isRecord(workspace) || !isRecord(repository) || !isRecord(pkg)) return false;
+  if (workspace.slug !== locator.workspace) return false;
+  if (repository.slug !== locator.repository || pkg.slug_perm !== locator.packageSlugPerm) return false;
+  return canonicalDateTime(value.started_at) === summary.startedAt
+    && canonicalDateTime(value.ended_at) === summary.endedAt
+    && Object.prototype.hasOwnProperty.call(value, "policy_output")
+    && Object.prototype.hasOwnProperty.call(value, "parsed_actions");
+}
+
+function hasQuarantineAction(value) {
+  if (Array.isArray(value)) {
+    return value.length <= 50 && value.some(entry => exactQuarantineAction(entry));
+  }
+  return exactQuarantineAction(value);
+}
+
+function exactQuarantineAction(value) {
+  if (!isRecord(value)) return false;
   if (
-    isRecord(entry.package)
-    && Object.prototype.hasOwnProperty.call(entry.package, "identifier")
-  ) {
-    aliases.push(entry.package.identifier);
-  }
-  if (aliases.length === 0) return null;
+    ownData(value, "action_type") === "SetPackageState"
+    && ownData(value, "package_state") === "QUARANTINED"
+  ) return true;
+  const named = ownData(value, "SetPackageState");
+  return isRecord(named) && ownData(named, "package_state") === "QUARANTINED";
+}
 
+function decisionLogIdentity(entry) {
+  return entry && ULID_PATTERN.test(entry.id || "") ? entry.id : null;
+}
+
+function extractDecisionLogs(value) {
+  return isRecord(value) && Array.isArray(value.results) ? value.results : null;
+}
+
+function canonicalAliases(values) {
+  const supplied = values.filter(value => value !== undefined && value !== null);
+  if (supplied.length === 0) return null;
+  const normalized = supplied.map(value => pathIdentity(unwrapOwnValue(value)));
+  return normalized.every(value => value && value === normalized[0]) ? normalized[0] : null;
+}
+
+function isLocator(locator) {
+  return isRecord(locator)
+    && pathIdentity(locator.workspace) === locator.workspace
+    && pathIdentity(locator.repository) === locator.repository
+    && pathIdentity(locator.packageSlugPerm) === locator.packageSlugPerm;
+}
+
+function pathIdentity(value) {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > MAX_PATH_IDENTITY_LENGTH
+    || value.trim() !== value
+    || CONTROL_PATTERN.test(value)
+    || value.includes("/")
+    || value.includes("\\")
+    || ENCODED_SEPARATOR_PATTERN.test(value)
+    || value === "."
+    || value === ".."
+  ) return null;
   try {
-    const normalized = aliases.map(value => exactIdentityPart(value, "policy package"));
-    return new Set(normalized).size === 1 ? normalized[0] : null;
+    encodeApiPathSegment(value);
+    exactIdentityPart(value, "policy trace");
+    return value;
   } catch {
     return null;
   }
 }
 
-function isRecord(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function boundedString(value, maxLength) {
-  return typeof value === "string"
-    && value.length > 0
-    && value.length <= maxLength
-    && value.trim() === value
-    ? value
-    : null;
+function canonicalDateTime(value) {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > 128
+    || value.trim() !== value
+    || CONTROL_PATTERN.test(value)
+    || !/^\d{4}-\d{2}-\d{2}T/.test(value)
+    || !Number.isFinite(Date.parse(value))
+  ) return null;
+  return value;
 }
 
 function displayString(value, maxLength) {
   if (typeof value !== "string") return null;
-  const bounded = value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
-  return bounded.trim() || null;
+  const normalized = value.replace(DISPLAY_CONTROL_PATTERN, " ").trim();
+  if (!normalized) return null;
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function isRecord(value) {
+  return Boolean(value)
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function ownData(value, key) {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && Object.prototype.hasOwnProperty.call(descriptor, "value")
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function unwrapOwnValue(value) {
+  let current = value;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (!isRecord(current)) return current;
+    const descriptor = Object.getOwnPropertyDescriptor(current, "value");
+    if (!descriptor) return null;
+    if (!Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+    current = descriptor.value;
+  }
+  return isRecord(current) ? null : current;
 }
 
 function failedCollection(message) {
@@ -204,9 +386,12 @@ module.exports = {
   MAX_POLICY_DECISION_LOG_PAGES,
   MAX_POLICY_STATUS_REASON_LENGTH,
   POLICY_DECISION_LOG_PAGE_SIZE,
-  decisionLogMatchesPackage,
+  createQuarantineLocator,
+  fetchDecisionLogDetail,
   fetchPackageDecisionLogs,
+  hasQuarantineAction,
   isDecisionLogResponse,
   normalizePolicyStatusReason,
   parsePolicyStatusReason,
+  selectCausalDecision,
 };

--- a/util/recentPackages.js
+++ b/util/recentPackages.js
@@ -107,22 +107,23 @@ function recentPackageIdentity(normalized) {
     || normalized.name.length === 0
     || typeof normalized.workspace !== "string"
     || typeof normalized.repository !== "string"
+    || typeof normalized.packageIdentifier !== "string"
+    || normalized.packageIdentifier.length === 0
     || !normalized.versionValid
   ) {
     return null;
   }
   return JSON.stringify([
     normalized.workspace,
-    normalized.name,
-    normalized.version,
     normalized.repository,
+    normalized.packageIdentifier,
   ]);
 }
 
 /**
  * Add a package to the recent list.
  * Workspace and repository may use their current or compatibility aliases. Only
- * records with a canonical workspace/repository/name/version tuple are deduplicated.
+ * records with a canonical workspace/repository/package identity are deduplicated.
  * @param {Object} pkg Must have a non-empty name and a supported version shape.
  */
 function add(pkg) {
@@ -132,11 +133,10 @@ function add(pkg) {
   const normalized = normalizeRecentPackage(pkg);
   if (!normalized.versionValid) return;
   const key = recentPackageIdentity(normalized);
-  if (key !== null) {
-    for (let index = _recent.length - 1; index >= 0; index -= 1) {
-      if (recentPackageIdentity(normalizeRecentPackage(_recent[index])) === key) {
-        _recent.splice(index, 1);
-      }
+  if (key === null) return;
+  for (let index = _recent.length - 1; index >= 0; index -= 1) {
+    if (recentPackageIdentity(normalizeRecentPackage(_recent[index])) === key) {
+      _recent.splice(index, 1);
     }
   }
   const rawTags = getRawTags(pkg);
@@ -164,6 +164,8 @@ function add(pkg) {
     cdn_url: getNestedField(pkg, "cdn_url") || null,
     filename: getNestedField(pkg, "filename") || null,
     status_str: unwrapValue(pkg.status_str) || pkg.status_str_raw || getNestedField(pkg, "status_str") || null,
+    status_reason: typeof pkg.status_reason === "string" ? pkg.status_reason : null,
+    uploaded_at: unwrapValue(pkg.uploaded_at) || getNestedField(pkg, "uploaded_at") || null,
     cloudsmithWorkspace: normalized.workspace,
     cloudsmithRepo: normalized.repository,
   });

--- a/views/quarantineExplainProvider.js
+++ b/views/quarantineExplainProvider.js
@@ -613,4 +613,4 @@ const QUARANTINE_MESSAGE_CONTRACTS = Object.freeze({
   showVulnerabilities: Object.freeze([]),
 });
 
-module.exports = { QuarantineExplainProvider, normalizeCurrentPackage };
+module.exports = { QuarantineExplainProvider };

--- a/views/quarantineExplainProvider.js
+++ b/views/quarantineExplainProvider.js
@@ -1,12 +1,12 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
 // Quarantine Explanation WebView panel provider.
-// Shows a focused explanation of why a package was quarantined,
-// including policy trace, decision logs, and remediation actions.
+// Shows a focused, current explanation of why a package was quarantined.
 
 const crypto = require("crypto");
 const vscode = require("vscode");
 const { CloudsmithAPI } = require("../util/cloudsmithAPI");
 const { apiEndpoint } = require("../util/apiEndpoint");
-const { formatApiError } = require("../util/errorFormatter");
 const { buildPackageUrl } = require("../util/webAppUrls");
 const { parseWebviewMessage } = require("../util/webviewMessage");
 const {
@@ -15,16 +15,25 @@ const {
   resolveConnectionManager,
 } = require("../util/accountOperation");
 const {
+  createQuarantineLocator,
+  fetchDecisionLogDetail,
   fetchPackageDecisionLogs,
   normalizePolicyStatusReason,
   parsePolicyStatusReason,
+  selectCausalDecision,
 } = require("../util/policyDecisionLogs");
+
+const MAX_DISPLAY_LENGTH = 4096;
+const STATUS_QUARANTINED = "Quarantined";
+const CURRENT_PACKAGE_MISSING = Object.freeze({ missing: true });
+const CONTROL_PATTERN = /[\u0000-\u001f\u007f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/g;
 
 class QuarantineExplainProvider {
   constructor(context, options = {}) {
     this.context = context;
     this._panel = null;
     this._operation = null;
+    this._operationVersion = 0;
     this._connectionManager = resolveConnectionManager(context, options.connectionManager);
     this._cloudsmithAPI = options.cloudsmithAPI || null;
     this._createWebviewPanel = options.createWebviewPanel || ((...args) => (
@@ -40,446 +49,419 @@ class QuarantineExplainProvider {
     this._createNonce = options.createNonce || (() => crypto.randomBytes(16).toString("hex"));
   }
 
-  /**
-   * Show the quarantine explanation panel for a package.
-   * @param {Object} item - PackageNode, SearchResultNode, or DependencyHealthNode
-   */
   async show(item) {
     if (!item) {
       this._notifications.warning("No package selected.");
       return;
     }
-
-    const workspace = item.namespace || item.cloudsmithWorkspace;
-    const repo = item.repository || item.cloudsmithRepo;
-    const name = item.name;
-    const format = item.format;
-
-    // Unwrap slug_perm
-    let slugPerm = item.slug_perm_raw;
-    if (!slugPerm) {
-      slugPerm = item.slug_perm;
-      if (slugPerm && typeof slugPerm === "object" && slugPerm.value) {
-        slugPerm = typeof slugPerm.value === "object" ? slugPerm.value.value : slugPerm.value;
-      }
+    let locator;
+    try {
+      locator = createQuarantineLocator(item);
+    } catch {
+      locator = null;
     }
-
-    // Unwrap version
-    let version = item.version;
-    if (version && typeof version === "object" && version.value) {
-      version = typeof version.value === "object" ? version.value.value : version.value;
-    }
-
-    const statusReason = normalizePolicyStatusReason(item.status_reason);
-    const packageUrl = buildPackageUrl(workspace, repo, format, name, version, slugPerm);
-
-    if (!workspace || !slugPerm) {
-      this._notifications.warning("Could not determine package details for quarantine explanation.");
+    if (!locator) {
+      this._notifications.warning("Could not open quarantine details. Select the package again and retry.");
       return;
     }
-
     const account = captureAccount(this._connectionManager);
     if (!account || !isAccountCurrent(this._connectionManager, account)) return;
 
-    // Create or reveal the WebView panel
     if (this._operation) this._disposeOperation(this._operation, true);
-
+    const caller = this._normalizeCallerPackage(item, locator);
     const panel = this._createWebviewPanel(
       "cloudsmithQuarantineExplain",
-      `Quarantine: ${name || ""} ${version || ""}`,
+      `Quarantine details: ${caller.name || "Package"}${caller.version ? ` ${caller.version}` : ""}`,
       vscode.ViewColumn.One,
       { enableScripts: true, localResourceRoots: [] }
     );
     this._panel = panel;
-    const requestController = new AbortController();
     const operation = {
       account,
-      controller: requestController,
-      panel,
-      messageSubscription: null,
-      disposeSubscription: null,
+      controller: new AbortController(),
       disposed: false,
+      disposeSubscription: null,
+      item,
+      locator,
+      messageSubscription: null,
+      nonce: this._getNonce(),
+      panel,
+      trace: this._initialTrace(caller, locator),
+      version: ++this._operationVersion,
     };
     this._operation = operation;
-    const nonce = this._getNonce();
+    operation.disposeSubscription = panel.onDidDispose(() => this._disposeOperation(operation, false));
+    operation.messageSubscription = panel.webview.onDidReceiveMessage(message => (
+      this._handleMessage(operation, message)
+    ));
 
-    operation.disposeSubscription = panel.onDidDispose(() => {
-      this._disposeOperation(operation, false);
+    this._render(operation);
+    await this._refreshOperation(operation, this._cloudsmithAPI || new CloudsmithAPI(this.context));
+  }
+
+  _normalizeCallerPackage(item, locator) {
+    return Object.freeze({
+      confirmed: false,
+      format: displayString(unwrapOwnValue(ownData(item, "format")), 64),
+      name: displayString(unwrapOwnValue(ownData(item, "name")), 512) || "Package",
+      status: displayString(
+        unwrapOwnValue(ownData(item, "status_str_raw") ?? ownData(item, "status_str")),
+        64
+      ),
+      statusReason: normalizePolicyStatusReason(ownData(item, "status_reason")),
+      uploadedAt: dateTime(unwrapOwnValue(ownData(item, "uploaded_at"))),
+      version: displayString(unwrapOwnValue(ownData(item, "version")), 512),
+      workspace: locator.workspace,
+      repository: locator.repository,
+      packageSlugPerm: locator.packageSlugPerm,
     });
+  }
 
-    // Show loading state
-    panel.webview.html = this._getLoadingHtml(name, version);
+  _initialTrace(caller, locator) {
+    const parsedReason = parsePolicyStatusReason(caller.statusReason);
+    return {
+      current: caller,
+      decision: null,
+      error: null,
+      locator,
+      packageUrl: this._packageUrl(caller, locator),
+      parsedReason,
+      policyDescription: null,
+      refreshed: false,
+    };
+  }
 
-    // Fetch policy decision trace
-    const cloudsmithAPI = this._cloudsmithAPI || new CloudsmithAPI(this.context);
-    const policyTrace = await this._fetchPolicyDecisionTrace(
-      cloudsmithAPI,
-      workspace,
-      slugPerm,
-      statusReason,
-      requestController.signal
-    );
-
-    if (!this._isOperationCurrent(operation)) {
+  async _refreshOperation(operation, api) {
+    const current = await this._fetchCurrentPackage(api, operation.locator, operation.controller.signal);
+    if (!this._isOperationCurrent(operation)) return;
+    if (current === CURRENT_PACKAGE_MISSING) {
+      operation.trace = { ...operation.trace, error: "missing", refreshed: true };
+      this._render(operation);
+      return;
+    }
+    if (!current) {
+      operation.trace = { ...operation.trace, current: null, error: "load", refreshed: true };
+      this._render(operation);
       return;
     }
 
-    // Render the full panel
-    panel.webview.html = this._getHtmlContent(
-      nonce, name, version, format, workspace, repo, slugPerm,
-      statusReason, packageUrl, policyTrace
-    );
+    operation.trace = {
+      ...operation.trace,
+      current,
+      decision: null,
+      error: current.status === STATUS_QUARANTINED ? null : "stale",
+      packageUrl: this._packageUrl(current, operation.locator),
+      parsedReason: parsePolicyStatusReason(current.statusReason),
+      policyDescription: null,
+      refreshed: true,
+    };
+    this._render(operation);
+    if (current.status !== STATUS_QUARANTINED) return;
 
-    // Handle messages from the WebView
-    operation.messageSubscription = panel.webview.onDidReceiveMessage(message => (
-      this._handleMessage(
-        operation,
-        message,
-        item,
-        name,
-        version,
-        statusReason,
-        packageUrl,
-        policyTrace
-      ).catch(() => {
-        if (this._isOperationCurrent(operation)) {
-          return this._notifications.warning("Could not complete the quarantine panel action.");
-        }
-        return undefined;
-      })
-    ));
+    const parsedPolicySlug = operation.trace.parsedReason?.policySlug || null;
+    const work = [];
+    if (current.uploadedAt && (!usefulStatusReason(current.statusReason) || parsedPolicySlug)) {
+      work.push(this._loadDecision(operation, api, parsedPolicySlug));
+    } else if (current.statusReason && !parsedPolicySlug) {
+      this._diagnostic("decision_policy_identity_unavailable");
+    } else {
+      this._diagnostic("decision_time_boundary_unavailable");
+    }
+    if (parsedPolicySlug) work.push(this._loadPolicyDescription(operation, api, parsedPolicySlug));
+    await Promise.allSettled(work);
   }
 
-  async _handleMessage(operation, message, item, name, version, statusReason, packageUrl, policyTrace) {
+  async _fetchCurrentPackage(api, locator, signal) {
+    if (!api || typeof api.get !== "function") return null;
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["packages", locator.workspace, locator.repository, locator.packageSlugPerm]);
+    } catch {
+      return null;
+    }
+    try {
+      const result = await api.get(endpoint, {
+        responseType: "object",
+        validate: isRecord,
+        retry: "never",
+        signal,
+      });
+      if (signal.aborted) return null;
+      if (!result.ok) return result.status === 404 ? CURRENT_PACKAGE_MISSING : null;
+      return normalizeCurrentPackage(result.data, locator);
+    } catch {
+      return null;
+    }
+  }
+
+  async _loadDecision(operation, api, policySlug) {
+    let collection;
+    try {
+      collection = await fetchPackageDecisionLogs(
+        api,
+        operation.locator,
+        operation.trace.current.uploadedAt,
+        { policySlug, signal: operation.controller.signal }
+      );
+    } catch {
+      this._diagnostic("decision_collection_failed");
+      return;
+    }
+    if (!this._isOperationCurrent(operation)) return;
+    const exactItems = collection.items.filter(item => (
+      item.packageSlugPerm === operation.locator.packageSlugPerm
+      && item.repositorySlug === operation.locator.repository
+    ));
+    if (exactItems.length !== collection.items.length) {
+      this._diagnostic("decision_identity_mismatch");
+      return;
+    }
+    const summary = selectCausalDecision(exactItems, policySlug);
+    if (!summary) {
+      if (!collection.complete) this._diagnostic("decision_collection_incomplete");
+      return;
+    }
+
+    let decision = summary;
+    const needsDetail = !usefulStatusReason(operation.trace.current.statusReason) || !policySlug;
+    if (needsDetail) {
+      const detail = await fetchDecisionLogDetail(api, operation.locator, summary, {
+        signal: operation.controller.signal,
+      });
+      if (!this._isOperationCurrent(operation) || !detail) {
+        this._diagnostic("decision_detail_unavailable");
+        return;
+      }
+      decision = detail;
+    }
+    if (!this._isOperationCurrent(operation)) return;
+    if (
+      policySlug
+      && operation.trace.parsedReason?.policySlug
+      && decision.policySlugPerm !== operation.trace.parsedReason.policySlug
+    ) {
+      this._diagnostic("decision_policy_conflict");
+      return;
+    }
+    operation.trace = { ...operation.trace, decision };
+    this._render(operation);
+    if (!policySlug && decision.policySlugPerm) {
+      await this._loadPolicyDescription(operation, api, decision.policySlugPerm);
+    }
+  }
+
+  async _loadPolicyDescription(operation, api, policySlug) {
+    if (!api || typeof api.getV2 !== "function" || !policySlug) return;
+    let endpoint;
+    try {
+      endpoint = apiEndpoint(["workspaces", operation.locator.workspace, "policies", policySlug]);
+    } catch {
+      return;
+    }
+    try {
+      const result = await api.getV2(endpoint, {
+        responseType: "object",
+        validate: isRecord,
+        retry: "never",
+        signal: operation.controller.signal,
+      });
+      if (!this._isOperationCurrent(operation) || !result.ok) return;
+      const returnedSlug = displayString(result.data.slug_perm, 512);
+      const description = displayString(result.data.description, 1024);
+      if (returnedSlug !== policySlug || !description) {
+        if (returnedSlug !== policySlug) this._diagnostic("policy_identity_mismatch");
+        return;
+      }
+      const reason = customerReason(operation.trace);
+      if (reason && normalizedComparison(reason) === normalizedComparison(description)) return;
+      operation.trace = { ...operation.trace, policyDescription: description };
+      this._render(operation);
+    } catch {
+      this._diagnostic("policy_description_unavailable");
+    }
+  }
+
+  async _handleMessage(operation, message) {
     if (!this._isOperationCurrent(operation)) return;
     const parsed = parseWebviewMessage(message, QUARANTINE_MESSAGE_CONTRACTS);
     if (!parsed || !this._isOperationCurrent(operation)) return;
-
-    if (parsed.command === "findSafeVersion") {
-      await this._executeCommand("cloudsmith-vsc.findSafeVersion", item);
-    } else if (parsed.command === "showVulnerabilities") {
-      await this._executeCommand("cloudsmith-vsc.showVulnerabilities", item);
-    } else if (parsed.command === "openInCloudsmith" && packageUrl) {
-      await this._openExternal(packageUrl);
-    } else if (parsed.command === "copyReport") {
-      const report = this._buildPlainTextReport(name, version, statusReason, policyTrace);
-      await this._writeClipboard(report);
-      if (this._isOperationCurrent(operation)) {
-        await this._notifications.information("Quarantine report copied.");
-      }
+    if (parsed.command === "retry") {
+      await this.show(operation.item);
+      return;
     }
-  }
-
-  /**
-   * Fetch policy decision logs for a package from the v2 API.
-   * Parses the status_reason field and fetches decision logs when available.
-   *
-   * @returns {Object} { parsedReason, decisionLogs: [...], policyDetail: Object|null }
-   */
-  async _fetchPolicyDecisionTrace(cloudsmithAPI, workspace, slugPerm, statusReason, signal) {
-    const trace = {
-      parsedReason: null,
-      decisionLogs: [],
-      decisionLogsComplete: false,
-      decisionLogsPartial: false,
-      decisionLogsIncomplete: true,
-      decisionLogsFailureCount: 0,
-      policyDetail: null,
-    };
-
-    // Parse the status_reason field if present
-    trace.parsedReason = parsePolicyStatusReason(statusReason);
-
-    // Fetch decision logs from v2 API
+    const trace = operation.trace;
+    if (!trace.refreshed || !trace.current?.confirmed || trace.current.status !== STATUS_QUARANTINED) {
+      return;
+    }
     try {
-      const logsResult = await fetchPackageDecisionLogs(cloudsmithAPI, workspace, slugPerm, {
-        signal,
-      });
-      if (signal && signal.aborted) return trace;
-      trace.decisionLogs = [...logsResult.items];
-      trace.decisionLogsComplete = logsResult.complete;
-      trace.decisionLogsPartial = logsResult.partial;
-      trace.decisionLogsIncomplete = logsResult.incomplete;
-      trace.decisionLogsFailureCount = logsResult.failureCount;
-    } catch {
-      trace.decisionLogsComplete = false;
-      trace.decisionLogsPartial = false;
-      trace.decisionLogsIncomplete = true;
-      trace.decisionLogsFailureCount = 1;
-    }
-
-    // If we have a policy slug, fetch the policy detail for the description
-    if (trace.parsedReason && trace.parsedReason.policySlug && !(signal && signal.aborted)) {
-      try {
-        const policyEndpoint = apiEndpoint([
-          "workspaces",
-          workspace,
-          "policies",
-          trace.parsedReason.policySlug,
-        ]);
-        const policyResult = await cloudsmithAPI.getV2(policyEndpoint, {
-          responseType: "object",
-          validate: isRecord,
-          retry: "never",
-          signal,
-        });
-        if (signal && signal.aborted) return trace;
-        if (policyResult.ok) {
-          trace.policyDetail = policyResult.data;
-        } else if (policyResult.error.kind !== "cancelled") {
-          console.warn(`[Quarantine] Policy detail unavailable: ${formatApiError(policyResult.error)}`);
+      if (parsed.command === "findSafeVersion") {
+        await this._executeCommand("cloudsmith-vsc.findSafeVersion", operation.item);
+      } else if (parsed.command === "showVulnerabilities") {
+        await this._executeCommand("cloudsmith-vsc.showVulnerabilities", operation.item);
+      } else if (parsed.command === "openInCloudsmith" && trace.packageUrl) {
+        await this._openExternal(trace.packageUrl);
+      } else if (parsed.command === "copyReport") {
+        await this._writeClipboard(this._buildPlainTextReport(trace));
+        if (this._isOperationCurrent(operation)) {
+          await this._notifications.information("Quarantine report copied.");
         }
-      } catch (error) { // eslint-disable-line no-unused-vars
-        // Policy detail may not be accessible
+      }
+    } catch {
+      if (this._isOperationCurrent(operation)) {
+        await this._notifications.warning(actionFailureMessage(parsed.command));
       }
     }
-
-    return trace;
   }
 
-  _getLoadingHtml(name, version) {
-    return `<!DOCTYPE html>
-<html>
-<head><style>body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 20px; }</style></head>
-<body><h2>Loading quarantine details for ${this._esc(name || "")} ${this._esc(version || "")}...</h2></body>
-</html>`;
+  _render(operation) {
+    if (!this._isOperationCurrent(operation)) return;
+    operation.panel.webview.html = this._getHtmlContent(operation.nonce, operation.trace);
   }
 
-  _getHtmlContent(nonce, name, version, format, workspace, repo, slugPerm, statusReason, packageUrl, policyTrace) {
-    // Determine if this is vulnerability-related by checking for CVE references in decision logs
-    const hasCVEs = policyTrace.decisionLogs.some(entry =>
-      (entry.reason && /CVE-/i.test(entry.reason)) ||
-      (entry.action && /vulnerabilit/i.test(entry.action))
-    );
-
-    // Build policy info section
-    let policyInfoHtml = "";
-    if (statusReason) {
-      policyInfoHtml += `<div class="status-reason-box">
-        <h3>Quarantine reason</h3>
-        <p class="status-reason">${this._esc(statusReason)}</p>
-      </div>`;
+  _getHtmlContent(nonce, trace) {
+    const current = trace.current;
+    const name = current?.name || "Package";
+    const version = current?.version;
+    const heading = [name, version].filter(Boolean).join(" ");
+    const metadata = [current?.format, current ? `${current.workspace}/${current.repository}` : null]
+      .filter(Boolean).join(" · ");
+    let body;
+    if (
+      !trace.refreshed
+      && (current?.status !== STATUS_QUARANTINED || !customerReason(trace))
+    ) {
+      body = `<p class="loading" role="status" aria-live="polite">Loading quarantine details...</p>`;
+    } else if (trace.error === "missing") {
+      body = `<div class="state"><p>This package is no longer available.</p></div>`;
+    } else if (trace.error === "load") {
+      body = `<div class="state" role="alert"><p>Could not load quarantine details.</p><button type="button" data-command="retry">Retry</button></div>`;
+    } else if (trace.error === "stale") {
+      body = `<div class="state"><p>This package is no longer quarantined.</p></div>`;
+    } else {
+      const reason = customerReason(trace);
+      const policyName = trace.parsedReason?.policyName || trace.decision?.policyName || null;
+      const recorded = trace.decision?.endedAt || null;
+      const rows = [
+        policyName ? `<div><dt>Policy</dt><dd>${this._esc(policyName)}</dd></div>` : "",
+        reason ? `<div><dt>Reason</dt><dd>${this._esc(reason)}</dd></div>` : "",
+        `<div><dt>Action</dt><dd>Quarantined</dd></div>`,
+        recorded ? `<div><dt>Decision recorded</dt><dd>${this._esc(formatTimestamp(recorded))}</dd></div>` : "",
+      ].join("");
+      const description = trace.policyDescription
+        ? `<section><h3>About this policy</h3><p>${this._esc(trace.policyDescription)}</p></section>`
+        : "";
+      const actions = trace.refreshed
+        ? `<section><h2>Next steps</h2><div class="actions">
+            <button type="button" data-command="findSafeVersion">Find safe version</button>
+            <button type="button" data-command="showVulnerabilities">Show vulnerabilities</button>
+            ${trace.packageUrl ? `<button type="button" data-command="openInCloudsmith">View in Cloudsmith</button>` : ""}
+            <button type="button" class="secondary" data-command="copyReport">Copy report</button>
+          </div></section>`
+        : `<p class="loading" role="status" aria-live="polite">Refreshing current package status...</p>`;
+      body = `<span class="badge"><span aria-hidden="true">⛔</span> Quarantined</span>
+        <section><h2>Quarantine details</h2><dl>${rows}</dl></section>
+        ${description}${actions}`;
     }
-
-    if (policyTrace.parsedReason && policyTrace.parsedReason.policyName) {
-      policyInfoHtml += `<div class="policy-card">
-        <strong>Policy:</strong> ${this._esc(policyTrace.parsedReason.policyName)}${policyTrace.parsedReason.policySlug ? ` <span class="slug">(${this._esc(policyTrace.parsedReason.policySlug)})</span>` : ""}<br>
-        <strong>Action:</strong> Quarantined<br>
-        ${policyTrace.parsedReason.description ? `<strong>Detail:</strong> ${this._esc(policyTrace.parsedReason.description)}` : ""}
-      </div>`;
-    }
-
-    // Show the full policy description from the EPM policy object if available
-    if (policyTrace.policyDetail && policyTrace.policyDetail.description) {
-      policyInfoHtml += `<div class="policy-description">
-        <h4>Policy description</h4>
-        <p>${this._esc(policyTrace.policyDetail.description)}</p>
-      </div>`;
-    }
-
-    // Decision logs table
-    let decisionLogsHtml = "";
-    if (policyTrace.decisionLogs.length > 0) {
-      decisionLogsHtml = `<div class="decision-logs">
-        <h3>Decision log entries</h3>
-        <table class="decision-log-table">
-          <thead><tr><th>Policy</th><th>Matched</th><th>Action</th><th>Reason</th></tr></thead>
-          <tbody>`;
-      for (const entry of policyTrace.decisionLogs) {
-        decisionLogsHtml += `<tr>
-          <td>${this._esc(entry.policy_name || entry.name || "Unknown")}</td>
-          <td>${this._esc(entry.matched === true ? "Yes" : entry.matched === false ? "No" : "Unknown")}</td>
-          <td>${this._esc(entry.action || entry.actions_taken || "\u2014")}</td>
-          <td>${this._esc(entry.reason || "\u2014")}</td>
-        </tr>`;
-      }
-      decisionLogsHtml += "</tbody></table></div>";
-    }
-
-    // Non-vulnerability notice
-    const decisionLogsWarning = policyTrace.decisionLogsComplete === false
-      ? `<div class="warning-banner">Policy decision log history is incomplete. Loaded entries are shown, but additional policy or vulnerability decisions may exist.</div>`
-      : "";
-    const nonVulnNotice = !hasCVEs && policyTrace.decisionLogsComplete === true
-      ? `<div class="info-banner">This quarantine was triggered by policy rules, not a specific vulnerability.</div>`
-      : "";
 
     return `<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src 'none';">
-<style>
-  body {
-    font-family: var(--vscode-font-family);
-    color: var(--vscode-foreground);
-    background-color: var(--vscode-editor-background);
-    padding: 16px 24px;
-    line-height: 1.5;
-  }
-  h2 { margin: 0 0 4px 0; }
-  h3 { margin: 16px 0 8px 0; }
-  h4 { margin: 12px 0 6px 0; }
-  .header-meta {
-    color: var(--vscode-descriptionForeground);
-    margin-bottom: 16px;
-  }
-  .quarantine-badge {
-    display: inline-block;
-    background: var(--vscode-inputValidation-errorBackground, rgba(255,0,0,0.1));
-    color: var(--vscode-errorForeground);
-    padding: 2px 10px;
-    border-radius: 3px;
-    font-weight: bold;
-    font-size: 13px;
-  }
-  .actions { margin: 16px 0 20px 0; }
-  .actions button {
-    background-color: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    border: none;
-    padding: 6px 14px;
-    margin-right: 8px;
-    cursor: pointer;
-    font-size: 13px;
-    border-radius: 2px;
-  }
-  .actions button:hover {
-    background-color: var(--vscode-button-hoverBackground);
-  }
-  .status-reason-box {
-    background: var(--vscode-inputValidation-warningBackground, rgba(255,200,0,0.08));
-    border: 1px solid var(--vscode-inputValidation-warningBorder, #c8a000);
-    border-radius: 4px;
-    padding: 12px 16px;
-    margin-bottom: 16px;
-  }
-  .status-reason-box h3 { margin-top: 0; }
-  .status-reason { color: var(--vscode-editorWarning-foreground, orange); }
-  .policy-card {
-    margin: 8px 0 16px 0;
-    padding: 10px 14px;
-    background: var(--vscode-editor-background);
-    border: 1px solid var(--vscode-panel-border, #444);
-    border-radius: 3px;
-  }
-  .slug { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
-  .policy-description {
-    margin: 8px 0 16px 0;
-    padding: 10px 14px;
-    background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.1));
-    border-left: 3px solid var(--vscode-textBlockQuote-border, #444);
-  }
-  .policy-description h4 { margin-top: 0; }
-  .decision-log-table { width: 100%; border-collapse: collapse; margin: 4px 0; }
-  .decision-log-table th, .decision-log-table td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--vscode-panel-border); }
-  .decision-log-table th { font-size: 0.9em; color: var(--vscode-descriptionForeground); border-bottom: 2px solid var(--vscode-panel-border, #444); }
-  .info-banner {
-    background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.1));
-    border: 1px solid var(--vscode-panel-border, #444);
-    border-radius: 4px;
-    padding: 10px 14px;
-    margin: 16px 0;
-    color: var(--vscode-descriptionForeground);
-  }
-  .warning-banner {
-    background: var(--vscode-inputValidation-warningBackground, rgba(255,200,0,0.08));
-    border: 1px solid var(--vscode-inputValidation-warningBorder, #c8a000);
-    border-radius: 4px;
-    padding: 10px 14px;
-    margin: 16px 0;
-  }
-</style>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); padding: 16px 24px; line-height: 1.5; }
+    h1 { margin: 0 0 2px; font-size: 1.65em; } h2 { margin: 22px 0 8px; } h3 { margin: 16px 0 6px; }
+    .meta { color: var(--vscode-descriptionForeground); margin-bottom: 14px; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 3px; font-weight: 600; color: var(--vscode-errorForeground); background: var(--vscode-inputValidation-errorBackground, rgba(255,0,0,.1)); }
+    dl { border: 1px solid var(--vscode-panel-border); border-radius: 4px; margin: 0; }
+    dl div { display: grid; grid-template-columns: minmax(8rem, 25%) 1fr; gap: 12px; padding: 9px 12px; border-bottom: 1px solid var(--vscode-panel-border); }
+    dl div:last-child { border-bottom: 0; } dt { font-weight: 600; } dd { margin: 0; overflow-wrap: anywhere; }
+    .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    button { border: 0; border-radius: 2px; padding: 6px 14px; cursor: pointer; color: var(--vscode-button-foreground); background: var(--vscode-button-background); }
+    button:hover { background: var(--vscode-button-hoverBackground); } button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+    button.secondary { color: var(--vscode-button-secondaryForeground); background: var(--vscode-button-secondaryBackground); }
+    .loading, .meta { color: var(--vscode-descriptionForeground); } .state { margin-top: 20px; }
+  </style>
 </head>
 <body>
-  <h2>${this._esc(name || "")} ${this._esc(version || "")}</h2>
-  <div class="header-meta">
-    ${this._esc(format || "")}${workspace ? ` &middot; ${this._esc(workspace)}` : ""}${repo ? `/${this._esc(repo)}` : ""}
-  </div>
-  <span class="quarantine-badge">\u26D4 Quarantined</span>
-
-  ${policyInfoHtml}
-  ${decisionLogsWarning}
-  ${nonVulnNotice}
-  ${decisionLogsHtml}
-
-  <div class="actions">
-    <button data-command="findSafeVersion">Find safe version</button>
-    ${packageUrl ? `<button data-command="openInCloudsmith">View in Cloudsmith</button>` : ""}
-    ${hasCVEs ? `<button data-command="showVulnerabilities">Show vulnerabilities</button>` : ""}
-    <button data-command="copyReport">Copy quarantine report</button>
-  </div>
-
+  <h1>${this._esc(heading)}</h1>
+  ${metadata ? `<div class="meta">${this._esc(metadata)}</div>` : ""}
+  ${body}
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
     document.querySelectorAll("[data-command]").forEach((button) => {
-      button.addEventListener("click", () => {
-        vscode.postMessage({ command: button.dataset.command });
-      });
+      button.addEventListener("click", () => vscode.postMessage({ command: button.dataset.command }));
     });
   </script>
 </body>
 </html>`;
   }
 
-  _buildPlainTextReport(name, version, statusReason, policyTrace) {
-    const lines = [];
-    lines.push(`Quarantine report: ${name || ""} ${version || ""}`);
-    lines.push("=".repeat(60));
-    lines.push("");
-    if (statusReason) {
-      lines.push(`Reason: ${statusReason}`);
-      lines.push("");
+  _buildPlainTextReport(trace) {
+    const current = trace.current;
+    const reason = customerReason(trace);
+    const policyName = trace.parsedReason?.policyName || trace.decision?.policyName || null;
+    const lines = [
+      "Quarantine report",
+      `Package: ${reportValue([current.name, current.version].filter(Boolean).join(" "))}`,
+    ];
+    if (current.format) lines.push(`Format: ${reportValue(current.format)}`);
+    lines.push(`Location: ${reportValue(`${current.workspace}/${current.repository}`)}`);
+    lines.push("Status: Quarantined");
+    if (policyName) lines.push(`Policy: ${reportValue(policyName)}`);
+    if (reason) lines.push(`Reason: ${reportValue(reason)}`);
+    lines.push("Action: Quarantined");
+    if (trace.decision?.endedAt) {
+      lines.push(`Decision recorded: ${reportValue(formatTimestamp(trace.decision.endedAt))}`);
     }
-    if (policyTrace.parsedReason && policyTrace.parsedReason.policyName) {
-      lines.push(`Policy: ${policyTrace.parsedReason.policyName}`);
-      if (policyTrace.parsedReason.description) {
-        lines.push(`Detail: ${policyTrace.parsedReason.description}`);
-      }
-      lines.push("");
-    }
-    if (policyTrace.policyDetail && policyTrace.policyDetail.description) {
-      lines.push(`Policy description: ${policyTrace.policyDetail.description}`);
-      lines.push("");
-    }
-    if (policyTrace.decisionLogs.length > 0) {
-      lines.push("Decision log:");
-      for (const entry of policyTrace.decisionLogs) {
-        lines.push(`  - ${entry.policy_name || entry.name || "Unknown"}: ${entry.reason || entry.action || "\u2014"}`);
-      }
-    }
-    if (policyTrace.decisionLogsComplete === false) {
-      lines.push("Policy decision log history is incomplete; additional entries may exist.");
+    if (trace.policyDescription) {
+      lines.push(`Policy description: ${reportValue(trace.policyDescription)}`);
     }
     return lines.join("\n");
   }
 
-  _esc(str) {
-    if (!str) return "";
-    return String(str)
+  _packageUrl(current, locator) {
+    try {
+      return buildPackageUrl(
+        locator.workspace,
+        locator.repository,
+        current.format,
+        current.name,
+        current.version,
+        locator.packageSlugPerm
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  _esc(value) {
+    return typeof value === "string" ? value
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
+      .replace(/"/g, "&quot;") : "";
   }
 
-  _getNonce() {
-    return this._createNonce();
+  _diagnostic(category) {
+    console.warn(`[Quarantine] ${category}`);
   }
+
+  _getNonce() { return this._createNonce(); }
 
   _isOperationCurrent(operation) {
     return Boolean(
       operation
       && this._operation === operation
       && this._panel === operation.panel
+      && operation.version === this._operationVersion
       && !operation.controller.signal.aborted
       && isAccountCurrent(this._connectionManager, operation.account)
     );
   }
 
   resetForAccountChange() {
-    const operation = this._operation;
-    if (operation) {
-      this._disposeOperation(operation, true);
+    if (this._operation) {
+      this._disposeOperation(this._operation, true);
       return;
     }
     const panel = this._panel;
@@ -487,17 +469,15 @@ class QuarantineExplainProvider {
     if (panel) panel.dispose();
   }
 
-  dispose() {
-    this.resetForAccountChange();
-  }
+  dispose() { this.resetForAccountChange(); }
 
   _disposeOperation(operation, disposePanel) {
     if (!operation || operation.disposed) return;
     operation.disposed = true;
     operation.controller.abort();
     operation.messageSubscription?.dispose();
-    operation.messageSubscription = null;
     operation.disposeSubscription?.dispose();
+    operation.messageSubscription = null;
     operation.disposeSubscription = null;
     if (this._operation === operation) this._operation = null;
     if (this._panel === operation.panel) this._panel = null;
@@ -505,15 +485,132 @@ class QuarantineExplainProvider {
   }
 }
 
-const QUARANTINE_MESSAGE_CONTRACTS = Object.freeze({
-  findSafeVersion: Object.freeze([]),
-  showVulnerabilities: Object.freeze([]),
-  openInCloudsmith: Object.freeze([]),
-  copyReport: Object.freeze([]),
-});
-
-function isRecord(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+function normalizeCurrentPackage(value, locator) {
+  if (!isRecord(value)) return null;
+  const workspace = displayString(ownData(value, "namespace"), 512);
+  const repository = displayString(ownData(value, "repository"), 512);
+  const packageSlugPerm = displayString(ownData(value, "slug_perm"), 512);
+  const packageSlugPermRaw = ownData(value, "slug_perm_raw") == null
+    ? null
+    : displayString(ownData(value, "slug_perm_raw"), 512);
+  const status = displayString(unwrapOwnValue(
+    ownData(value, "status_str") ?? ownData(value, "status")
+  ), 64);
+  const uploadedAt = dateTime(ownData(value, "uploaded_at"));
+  const format = displayString(ownData(value, "format"), 64);
+  const name = displayString(ownData(value, "name"), 512);
+  const version = displayString(ownData(value, "version"), 512);
+  if (
+    workspace !== locator.workspace
+    || repository !== locator.repository
+    || packageSlugPerm !== locator.packageSlugPerm
+    || (packageSlugPermRaw !== null && packageSlugPermRaw !== packageSlugPerm)
+    || !status
+    || !format
+    || !name
+    || !version
+  ) return null;
+  return Object.freeze({
+    confirmed: true,
+    format,
+    name,
+    packageSlugPerm,
+    repository,
+    status,
+    statusReason: normalizePolicyStatusReason(ownData(value, "status_reason")),
+    uploadedAt,
+    version,
+    workspace,
+  });
 }
 
-module.exports = { QuarantineExplainProvider };
+function displayString(value, maxLength = MAX_DISPLAY_LENGTH) {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(CONTROL_PATTERN, " ").trim();
+  if (!normalized) return null;
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function dateTime(value) {
+  return typeof value === "string"
+    && value.length <= 128
+    && /^\d{4}-\d{2}-\d{2}T/.test(value)
+    && Number.isFinite(Date.parse(value))
+    ? value
+    : null;
+}
+
+function formatTimestamp(value) {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toLocaleString() : "";
+}
+
+function normalizedComparison(value) {
+  return displayString(value)?.toLocaleLowerCase() || "";
+}
+
+function customerReason(trace) {
+  if (usefulStatusReason(trace.current?.statusReason)) {
+    return trace.parsedReason?.description || trace.parsedReason?.raw || trace.current.statusReason;
+  }
+  return trace.decision?.reason || null;
+}
+
+function usefulStatusReason(value) {
+  const normalized = displayString(value);
+  return Boolean(normalized && !/^quarantined[.!]?$/i.test(normalized));
+}
+
+function reportValue(value) {
+  const normalized = displayString(value, 1024) || "";
+  return normalized.replace(/\s+/g, " ").replace(/^[=+\-@]/, "'$&");
+}
+
+function actionFailureMessage(command) {
+  const messages = {
+    copyReport: "Could not copy the quarantine report. Retry.",
+    findSafeVersion: "Could not find a safe version. Retry.",
+    openInCloudsmith: "Could not open this package in Cloudsmith. Retry.",
+    showVulnerabilities: "Could not show vulnerabilities. Retry.",
+  };
+  return messages[command] || "Could not complete this action. Retry.";
+}
+
+function isRecord(value) {
+  return Boolean(value)
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function ownData(value, key) {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && Object.prototype.hasOwnProperty.call(descriptor, "value")
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function unwrapOwnValue(value) {
+  let current = value;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (!isRecord(current)) return current;
+    const descriptor = Object.getOwnPropertyDescriptor(current, "value");
+    if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, "value")) return null;
+    current = descriptor.value;
+  }
+  return isRecord(current) ? null : current;
+}
+
+const QUARANTINE_MESSAGE_CONTRACTS = Object.freeze({
+  copyReport: Object.freeze([]),
+  findSafeVersion: Object.freeze([]),
+  openInCloudsmith: Object.freeze([]),
+  retry: Object.freeze([]),
+  showVulnerabilities: Object.freeze([]),
+});
+
+module.exports = { QuarantineExplainProvider, normalizeCurrentPackage };


### PR DESCRIPTION
## Summary
- Replace the obsolete unfiltered policy-log scan with bounded, exact package and policy decision reconciliation against the current API.
- Refresh authoritative package state before presenting quarantine details, preserve exact recent-package identity and reasons, and prevent stale or cross-account results.
- Keep quarantine normalization private, narrow policy-log exports to production consumers, and verify supported caller shapes through the provider entry point.

## Validation
- npm test — 721 passing
- npm run check
- npm run package
- npm run package:verify
- Focused quarantine provider tests — 20 passing
- Focused policy decision-log tests — 17 passing
- Fresh Extension Development Host acceptance verified the constrained no-recent-quarantine state, refusal to relabel a completed package as quarantined, and zero VS Code problems.