### PR TITLE
fix: show authentication initialization state

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,6 +48,9 @@ const { fetchWorkspaces, normalizedWorkspaceName } = require("./util/workspaceFe
 const { fetchWorkspaceRepositories } = require("./util/workspaceRepositoryFetcher");
 const { PaginatedFetch, replaceCollectionItems } = require("./util/paginatedFetch");
 const { packageCollectionIdentity } = require("./util/collectionIdentity");
+const {
+  connectionSetupAvailable,
+} = require("./util/connectionPresentation");
 
 let exportTerraformAbortController = null;
 let activeActivationOwner = null;
@@ -1000,13 +1003,32 @@ async function activateOwned(context, own) {
   let quarantineExplainProvider = null;
   let upstreamPreviewProvider = null;
   let upstreamDetailProvider = null;
+  let connectionPresentationProjection = Promise.resolve();
+  let connectionPresentationProjectionDisposed = false;
+  own({ dispose: () => { connectionPresentationProjectionDisposed = true; } });
+  const projectConnectionPresentation = (state) => {
+    const setupAvailable = connectionSetupAvailable(state);
+    const project = async () => {
+      if (connectionPresentationProjectionDisposed) return;
+      await vscode.commands.executeCommand(
+        "setContext",
+        "cloudsmith.connectionSetupAvailable",
+        setupAvailable
+      );
+    };
+    const run = connectionPresentationProjection.then(project, project);
+    connectionPresentationProjection = run.catch(() => {
+      console.warn("[Cloudsmith] Could not update the connection presentation indicator.");
+    });
+    return run;
+  };
   const handleConnectionStateChange = async (state) => {
+    void projectConnectionPresentation(state).catch(() => {});
     if (state.accountEpoch !== projectedAccountEpoch) {
       projectedAccountEpoch = state.accountEpoch;
       promotionProvider?.resetForAccountChange();
       await resetAccountScopedState(context, {
         workspaceCache,
-        searchProvider,
         dependencyHealthProvider,
         workspaceContextProjector,
         vulnerabilityStateService,
@@ -1017,9 +1039,6 @@ async function activateOwned(context, own) {
       });
     }
 
-    cloudsmithProvider.refresh({ suppressMissingCredentialsWarning: !state.credentialPresent });
-    searchProvider.refresh();
-    dependencyHealthProvider.refresh();
   };
   const connectionSubscription = connectionManager.onDidChange(state => {
     void handleConnectionStateChange(state).catch(() => {
@@ -1027,6 +1046,7 @@ async function activateOwned(context, own) {
     });
   });
   own(connectionSubscription);
+  void projectConnectionPresentation(connectionManager.getState()).catch(() => {});
 
   // Create vulnerability WebView provider
   vulnerabilityProvider = new VulnerabilityProvider(context, {
@@ -1114,27 +1134,39 @@ async function activateOwned(context, own) {
     return result;
   }
 
-  const initializationResult = await connectionManager.initialize();
-  await handleAuthenticationResult(initializationResult, {
-    showSuccess: false,
-    offerDefault: false,
-    reportFailure: false,
+  let initializationFollowUpDisposed = false;
+  let cliAutoDetectTimer = null;
+  own({
+    dispose() {
+      initializationFollowUpDisposed = true;
+      if (cliAutoDetectTimer) clearTimeout(cliAutoDetectTimer);
+    },
   });
-
-  // Auto-detect Cloudsmith CLI credentials on activation.
-  // If no API key is stored but CLI credentials exist, offer to import them.
-  const cliAutoDetectTimer = setTimeout(() => {
-    void runCLIAutoDetect({
-      connectionManager,
-      secrets: context.secrets,
-      ssoManager,
-      showInformationMessage: (...args) => vscode.window.showInformationMessage(...args),
-      handleAuthenticationResult,
-    }).catch(() => {
-      console.warn("[Cloudsmith] CLI credential auto-detection failed.");
+  const initialization = connectionManager.initialize();
+  void initialization.then(async result => {
+    await handleAuthenticationResult(result, {
+      showSuccess: false,
+      offerDefault: false,
+      reportFailure: false,
     });
-  }, 3000);
-  own({ dispose: () => clearTimeout(cliAutoDetectTimer) });
+    if (initializationFollowUpDisposed) return;
+
+    // Auto-detect Cloudsmith CLI credentials after the initial stored state settles.
+    cliAutoDetectTimer = setTimeout(() => {
+      if (initializationFollowUpDisposed) return;
+      void runCLIAutoDetect({
+        connectionManager,
+        secrets: context.secrets,
+        ssoManager,
+        showInformationMessage: (...args) => vscode.window.showInformationMessage(...args),
+        handleAuthenticationResult,
+      }).catch(() => {
+        console.warn("[Cloudsmith] CLI credential auto-detection failed.");
+      });
+    }, 3000);
+  }).catch(() => {
+    console.warn("[Cloudsmith] Connection initialization did not complete cleanly.");
+  });
 
   // register general commands. Will move this over to command Manager in future release.
   own(

--- a/extension.js
+++ b/extension.js
@@ -394,6 +394,11 @@ async function evictPersistedUpstreamCaches(context) {
 }
 
 async function resetAccountScopedState(context, options = {}) {
+  const reset = beginAccountScopedStateReset(options);
+  return completeAccountScopedStateReset(context, options, reset);
+}
+
+function beginAccountScopedStateReset(options = {}) {
   const synchronousInvalidators = [
     () => options.workspaceCache?.clear?.(),
     () => options.searchProvider?.clear?.(),
@@ -405,6 +410,7 @@ async function resetAccountScopedState(context, options = {}) {
     () => options.quarantineExplainProvider?.resetForAccountChange?.(),
     () => options.upstreamPreviewProvider?.resetForAccountChange?.(),
     () => options.upstreamDetailProvider?.resetForAccountChange?.(),
+    () => options.promotionProvider?.resetForAccountChange?.(),
   ];
   const syncFailures = [];
   for (const invalidate of synchronousInvalidators) {
@@ -415,10 +421,14 @@ async function resetAccountScopedState(context, options = {}) {
     }
   }
 
+  return Object.freeze({ syncFailures });
+}
+
+async function completeAccountScopedStateReset(context, options, reset) {
   // Start each fallible authority projection independently. A rejected tree or
   // context update must not retain another cache from the previous account.
   const asynchronousInvalidators = [
-    () => options.dependencyHealthProvider?.resetForAccountChange?.(),
+    () => options.dependencyHealthProvider?.resetForAccountChange?.(options.accountState),
     () => (options.projectHasMultipleWorkspaces
       ? options.projectHasMultipleWorkspaces(false)
       : setHasMultipleWorkspacesContext(context, false, {
@@ -434,8 +444,13 @@ async function resetAccountScopedState(context, options = {}) {
     }
   });
   const asyncResults = await Promise.allSettled(pending);
+  try {
+    options.cloudsmithProvider?.completeAccountReset?.(options.accountState);
+  } catch (error) {
+    reset.syncFailures.push(error);
+  }
   return Object.freeze({
-    syncFailures: Object.freeze([...syncFailures]),
+    syncFailures: Object.freeze([...reset.syncFailures]),
     asyncResults: Object.freeze(asyncResults),
   });
 }
@@ -927,6 +942,7 @@ async function activateOwned(context, own) {
     workspaceCache,
     workspaceContextProjector,
     vulnerabilityStateService,
+    accountResetOrchestrated: true,
   });
   own({ dispose: () => cloudsmithProvider.dispose() });
   const treeView = vscode.window.createTreeView("cloudsmithView", {
@@ -985,6 +1001,7 @@ async function activateOwned(context, own) {
   const dependencyHealthProvider = new DependencyHealthProvider(context, diagnosticsPublisher, {
     connectionManager,
     vulnerabilityStateService,
+    accountResetOrchestrated: true,
   });
   own(
     { dispose: () => searchProvider.dispose() },
@@ -997,7 +1014,9 @@ async function activateOwned(context, own) {
   own(dependencyTreeView);
   dependencyHealthProvider.setTreeView(dependencyTreeView);
 
-  let projectedAccountEpoch = connectionManager.getState().accountEpoch;
+  let projectedAccountIdentity = connectionManager.getState();
+  let accountResetQueue = Promise.resolve();
+  own({ dispose: () => accountResetQueue });
   let promotionProvider = null;
   let vulnerabilityProvider = null;
   let quarantineExplainProvider = null;
@@ -1022,13 +1041,18 @@ async function activateOwned(context, own) {
     });
     return run;
   };
-  const handleConnectionStateChange = async (state) => {
+  const connectionSubscription = connectionManager.onDidChange(state => {
     void projectConnectionPresentation(state).catch(() => {});
-    if (state.accountEpoch !== projectedAccountEpoch) {
-      projectedAccountEpoch = state.accountEpoch;
-      promotionProvider?.resetForAccountChange();
-      await resetAccountScopedState(context, {
+    if (
+      state.accountEpoch !== projectedAccountIdentity.accountEpoch
+      || state.activationId !== projectedAccountIdentity.activationId
+    ) {
+      projectedAccountIdentity = state;
+      const resetOptions = {
         workspaceCache,
+        cloudsmithProvider,
+        accountState: state,
+        promotionProvider,
         dependencyHealthProvider,
         workspaceContextProjector,
         vulnerabilityStateService,
@@ -1036,14 +1060,14 @@ async function activateOwned(context, own) {
         quarantineExplainProvider,
         upstreamPreviewProvider,
         upstreamDetailProvider,
+      };
+      const reset = beginAccountScopedStateReset(resetOptions);
+      const complete = () => completeAccountScopedStateReset(context, resetOptions, reset);
+      const run = accountResetQueue.then(complete, complete);
+      accountResetQueue = run.catch(() => {
+        console.warn("[Cloudsmith] Could not refresh all account-scoped state.");
       });
     }
-
-  };
-  const connectionSubscription = connectionManager.onDidChange(state => {
-    void handleConnectionStateChange(state).catch(() => {
-      console.warn("[Cloudsmith] Could not refresh all account-scoped state.");
-    });
   });
   own(connectionSubscription);
   void projectConnectionPresentation(connectionManager.getState()).catch(() => {});

--- a/models/connectionStatusNode.js
+++ b/models/connectionStatusNode.js
@@ -1,0 +1,47 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const InfoNode = require("./infoNode");
+const { CONNECTION_PRESENTATIONS } = require("../util/connectionPresentation");
+
+function createConnectionStatusNode(presentation) {
+  switch (presentation) {
+    case CONNECTION_PRESENTATIONS.CONNECTING:
+      return new InfoNode(
+        "Connecting to Cloudsmith...",
+        "",
+        "Connecting to Cloudsmith...",
+        "loading~spin"
+      );
+    case CONNECTION_PRESENTATIONS.ABSENT:
+      return new InfoNode(
+        "Connect to Cloudsmith",
+        "Set up authentication to get started.",
+        "Set up an API key, import Cloudsmith CLI credentials, or sign in with SSO.",
+        "plug",
+        undefined,
+        { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
+      );
+    case CONNECTION_PRESENTATIONS.FAILED:
+      return new InfoNode(
+        "Connection failed",
+        "Check the API key in settings.",
+        "Connection failed. Check the API key in settings.",
+        "warning",
+        undefined,
+        { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
+      );
+    case CONNECTION_PRESENTATIONS.UNAVAILABLE:
+      return new InfoNode(
+        "Could not check the connection",
+        "Retry.",
+        "Could not check the Cloudsmith connection. Retry.",
+        "warning",
+        undefined,
+        { command: "cloudsmith-vsc.connectCloudsmith", title: "Retry connection" }
+      );
+    default:
+      return null;
+  }
+}
+
+module.exports = { createConnectionStatusNode };

--- a/package.json
+++ b/package.json
@@ -671,17 +671,17 @@
         {
           "command": "cloudsmith-vsc.connectCloudsmith",
           "group": "navigation",
-          "when": "view == cloudsmithView && !cloudsmith.connected"
+          "when": "view == cloudsmithView && !cloudsmith.connected && cloudsmith.connectionSetupAvailable"
         },
         {
           "command": "cloudsmith-vsc.configureCredentials",
           "group": "navigation",
-          "when": "view == cloudsmithView && !cloudsmith.connected"
+          "when": "view == cloudsmithView && !cloudsmith.connected && cloudsmith.connectionSetupAvailable"
         },
         {
           "command": "cloudsmith-vsc.ssoLogin",
           "group": "navigation",
-          "when": "view == cloudsmithView && !cloudsmith.connected"
+          "when": "view == cloudsmithView && !cloudsmith.connected && cloudsmith.connectionSetupAvailable"
         },
         {
           "command": "cloudsmith-vsc.openSettings",
@@ -696,42 +696,42 @@
         {
           "command": "cloudsmith-vsc.searchPackages",
           "group": "navigation",
-          "when": "view == cloudsmithSearchView"
+          "when": "view == cloudsmithSearchView && cloudsmith.connected"
         },
         {
           "command": "cloudsmith-vsc.clearSearch",
           "group": "navigation",
-          "when": "view == cloudsmithSearchView"
+          "when": "view == cloudsmithSearchView && cloudsmith.connected"
         },
         {
           "command": "cloudsmith-vsc.guidedSearch",
           "group": "navigation",
-          "when": "view == cloudsmithSearchView"
+          "when": "view == cloudsmithSearchView && cloudsmith.connected"
         },
         {
           "command": "cloudsmith-vsc.searchByLicense",
           "group": "navigation",
-          "when": "view == cloudsmithSearchView"
+          "when": "view == cloudsmithSearchView && cloudsmith.connected"
         },
         {
           "command": "cloudsmith-vsc.previewUpstreamResolution",
           "group": "navigation",
-          "when": "view == cloudsmithSearchView"
+          "when": "view == cloudsmithSearchView && cloudsmith.connected"
         },
         {
           "command": "cloudsmith-vsc.scanDependencies",
           "group": "navigation@1",
-          "when": "view == cloudsmithDependencyHealthView && !cloudsmith.depOperationRunning"
+          "when": "view == cloudsmithDependencyHealthView && cloudsmith.connected && !cloudsmith.depOperationRunning"
         },
         {
           "command": "cloudsmith-vsc.changeDependencyScanScope",
           "group": "navigation@1.5",
-          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning"
+          "when": "view == cloudsmithDependencyHealthView && cloudsmith.connected && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning"
         },
         {
           "command": "cloudsmith-vsc.pullDependencies",
           "group": "navigation@2",
-          "when": "view == cloudsmithDependencyHealthView && cloudsmith.depScanComplete && !cloudsmith.depOperationRunning"
+          "when": "view == cloudsmithDependencyHealthView && cloudsmith.connected && cloudsmith.depScanComplete && !cloudsmith.depOperationRunning"
         },
         {
           "command": "cloudsmith-vsc.cycleDepViewDirect",

--- a/test/accountOperation.test.js
+++ b/test/accountOperation.test.js
@@ -1,0 +1,69 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const assert = require("assert");
+const { captureAccount, isAccountCurrent } = require("../util/accountOperation");
+
+suite("account operation boundary", () => {
+  function manager(initial) {
+    let state = { ...initial };
+    return {
+      getState: () => Object.freeze({ ...state }),
+      update: next => { state = { ...state, ...next }; },
+    };
+  }
+
+  test("does not capture an unvalidated startup account", () => {
+    const connectionManager = manager({
+      activationId: "activation-a",
+      accountEpoch: 1,
+      credentialPresent: true,
+      sessionConnected: false,
+      status: "validating",
+    });
+    assert.strictEqual(captureAccount(connectionManager), null);
+  });
+
+  test("captures only a currently authorized account identity", () => {
+    const connectionManager = manager({
+      activationId: "activation-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+      status: "connected",
+    });
+    const account = captureAccount(connectionManager);
+    assert.deepStrictEqual(account, { activationId: "activation-a", accountEpoch: 1 });
+    assert.strictEqual(Object.isFrozen(account), true);
+    assert.strictEqual(isAccountCurrent(connectionManager, account), true);
+
+    connectionManager.update({ sessionConnected: false, status: "validating" });
+    assert.strictEqual(isAccountCurrent(connectionManager, account), false);
+    connectionManager.update({ sessionConnected: true, accountEpoch: 2, status: "connected" });
+    assert.strictEqual(isAccountCurrent(connectionManager, account), false);
+  });
+
+  test("preserves capture of the old authorized session during candidate validation", () => {
+    const connectionManager = manager({
+      activationId: "activation-a",
+      accountEpoch: 4,
+      credentialPresent: true,
+      sessionConnected: true,
+      status: "validating",
+    });
+    assert.deepStrictEqual(captureAccount(connectionManager), {
+      activationId: "activation-a",
+      accountEpoch: 4,
+    });
+  });
+
+  test("rejects malformed identity and every disconnected terminal state", () => {
+    for (const state of [
+      null,
+      { activationId: "", accountEpoch: 1, sessionConnected: true },
+      { activationId: "a", accountEpoch: null, sessionConnected: true },
+      { activationId: "a", accountEpoch: 1, sessionConnected: false, status: "absent" },
+      { activationId: "a", accountEpoch: 1, sessionConnected: false, status: "failed" },
+      { activationId: "a", accountEpoch: 1, sessionConnected: false, status: "disposed" },
+    ]) {
+      assert.strictEqual(captureAccount({ getState: () => state }), null);
+    }
+  });
+});

--- a/test/cloudsmithProvider.test.js
+++ b/test/cloudsmithProvider.test.js
@@ -217,6 +217,138 @@ suite("CloudsmithProvider", () => {
     assert.deepStrictEqual(await provider.getChildren(), []);
   });
 
+  test("waits for an orchestrated account reset before refreshing connected Account B", async () => {
+    const fetchedEpochs = [];
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      accountResetOrchestrated: true,
+      fetchWorkspaces: async () => {
+        const epoch = manager.getState().accountEpoch;
+        fetchedEpochs.push(epoch);
+        return collectionResult([{
+          slug: `workspace-${epoch}`,
+          name: `Workspace ${epoch}`,
+        }]);
+      },
+    });
+    let refreshes = 0;
+    provider.onDidChangeTreeData(() => { refreshes += 1; });
+
+    const accountANodes = await provider.getWorkspaces();
+    assert.strictEqual(accountANodes[0].workspace, "workspace-1");
+    manager.setState({ accountEpoch: 2 });
+    assert.strictEqual(refreshes, 1, "Account A must disappear immediately");
+    assert.strictEqual(
+      (await provider.getChildren())[0].getTreeItem().label,
+      "Connecting to Cloudsmith..."
+    );
+    assert.deepStrictEqual(fetchedEpochs, [1], "Account B must not load before reset");
+
+    provider._workspaceCache.clear();
+    assert.strictEqual(provider.completeAccountReset(manager.getState()), true);
+    assert.strictEqual(refreshes, 2);
+    const accountBNodes = await provider.getWorkspaces();
+    assert.strictEqual(accountBNodes[0].workspace, "workspace-2");
+    assert.deepStrictEqual(fetchedEpochs, [1, 2]);
+  });
+
+  test("an Account A fetch cannot publish after an orchestrated Account B switch", async () => {
+    const accountA = deferred();
+    let fetchStarted = false;
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      accountResetOrchestrated: true,
+      fetchWorkspaces: async () => {
+        fetchStarted = true;
+        return accountA.promise;
+      },
+    });
+    const pending = provider.getWorkspaces();
+    while (!fetchStarted) await new Promise(resolve => setImmediate(resolve));
+
+    manager.setState({ accountEpoch: 2 });
+    accountA.resolve(collectionResult([{ slug: "account-a", name: "Account A" }]));
+
+    assert.deepStrictEqual(await pending, []);
+    assert.strictEqual(
+      (await provider.getChildren())[0].getTreeItem().label,
+      "Connecting to Cloudsmith..."
+    );
+  });
+
+  test("refreshes an account identity change when no external reset orchestrator is used", () => {
+    const provider = createProvider(async () => workspaceSuccess([]));
+    let refreshes = 0;
+    provider.onDidChangeTreeData(() => { refreshes += 1; });
+
+    manager.setState({ accountEpoch: 2 });
+
+    assert.strictEqual(refreshes, 1);
+  });
+
+  test("connection roots supersede loading ownership for connecting, absent, and failed", async () => {
+    const cases = [
+      [{ status: "validating", credentialPresent: true }, "Connecting to Cloudsmith..."],
+      [{ status: "absent", credentialPresent: false }, "Connect to Cloudsmith"],
+      [{ status: "failed", credentialPresent: true }, "Connection failed"],
+    ];
+    for (const [state, expectedLabel] of cases) {
+      manager = createConnectionManager();
+      const response = deferred();
+      const provider = createProvider(async () => { throw new Error("not used"); }, {
+        fetchWorkspaces: async () => response.promise,
+      });
+      const treeView = {};
+      provider.setTreeView(treeView);
+      const oldLoad = provider.getWorkspaces();
+      assert.strictEqual(treeView.message, "Loading...");
+
+      manager.setState({ ...state, sessionConnected: false });
+      assert.strictEqual(treeView.message, undefined);
+      assert.strictEqual(provider._loadingOperationId, null);
+      assert.strictEqual((await provider.getChildren())[0].getTreeItem().label, expectedLabel);
+
+      response.resolve(collectionResult([{ slug: "old", name: "Old" }]));
+      assert.deepStrictEqual(await oldLoad, []);
+      assert.strictEqual(treeView.message, undefined);
+      assert.strictEqual(provider._loadingOperationId, null);
+      provider.dispose();
+    }
+  });
+
+  test("a stale operation finally cannot clear a newer loading operation", async () => {
+    const accountA = deferred();
+    const accountB = deferred();
+    let fetches = 0;
+    const provider = createProvider(async () => { throw new Error("not used"); }, {
+      fetchWorkspaces: async () => {
+        fetches += 1;
+        return fetches === 1 ? accountA.promise : accountB.promise;
+      },
+    });
+    const treeView = {};
+    provider.setTreeView(treeView);
+    const operationA = provider.getWorkspaces();
+    assert.strictEqual(treeView.message, "Loading...");
+    while (fetches === 0) await new Promise(resolve => setImmediate(resolve));
+
+    manager.setState({ status: "validating", sessionConnected: false });
+    assert.strictEqual(treeView.message, undefined);
+    manager.setState({ status: "connected", sessionConnected: true });
+    const operationB = provider.getWorkspaces();
+    const operationBLoadingId = provider._loadingOperationId;
+    assert.strictEqual(treeView.message, "Loading...");
+
+    accountA.resolve(collectionResult([{ slug: "account-a", name: "Account A" }]));
+    assert.deepStrictEqual(await operationA, []);
+    assert.strictEqual(provider._loadingOperationId, operationBLoadingId);
+    assert.strictEqual(treeView.message, "Loading...");
+
+    accountB.resolve(collectionResult([{ slug: "account-b", name: "Account B" }]));
+    const nodes = await operationB;
+    assert.strictEqual(nodes[0].workspace, "account-b");
+    assert.strictEqual(provider._loadingOperationId, null);
+    assert.strictEqual(treeView.message, undefined);
+  });
+
   test("reports malformed workspace payloads as load failures", async () => {
     const provider = createProvider(async (_endpoint, options) => {
       const malformed = [{ name: "Missing stable slug" }];

--- a/test/cloudsmithProvider.test.js
+++ b/test/cloudsmithProvider.test.js
@@ -44,15 +44,26 @@ function deferred() {
 }
 
 function createConnectionManager(overrides = {}) {
+  const listeners = new Set();
   let state = {
     activationId: "activation-a",
     accountEpoch: 1,
+    credentialPresent: true,
     sessionConnected: true,
+    status: "connected",
+    error: null,
     ...overrides,
   };
   return {
     getState() { return Object.freeze({ ...state }); },
-    setState(next) { state = { ...state, ...next }; },
+    setState(next) {
+      state = { ...state, ...next };
+      for (const listener of listeners) listener(Object.freeze({ ...state }));
+    },
+    onDidChange(listener) {
+      listeners.add(listener);
+      return { dispose() { listeners.delete(listener); } };
+    },
   };
 }
 
@@ -120,7 +131,11 @@ suite("CloudsmithProvider", () => {
   }
 
   test("fails closed to the signed-out root without making an API request", async () => {
-    manager.setState({ sessionConnected: false });
+    manager.setState({
+      credentialPresent: false,
+      sessionConnected: false,
+      status: "absent",
+    });
     let requests = 0;
     const provider = createProvider(async () => { requests += 1; });
     const treeView = { message: "old" };
@@ -136,6 +151,70 @@ suite("CloudsmithProvider", () => {
       && call[1] === "cloudsmith.hasMultipleWorkspaces"
       && call[2] === false
     )));
+  });
+
+  test("projects startup and terminal connection states without API work", async () => {
+    manager.setState({
+      credentialPresent: null,
+      sessionConnected: false,
+      status: "indeterminate",
+      error: null,
+    });
+    let apiCalls = 0;
+    const provider = createProvider(async () => {
+      apiCalls += 1;
+      return apiSuccess([]);
+    });
+    assert.deepStrictEqual(
+      await provider.getChildren({ getChildren: () => ["private result"] }),
+      []
+    );
+    const cases = [
+      [{ status: "indeterminate", credentialPresent: null, error: null }, "Connecting to Cloudsmith...", null],
+      [{ status: "validating", credentialPresent: true, error: null }, "Connecting to Cloudsmith...", null],
+      [{ status: "absent", credentialPresent: false, error: null }, "Connect to Cloudsmith", "cloudsmith-vsc.configureCredentials"],
+      [{ status: "failed", credentialPresent: true, error: { message: "unsafe raw detail" } }, "Connection failed", "cloudsmith-vsc.configureCredentials"],
+      [{ status: "indeterminate", credentialPresent: null, error: { message: "SecretStorage csa_secret" } }, "Could not check the connection", "cloudsmith-vsc.connectCloudsmith"],
+    ];
+    for (const [state, label, command] of cases) {
+      manager.setState({ ...state, sessionConnected: false });
+      const item = (await provider.getChildren())[0].getTreeItem();
+      assert.strictEqual(item.label, label);
+      assert.strictEqual(item.command?.command || null, command);
+      if (label !== "Connect to Cloudsmith") {
+        assert.strictEqual(JSON.stringify(item).includes("Set up Cloudsmith authentication"), false);
+      }
+      assert.strictEqual(JSON.stringify(item).includes("csa_secret"), false);
+    }
+    manager.setState({ status: "disposed", credentialPresent: null, sessionConnected: false });
+    assert.deepStrictEqual(await provider.getChildren(), []);
+    assert.strictEqual(apiCalls, 0);
+    provider.dispose();
+    assert.deepStrictEqual(await provider.getChildren(), []);
+  });
+
+  test("refreshes from validating to connected and only then starts workspace loading", async () => {
+    manager.setState({ status: "validating", credentialPresent: true, sessionConnected: false });
+    let fetches = 0;
+    const provider = createProvider(async () => apiSuccess([]), {
+      fetchWorkspaces: async () => {
+        fetches += 1;
+        return collectionResult([]);
+      },
+    });
+    let refreshes = 0;
+    provider.onDidChangeTreeData(() => { refreshes += 1; });
+
+    assert.strictEqual((await provider.getChildren())[0].getTreeItem().label, "Connecting to Cloudsmith...");
+    assert.strictEqual(fetches, 0);
+    manager.setState({ status: "connected", credentialPresent: true, sessionConnected: true });
+    assert.strictEqual(refreshes, 1);
+    await provider.getChildren();
+    assert.strictEqual(fetches, 1);
+    provider.dispose();
+    manager.setState({ status: "absent", credentialPresent: false, sessionConnected: false });
+    assert.strictEqual(refreshes, 1);
+    assert.deepStrictEqual(await provider.getChildren(), []);
   });
 
   test("reports malformed workspace payloads as load failures", async () => {

--- a/test/connectionPresentation.test.js
+++ b/test/connectionPresentation.test.js
@@ -1,0 +1,100 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+const assert = require("assert");
+const {
+  CONNECTION_PRESENTATIONS,
+  connectionPresentation,
+  connectionSetupAvailable,
+} = require("../util/connectionPresentation");
+
+suite("connection presentation", () => {
+  const base = Object.freeze({
+    activationId: "activation-a",
+    accountEpoch: 1,
+    credentialPresent: null,
+    sessionConnected: false,
+    error: null,
+  });
+
+  test("maps the authoritative lifecycle without treating uncertainty as absence", () => {
+    const cases = [
+      [{ ...base, status: "indeterminate" }, CONNECTION_PRESENTATIONS.CONNECTING],
+      [{ ...base, status: "validating" }, CONNECTION_PRESENTATIONS.CONNECTING],
+      [{ ...base, status: "absent", credentialPresent: false }, CONNECTION_PRESENTATIONS.ABSENT],
+      [{ ...base, status: "failed", credentialPresent: true }, CONNECTION_PRESENTATIONS.FAILED],
+      [{ ...base, status: "indeterminate", error: { message: "safe" } }, CONNECTION_PRESENTATIONS.UNAVAILABLE],
+      [{ ...base, status: "disposed" }, CONNECTION_PRESENTATIONS.DISPOSED],
+    ];
+    for (const [state, expected] of cases) {
+      assert.strictEqual(connectionPresentation(state), expected);
+    }
+  });
+
+  test("keeps a previously authorized account connected during candidate validation", () => {
+    assert.strictEqual(connectionPresentation({
+      ...base,
+      status: "validating",
+      credentialPresent: true,
+      sessionConnected: true,
+    }), CONNECTION_PRESENTATIONS.CONNECTED);
+  });
+
+  test("requires coherent authoritative fields before presenting connected or absent", () => {
+    for (const state of [
+      { ...base, status: "connected", sessionConnected: false, credentialPresent: true },
+      { ...base, status: "connected", sessionConnected: true, activationId: "" },
+      { ...base, status: "connected", sessionConnected: true, accountEpoch: -1 },
+      { ...base, status: "connected", sessionConnected: true, credentialPresent: false },
+      { ...base, status: "absent", credentialPresent: null },
+      { ...base, status: "failed", credentialPresent: false },
+    ]) {
+      assert.strictEqual(connectionPresentation(state), CONNECTION_PRESENTATIONS.UNAVAILABLE);
+    }
+    assert.strictEqual(connectionPresentation({
+      ...base,
+      status: "connected",
+      credentialPresent: true,
+      sessionConnected: true,
+    }), CONNECTION_PRESENTATIONS.CONNECTED);
+  });
+
+  test("fails closed for omitted, malformed, and unknown input without reflecting errors", () => {
+    const sensitiveError = Object.freeze({
+      message: "SecretStorage /user/self csa_raw_secret https://key@example.test",
+    });
+    for (const state of [
+      undefined,
+      null,
+      [],
+      "connected",
+      { ...base, status: "future-state" },
+      { ...base, status: "indeterminate", error: sensitiveError },
+    ]) {
+      const result = connectionPresentation(state);
+      assert.strictEqual(result, CONNECTION_PRESENTATIONS.UNAVAILABLE);
+      assert.strictEqual(result.includes("SecretStorage"), false);
+      assert.strictEqual(result.includes("csa_raw_secret"), false);
+    }
+  });
+
+  test("allows setup actions only for authoritative absence or actionable failure", () => {
+    const visible = [
+      { ...base, status: "absent", credentialPresent: false },
+      { ...base, status: "failed", credentialPresent: true },
+    ];
+    const hidden = [
+      undefined,
+      { ...base, status: "indeterminate" },
+      { ...base, status: "validating", credentialPresent: true },
+      { ...base, status: "indeterminate", error: { message: "safe" } },
+      { ...base, status: "disposed" },
+      {
+        ...base,
+        status: "connected",
+        credentialPresent: true,
+        sessionConnected: true,
+      },
+    ];
+    for (const state of visible) assert.strictEqual(connectionSetupAvailable(state), true);
+    for (const state of hidden) assert.strictEqual(connectionSetupAvailable(state), false);
+  });
+});

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -55,6 +55,7 @@ suite("DependencyHealthProvider Test Suite", () => {
         return Object.freeze({
           activationId: this.activationId,
           accountEpoch: 1,
+          credentialPresent: connected,
           sessionConnected: connected,
           status: connected ? "connected" : "absent",
         });
@@ -1065,6 +1066,78 @@ suite("DependencyHealthProvider Test Suite", () => {
 
     assert.strictEqual(nodes.length, 1);
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
+  });
+
+  test("projects startup and terminal connection states through its owned refresh path", async () => {
+    const listeners = new Set();
+    let state = Object.freeze({
+      activationId: "dependency-presentation",
+      accountEpoch: 1,
+      credentialPresent: null,
+      sessionConnected: false,
+      status: "indeterminate",
+      error: null,
+    });
+    const connectionManager = {
+      getState: () => state,
+      onDidChange(listener) {
+        listeners.add(listener);
+        return { dispose() { listeners.delete(listener); } };
+      },
+      update(next) {
+        state = Object.freeze({ ...state, ...next });
+        for (const listener of listeners) listener(state);
+      },
+    };
+    const provider = new DependencyHealthProvider(createContext(), null, { connectionManager });
+    let refreshes = 0;
+    provider.onDidChangeTreeData(() => { refreshes += 1; });
+
+    let item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connecting to Cloudsmith...");
+    assert.strictEqual(item.command, undefined);
+
+    connectionManager.update({ status: "validating", credentialPresent: true });
+    assert.strictEqual(refreshes, 0);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connecting to Cloudsmith...");
+    assert.strictEqual(JSON.stringify(item).includes("Set up Cloudsmith authentication"), false);
+
+    connectionManager.update({ status: "failed", credentialPresent: true });
+    assert.strictEqual(refreshes, 1);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connection failed");
+
+    connectionManager.update({ status: "absent", credentialPresent: false });
+    assert.strictEqual(refreshes, 2);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connect to Cloudsmith");
+
+    connectionManager.update({
+      status: "connected",
+      credentialPresent: true,
+      sessionConnected: true,
+    });
+    assert.strictEqual(refreshes, 3);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Scan dependencies");
+
+    const staleChild = { getChildren: () => ["private result"] };
+    connectionManager.update({
+      status: "indeterminate",
+      credentialPresent: null,
+      sessionConnected: false,
+      error: { message: "SecretStorage csa_secret" },
+    });
+    assert.deepStrictEqual(await provider.getChildren(staleChild), []);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Could not check the connection");
+    assert.strictEqual(JSON.stringify(item).includes("csa_secret"), false);
+
+    provider.dispose();
+    connectionManager.update({ status: "disposed" });
+    assert.strictEqual(refreshes, 4);
+    assert.deepStrictEqual(await provider.getChildren(), []);
   });
 
   test("_performScan projects canonical adapter records into the compatibility tree", async () => {

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -611,6 +611,196 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.deepStrictEqual(diagnostics.current, []);
   });
 
+  test("connected Account B cannot inherit Account A dependency health results", async () => {
+    let accountEpoch = 1;
+    const listeners = new Set();
+    const contextReset = deferred();
+    let holdContexts = false;
+    const connectionManager = {
+      getState() {
+        return Object.freeze({
+          activationId: "dependency-account-switch",
+          accountEpoch,
+          credentialPresent: true,
+          sessionConnected: true,
+          status: "connected",
+        });
+      },
+      onDidChange(listener) {
+        listeners.add(listener);
+        return { dispose() { listeners.delete(listener); } };
+      },
+      updateEpoch(nextEpoch) {
+        accountEpoch = nextEpoch;
+        const state = this.getState();
+        for (const listener of listeners) listener(state);
+      },
+    };
+    const diagnostics = createDiagnosticsPublisher();
+    const provider = new DependencyHealthProvider(createContext(), diagnostics, {
+      connectionManager,
+      accountResetOrchestrated: true,
+      executeCommand: async () => {
+        if (holdContexts) await contextReset.promise;
+      },
+    });
+    installScanSteps(provider, [{ name: "account-a-result" }, { name: "account-b-result" }]);
+    await provider.scan("workspace-a", "repo-a", "/project-a");
+    assert.strictEqual(provider.dependencies[0].name, "account-a-result");
+
+    holdContexts = true;
+    connectionManager.updateEpoch(2);
+    assert.deepStrictEqual(provider.dependencies, []);
+    assert.strictEqual(provider.hasSuccessfulScan(), false);
+    assert.strictEqual(
+      (await provider.getChildren())[0].getTreeItem().label,
+      "Connecting to Cloudsmith..."
+    );
+    const reset = provider.resetForAccountChange(connectionManager.getState());
+    contextReset.resolve();
+    await reset;
+    assert.strictEqual((await provider.getChildren())[0].getTreeItem().label, "Scan dependencies");
+
+    await provider.scan("workspace-b", "repo-b", "/project-b");
+    assert.strictEqual(provider.dependencies[0].name, "account-b-result");
+    assert.deepStrictEqual(diagnostics.current.dependencies, ["account-b-result"]);
+  });
+
+  test("account-reset context failure releases the pending connection root", async () => {
+    let accountEpoch = 1;
+    let rejectContexts = false;
+    const listeners = new Set();
+    const connectionManager = {
+      getState: () => Object.freeze({
+        activationId: "dependency-context-failure",
+        accountEpoch,
+        credentialPresent: true,
+        sessionConnected: true,
+        status: "connected",
+      }),
+      onDidChange(listener) {
+        listeners.add(listener);
+        return { dispose() { listeners.delete(listener); } };
+      },
+      updateEpoch(nextEpoch) {
+        accountEpoch = nextEpoch;
+        for (const listener of listeners) listener(this.getState());
+      },
+    };
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      connectionManager,
+      accountResetOrchestrated: true,
+      executeCommand: async () => {
+        if (rejectContexts) throw new Error("context projection failed");
+      },
+    });
+    connectionManager.updateEpoch(2);
+    assert.strictEqual(
+      (await provider.getChildren())[0].getTreeItem().label,
+      "Connecting to Cloudsmith..."
+    );
+
+    rejectContexts = true;
+    await assert.rejects(
+      provider.resetForAccountChange(connectionManager.getState()),
+      /context projection failed/
+    );
+    assert.strictEqual((await provider.getChildren())[0].getTreeItem().label, "Scan dependencies");
+  });
+
+  test("stale Account B reset completion cannot mutate pending Account C", async () => {
+    let accountEpoch = 1;
+    const listeners = new Set();
+    const connectionManager = {
+      getState: () => Object.freeze({
+        activationId: "dependency-overlap",
+        accountEpoch,
+        credentialPresent: true,
+        sessionConnected: true,
+        status: "connected",
+      }),
+      onDidChange(listener) {
+        listeners.add(listener);
+        return { dispose() { listeners.delete(listener); } };
+      },
+      updateEpoch(nextEpoch) {
+        accountEpoch = nextEpoch;
+        for (const listener of listeners) listener(this.getState());
+      },
+    };
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      connectionManager,
+      accountResetOrchestrated: true,
+      executeCommand: async () => {},
+    });
+    connectionManager.updateEpoch(2);
+    const accountB = connectionManager.getState();
+    connectionManager.updateEpoch(3);
+    const accountC = connectionManager.getState();
+    const generation = provider._nextScanOperationId;
+
+    await provider.resetForAccountChange(accountB);
+    assert.strictEqual(provider._nextScanOperationId, generation);
+    assert.strictEqual(
+      (await provider.getChildren())[0].getTreeItem().label,
+      "Connecting to Cloudsmith..."
+    );
+
+    await provider.resetForAccountChange(accountC);
+    assert.strictEqual((await provider.getChildren())[0].getTreeItem().label, "Scan dependencies");
+  });
+
+  test("pending account reset blocks stale dependency pull commands", async () => {
+    let accountEpoch = 1;
+    let prepareCalls = 0;
+    let runCalls = 0;
+    const listeners = new Set();
+    const connectionManager = {
+      getState: () => Object.freeze({
+        activationId: "dependency-pull-switch",
+        accountEpoch,
+        credentialPresent: true,
+        sessionConnected: true,
+        status: "connected",
+      }),
+      onDidChange(listener) {
+        listeners.add(listener);
+        return { dispose() { listeners.delete(listener); } };
+      },
+      updateEpoch(nextEpoch) {
+        accountEpoch = nextEpoch;
+        for (const listener of listeners) listener(this.getState());
+      },
+    };
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      connectionManager,
+      accountResetOrchestrated: true,
+      upstreamPullService: {
+        async prepareSingle() { prepareCalls += 1; },
+        async run() { runCalls += 1; },
+      },
+    });
+    provider.lastWorkspace = "workspace-a";
+    provider.lastRepo = "repo-a";
+    provider._fullTrees = [{ dependencies: [createProblemDependency(
+      "account-a-package",
+      "1.0.0",
+      "/project/package.json"
+    )] }];
+    connectionManager.updateEpoch(2);
+
+    await provider.pullSingleDependency({
+      name: "account-a-package",
+      version: "1.0.0",
+      format: "npm",
+      ecosystem: "npm",
+    });
+    await provider.pullDependencies();
+
+    assert.strictEqual(prepareCalls, 0);
+    assert.strictEqual(runCalls, 0);
+  });
+
   test("successful rescan leaves prior results visible while running and replaces them on commit", async () => {
     const diagnostics = createDiagnosticsPublisher();
     const provider = new DependencyHealthProvider(createContext(), diagnostics);

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -91,7 +91,7 @@ suite("Extension Test Suite", () => {
     assert.deepStrictEqual(titleScanCommands, [{
       command: "cloudsmith-vsc.scanDependencies",
       group: "navigation@1",
-      when: "view == cloudsmithDependencyHealthView && !cloudsmith.depOperationRunning",
+      when: "view == cloudsmithDependencyHealthView && cloudsmith.connected && !cloudsmith.depOperationRunning",
     }]);
 
     const changeScopeEntry = manifest.contributes.menus["view/title"].find(
@@ -100,7 +100,30 @@ suite("Extension Test Suite", () => {
     assert.deepStrictEqual(changeScopeEntry, {
       command: "cloudsmith-vsc.changeDependencyScanScope",
       group: "navigation@1.5",
-      when: "view == cloudsmithDependencyHealthView && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning",
+      when: "view == cloudsmithDependencyHealthView && cloudsmith.connected && cloudsmith.depScanSucceeded && !cloudsmith.depOperationRunning",
     });
+  });
+
+  test("connection-sensitive title actions do not infer absence while initializing", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
+    const titleEntries = manifest.contributes.menus["view/title"];
+    const setupCommands = new Set([
+      "cloudsmith-vsc.connectCloudsmith",
+      "cloudsmith-vsc.configureCredentials",
+      "cloudsmith-vsc.ssoLogin",
+    ]);
+    const setupEntries = titleEntries.filter(entry => setupCommands.has(entry.command));
+    assert.strictEqual(setupEntries.length, 3);
+    for (const entry of setupEntries) {
+      assert.match(entry.when, /cloudsmith\.connectionSetupAvailable/);
+      assert.match(entry.when, /!cloudsmith\.connected/);
+    }
+
+    for (const entry of titleEntries.filter(entry => (
+      entry.when?.includes("view == cloudsmithSearchView")
+      || entry.command === "cloudsmith-vsc.scanDependencies"
+    ))) {
+      assert.match(entry.when, /cloudsmith\.connected/);
+    }
   });
 });

--- a/test/searchIntent.test.js
+++ b/test/searchIntent.test.js
@@ -85,6 +85,47 @@ suite("search intent command boundary", () => {
     ]);
   });
 
+  test("account reset finishes every asynchronous invalidator before refreshing Cloudsmith", async () => {
+    const dependencyReset = deferred();
+    const order = [];
+    const accountState = Object.freeze({ activationId: "activation-b", accountEpoch: 2 });
+    const pending = resetAccountScopedState({ globalState: {} }, {
+      workspaceCache: { clear() { order.push("workspace-clear"); } },
+      filterState: { clear() {} },
+      recentPackages: { clear() {} },
+      clearVulnerabilityCache() {},
+      dependencyHealthProvider: {
+        async resetForAccountChange() {
+          order.push("dependency-start");
+          await dependencyReset.promise;
+          order.push("dependency-complete");
+        },
+      },
+      async projectHasMultipleWorkspaces() {
+        order.push("workspace-context");
+      },
+      async evictPersistedUpstreamCaches() {
+        order.push("persisted-cache");
+      },
+      cloudsmithProvider: {
+        completeAccountReset(state) {
+          assert.strictEqual(state, accountState);
+          order.push("cloudsmith-refresh");
+        },
+      },
+      accountState,
+    });
+
+    await Promise.resolve();
+    assert.strictEqual(order.includes("cloudsmith-refresh"), false);
+    dependencyReset.resolve();
+    await pending;
+    assert.ok(order.indexOf("workspace-clear") < order.indexOf("cloudsmith-refresh"));
+    assert.ok(order.indexOf("dependency-complete") < order.indexOf("cloudsmith-refresh"));
+    assert.ok(order.indexOf("workspace-context") < order.indexOf("cloudsmith-refresh"));
+    assert.ok(order.indexOf("persisted-cache") < order.indexOf("cloudsmith-refresh"));
+  });
+
   test("evicts persisted upstream state before account availability is known", async () => {
     const store = new Map([
       ["cloudsmith-upstreams:v3:stale", { version: 3 }],

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -351,7 +351,11 @@ suite("SearchProvider atomic search state", () => {
     });
     const search = provider.search("workspace-a", "slow");
 
-    connectionManager.update({ sessionConnected: false, status: "absent" });
+    connectionManager.update({
+      credentialPresent: false,
+      sessionConnected: false,
+      status: "absent",
+    });
     pending.resolve(page([pkg("stale")]));
     await search;
 
@@ -411,6 +415,7 @@ suite("SearchProvider atomic search state", () => {
   test("does not dispatch a search while disconnected", async () => {
     let fetches = 0;
     const connectionManager = createConnectionManager({
+      credentialPresent: false,
       sessionConnected: false,
       status: "absent",
     });
@@ -1749,15 +1754,75 @@ suite("SearchProvider atomic search state", () => {
   });
 
   test("idle tree derives connection state from the shared manager", async () => {
-    const connectionManager = createConnectionManager({ accountEpoch: 0, sessionConnected: false });
+    const connectionManager = createConnectionManager({
+      accountEpoch: 0,
+      credentialPresent: false,
+      sessionConnected: false,
+      status: "absent",
+    });
     const { provider } = createProvider({ connectionManager });
 
     let nodes = await provider.getChildren();
     assert.strictEqual(nodes[0].getTreeItem().label, "Connect to Cloudsmith");
 
-    connectionManager.update({ accountEpoch: 0, sessionConnected: true });
+    connectionManager.update({
+      accountEpoch: 0,
+      credentialPresent: true,
+      sessionConnected: true,
+      status: "connected",
+    });
     nodes = await provider.getChildren();
     assert.strictEqual(nodes[0].getTreeItem().label, "Search packages across a Cloudsmith workspace");
+  });
+
+  test("projects connection states distinctly and refreshes on terminal resolution", async () => {
+    const connectionManager = createConnectionManager({
+      credentialPresent: null,
+      sessionConnected: false,
+      status: "indeterminate",
+      error: null,
+    });
+    const { provider } = createProvider({ connectionManager });
+    let refreshes = 0;
+    provider.onDidChangeTreeData(() => { refreshes += 1; });
+
+    let item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connecting to Cloudsmith...");
+    assert.strictEqual(item.command, undefined);
+    assert.deepStrictEqual(
+      await provider.getChildren({ getChildren: () => ["private result"] }),
+      []
+    );
+
+    connectionManager.update({ status: "validating", credentialPresent: true });
+    assert.strictEqual(refreshes, 0, "equivalent startup presentation should not refresh twice");
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connecting to Cloudsmith...");
+    assert.strictEqual(JSON.stringify(item).includes("Set up Cloudsmith authentication"), false);
+
+    connectionManager.update({ status: "failed", credentialPresent: true });
+    assert.strictEqual(refreshes, 1);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connection failed");
+
+    connectionManager.update({ status: "absent", credentialPresent: false });
+    assert.strictEqual(refreshes, 2);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Connect to Cloudsmith");
+
+    connectionManager.update({
+      status: "connected",
+      credentialPresent: true,
+      sessionConnected: true,
+    });
+    assert.strictEqual(refreshes, 3);
+    item = (await provider.getChildren())[0].getTreeItem();
+    assert.strictEqual(item.label, "Search packages across a Cloudsmith workspace");
+
+    provider.dispose();
+    connectionManager.update({ status: "disposed", sessionConnected: false });
+    assert.strictEqual(refreshes, 3);
+    assert.deepStrictEqual(await provider.getChildren(), []);
   });
 
   function createProvider(options = {}) {
@@ -1795,8 +1860,10 @@ function createConnectionManager(initial = {}) {
   let state = Object.freeze({
     activationId: "activation-a",
     accountEpoch: 0,
+    credentialPresent: true,
     sessionConnected: true,
     status: "connected",
+    error: null,
     ...initial,
   });
   const listeners = new Set();

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -342,6 +342,25 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.state.pending, null);
   });
 
+  test("connected Account B cannot display Account A committed results", async () => {
+    const connectionManager = createConnectionManager();
+    let resultName = "account-a";
+    const { provider } = createProvider({
+      connectionManager,
+      fetchPage: async () => page([pkg(resultName)]),
+    });
+    await provider.search("workspace-a", "account-a");
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["account-a"]);
+
+    connectionManager.update({ accountEpoch: 1 });
+    assert.strictEqual(provider.state.committed, null);
+    assert.deepStrictEqual(provider.searchResults, []);
+
+    resultName = "account-b";
+    await provider.search("workspace-a", "account-b");
+    assert.deepStrictEqual(provider.searchResults.map(node => node.name), ["account-b"]);
+  });
+
   test("a same-epoch session disconnect aborts and suppresses root publication", async () => {
     const pending = deferred();
     const connectionManager = createConnectionManager();

--- a/test/testInventories.js
+++ b/test/testInventories.js
@@ -1,6 +1,8 @@
 const STANDALONE_NODE_TESTS = Object.freeze([
+  "test/accountOperation.test.js",
   "test/apiEndpoint.test.js",
   "test/collectionIdentity.test.js",
+  "test/connectionPresentation.test.js",
   "test/dependencyAdapterRegistry.test.js",
   "test/dependencyManifestDiscovery.test.js",
   "test/dependencyPolicyEnricher.test.js",

--- a/util/connectionPresentation.js
+++ b/util/connectionPresentation.js
@@ -1,0 +1,68 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+const CONNECTION_PRESENTATIONS = Object.freeze({
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  ABSENT: "absent",
+  FAILED: "failed",
+  UNAVAILABLE: "unavailable",
+  DISPOSED: "disposed",
+});
+
+/**
+ * Derive customer-facing connection presentation from one authoritative state snapshot.
+ * This projection never authorizes account-scoped work.
+ */
+function connectionPresentation(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return CONNECTION_PRESENTATIONS.UNAVAILABLE;
+  }
+
+  const status = state.status;
+  if (status === "disposed") {
+    return CONNECTION_PRESENTATIONS.DISPOSED;
+  }
+
+  const hasAuthorizedAccount = state.sessionConnected === true
+    && typeof state.activationId === "string"
+    && state.activationId.length > 0
+    && Number.isSafeInteger(state.accountEpoch)
+    && state.accountEpoch >= 0
+    && state.credentialPresent !== false;
+  if (hasAuthorizedAccount && (status === "connected" || status === "validating")) {
+    return CONNECTION_PRESENTATIONS.CONNECTED;
+  }
+
+  if (state.sessionConnected === true) {
+    return CONNECTION_PRESENTATIONS.UNAVAILABLE;
+  }
+
+  if (status === "validating") {
+    return CONNECTION_PRESENTATIONS.CONNECTING;
+  }
+  if (status === "indeterminate") {
+    return state.error
+      ? CONNECTION_PRESENTATIONS.UNAVAILABLE
+      : CONNECTION_PRESENTATIONS.CONNECTING;
+  }
+  if (status === "absent" && state.credentialPresent === false) {
+    return CONNECTION_PRESENTATIONS.ABSENT;
+  }
+  if (status === "failed" && state.credentialPresent === true) {
+    return CONNECTION_PRESENTATIONS.FAILED;
+  }
+
+  return CONNECTION_PRESENTATIONS.UNAVAILABLE;
+}
+
+function connectionSetupAvailable(state) {
+  const presentation = connectionPresentation(state);
+  return presentation === CONNECTION_PRESENTATIONS.ABSENT
+    || presentation === CONNECTION_PRESENTATIONS.FAILED;
+}
+
+module.exports = {
+  CONNECTION_PRESENTATIONS,
+  connectionPresentation,
+  connectionSetupAvailable,
+};

--- a/views/cloudsmithProvider.js
+++ b/views/cloudsmithProvider.js
@@ -61,11 +61,33 @@ class CloudsmithProvider {
     this._operationController = null;
     this._repositoryNodes = new Set();
     this._disposed = false;
+    this._accountResetOrchestrated = options.accountResetOrchestrated === true;
+    this._accountIdentity = accountIdentity(this._connectionManager?.getState?.());
+    this._pendingAccountIdentity = null;
     this._connectionPresentation = this._readConnectionPresentation();
     this._connectionSubscription = this._connectionManager?.onDidChange?.(state => {
+      const nextIdentity = accountIdentity(state);
+      const identityChanged = !sameAccountIdentity(nextIdentity, this._accountIdentity);
       const nextPresentation = connectionPresentation(state);
-      if (nextPresentation === this._connectionPresentation) return;
+      const presentationChanged = nextPresentation !== this._connectionPresentation;
+      this._accountIdentity = nextIdentity;
       this._connectionPresentation = nextPresentation;
+      if (identityChanged && this._accountResetOrchestrated) {
+        this._pendingAccountIdentity = nextIdentity;
+        this._invalidateAccountOperations();
+        this._onDidChangeTreeData.fire();
+      }
+      if (identityChanged && !this._accountResetOrchestrated) {
+        this.refresh();
+        return;
+      }
+      if (!presentationChanged) return;
+      if (
+        this._pendingAccountIdentity
+        && nextPresentation === CONNECTION_PRESENTATIONS.CONNECTED
+      ) {
+        return;
+      }
       this.refresh();
     }) || null;
   }
@@ -81,6 +103,7 @@ class CloudsmithProvider {
   getChildren(element) {
     if (this._disposed) return [];
     const connectionNodes = this._connectionRootNodes();
+    if (connectionNodes) this._clearLoading();
     if (!element) {
       if (connectionNodes) {
         if (connectionNodes.length === 0) return connectionNodes;
@@ -104,9 +127,7 @@ class CloudsmithProvider {
     if (options.suppressMissingCredentialsWarning) {
       this._suppressMissingCredentialsWarningOnce = true;
     }
-    this._invalidateRepositoryNodes();
-    this._abortActiveOperation();
-    this._operationId += 1;
+    this._invalidateAccountOperations();
     void this._projectMultipleWorkspaces(
       Boolean(captureAccount(this._connectionManager))
     ).catch(() => {});
@@ -119,6 +140,7 @@ class CloudsmithProvider {
     this._invalidateRepositoryNodes();
     this._abortActiveOperation();
     this._operationId += 1;
+    this._clearLoading();
     this._workspaceCache.clear();
     this._vulnerabilitySummaries.clear();
     this._clearVulnerabilityRefreshTimers();
@@ -167,11 +189,21 @@ class CloudsmithProvider {
     this._operationController = null;
   }
 
+  _invalidateAccountOperations() {
+    this._invalidateRepositoryNodes();
+    this._abortActiveOperation();
+    this._operationId += 1;
+    this._clearLoading();
+  }
+
   _readConnectionPresentation() {
     return connectionPresentation(this._connectionManager?.getState?.());
   }
 
   _connectionRootNodes() {
+    if (this._pendingAccountIdentity) {
+      return [createConnectionStatusNode(CONNECTION_PRESENTATIONS.CONNECTING)];
+    }
     const presentation = this._readConnectionPresentation();
     if (presentation === CONNECTION_PRESENTATIONS.CONNECTED) return null;
     if (presentation === CONNECTION_PRESENTATIONS.DISPOSED) return [];
@@ -197,6 +229,27 @@ class CloudsmithProvider {
     if (this._loadingOperationId !== operation.id) return;
     this._loadingOperationId = null;
     if (this._treeView) this._treeView.message = undefined;
+  }
+
+  _clearLoading() {
+    this._loadingOperationId = null;
+    if (this._treeView) this._treeView.message = undefined;
+  }
+
+  completeAccountReset(expectedState) {
+    if (this._disposed || !this._accountResetOrchestrated) return false;
+    const expectedIdentity = accountIdentity(expectedState);
+    const currentState = this._connectionManager?.getState?.();
+    const currentIdentity = accountIdentity(currentState);
+    if (
+      !sameAccountIdentity(expectedIdentity, currentIdentity)
+      || !sameAccountIdentity(this._pendingAccountIdentity, currentIdentity)
+    ) {
+      return false;
+    }
+    this._pendingAccountIdentity = null;
+    this._onDidChangeTreeData.fire();
+    return connectionPresentation(currentState) === CONNECTION_PRESENTATIONS.CONNECTED;
   }
 
   _projectMultipleWorkspaces(hasMultiple, operation = null) {
@@ -349,7 +402,7 @@ class CloudsmithProvider {
     this._consumeMissingCredentialsWarningSuppression();
     const connectionNodes = this._connectionRootNodes();
     if (connectionNodes) {
-      if (this._treeView) this._treeView.message = undefined;
+      this._clearLoading();
       if (connectionNodes.length > 0) await this._projectMultipleWorkspaces(false);
       return connectionNodes;
     }
@@ -420,7 +473,7 @@ class CloudsmithProvider {
     this._consumeMissingCredentialsWarningSuppression();
     const connectionNodes = this._connectionRootNodes();
     if (connectionNodes) {
-      if (this._treeView) this._treeView.message = undefined;
+      this._clearLoading();
       return connectionNodes;
     }
     const operation = this._beginOperation();
@@ -517,6 +570,31 @@ class CloudsmithProvider {
       "warning"
     );
   }
+}
+
+function accountIdentity(state) {
+  if (
+    !state
+    || typeof state.activationId !== "string"
+    || state.activationId.length === 0
+    || !Number.isSafeInteger(state.accountEpoch)
+    || state.accountEpoch < 0
+  ) {
+    return null;
+  }
+  return Object.freeze({
+    activationId: state.activationId,
+    accountEpoch: state.accountEpoch,
+  });
+}
+
+function sameAccountIdentity(left, right) {
+  return Boolean(
+    left
+    && right
+    && left.activationId === right.activationId
+    && left.accountEpoch === right.accountEpoch
+  ) || (!left && !right);
 }
 
 function vulnerabilityEventIdentity(event) {

--- a/views/cloudsmithProvider.js
+++ b/views/cloudsmithProvider.js
@@ -11,6 +11,11 @@ const {
 } = require("../util/accountOperation");
 const { WorkspaceCache } = require("../util/workspaceCache");
 const InfoNode = require("../models/infoNode");
+const { createConnectionStatusNode } = require("../models/connectionStatusNode");
+const {
+  CONNECTION_PRESENTATIONS,
+  connectionPresentation,
+} = require("../util/connectionPresentation");
 const { WorkspaceInfoNode } = require("../models/workspaceInfoNode");
 const WorkspaceNode = require("../models/workspaceNode");
 const RepositoryNode = require("../models/repositoryNode");
@@ -55,6 +60,14 @@ class CloudsmithProvider {
     this._loadingOperationId = null;
     this._operationController = null;
     this._repositoryNodes = new Set();
+    this._disposed = false;
+    this._connectionPresentation = this._readConnectionPresentation();
+    this._connectionSubscription = this._connectionManager?.onDidChange?.(state => {
+      const nextPresentation = connectionPresentation(state);
+      if (nextPresentation === this._connectionPresentation) return;
+      this._connectionPresentation = nextPresentation;
+      this.refresh();
+    }) || null;
   }
 
   getTreeItem(element) {
@@ -66,7 +79,14 @@ class CloudsmithProvider {
   }
 
   getChildren(element) {
+    if (this._disposed) return [];
+    const connectionNodes = this._connectionRootNodes();
     if (!element) {
+      if (connectionNodes) {
+        if (connectionNodes.length === 0) return connectionNodes;
+        return this._projectMultipleWorkspaces(false)
+          .then(() => connectionNodes, () => connectionNodes);
+      }
       // Root level — check if default workspace is configured
       const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
       const defaultWorkspace = config.get("defaultWorkspace");
@@ -76,6 +96,7 @@ class CloudsmithProvider {
       }
       return this.getWorkspaces();
     }
+    if (connectionNodes) return [];
     return element.getChildren();
   }
 
@@ -93,6 +114,8 @@ class CloudsmithProvider {
   }
 
   dispose() {
+    if (this._disposed) return;
+    this._disposed = true;
     this._invalidateRepositoryNodes();
     this._abortActiveOperation();
     this._operationId += 1;
@@ -100,6 +123,7 @@ class CloudsmithProvider {
     this._vulnerabilitySummaries.clear();
     this._clearVulnerabilityRefreshTimers();
     this._vulnerabilityStateSubscription?.dispose?.();
+    this._connectionSubscription?.dispose?.();
     for (const subscription of this._treeExpansionSubscriptions) subscription.dispose?.();
     this._onDidChangeTreeData.dispose();
   }
@@ -143,15 +167,16 @@ class CloudsmithProvider {
     this._operationController = null;
   }
 
-  _signedOutNode() {
-    return new InfoNode(
-      "Connect to Cloudsmith",
-      "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
-      "Set up Cloudsmith authentication to get started.",
-      "plug",
-      undefined,
-      { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-    );
+  _readConnectionPresentation() {
+    return connectionPresentation(this._connectionManager?.getState?.());
+  }
+
+  _connectionRootNodes() {
+    const presentation = this._readConnectionPresentation();
+    if (presentation === CONNECTION_PRESENTATIONS.CONNECTED) return null;
+    if (presentation === CONNECTION_PRESENTATIONS.DISPOSED) return [];
+    const node = createConnectionStatusNode(presentation);
+    return node ? [node] : [];
   }
 
   _loadFailureNode(kind = "workspaces") {
@@ -320,12 +345,19 @@ class CloudsmithProvider {
   }
 
   async getWorkspaces() {
+    if (this._disposed) return [];
     this._consumeMissingCredentialsWarningSuppression();
+    const connectionNodes = this._connectionRootNodes();
+    if (connectionNodes) {
+      if (this._treeView) this._treeView.message = undefined;
+      if (connectionNodes.length > 0) await this._projectMultipleWorkspaces(false);
+      return connectionNodes;
+    }
     const operation = this._beginOperation();
     if (!operation) {
       if (this._treeView) this._treeView.message = undefined;
       await this._projectMultipleWorkspaces(false);
-      return [this._signedOutNode()];
+      return [createConnectionStatusNode(CONNECTION_PRESENTATIONS.UNAVAILABLE)];
     }
 
     this._startLoading(operation);
@@ -384,11 +416,17 @@ class CloudsmithProvider {
    * @returns {Array} Array of RepositoryNode instances, or empty on error.
    */
   async getRepositories(workspaceSlug) {
+    if (this._disposed) return [];
     this._consumeMissingCredentialsWarningSuppression();
+    const connectionNodes = this._connectionRootNodes();
+    if (connectionNodes) {
+      if (this._treeView) this._treeView.message = undefined;
+      return connectionNodes;
+    }
     const operation = this._beginOperation();
     if (!operation) {
       if (this._treeView) this._treeView.message = undefined;
-      return [this._signedOutNode()];
+      return [createConnectionStatusNode(CONNECTION_PRESENTATIONS.UNAVAILABLE)];
     }
 
     this._startLoading(operation);

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -49,7 +49,12 @@ const DependencyHealthNode = require("../models/dependencyHealthNode");
 const DependencySourceGroupNode = require("../models/dependencySourceGroupNode");
 const DependencySummaryNode = require("../models/dependencySummaryNode");
 const InfoNode = require("../models/infoNode");
+const { createConnectionStatusNode } = require("../models/connectionStatusNode");
 const { getConnectionManager } = require("../util/connectionManager");
+const {
+  CONNECTION_PRESENTATIONS,
+  connectionPresentation,
+} = require("../util/connectionPresentation");
 const { packageCollectionIdentity } = require("../util/collectionIdentity");
 
 const DEFAULT_MAX_DEPENDENCIES_TO_SCAN = 10000;
@@ -164,6 +169,15 @@ class DependencyHealthProvider {
     this._dependencyOperationRunning = false;
     this._scanOperation = createScanOperation(SCAN_STATES.IDLE, 0);
     this._hasSuccessfulScan = false;
+    this._connectionPresentation = connectionPresentation(
+      this._connectionManager?.getState?.()
+    );
+    this._connectionSubscription = this._connectionManager?.onDidChange?.(state => {
+      const nextPresentation = connectionPresentation(state);
+      if (nextPresentation === this._connectionPresentation) return;
+      this._connectionPresentation = nextPresentation;
+      this.refresh();
+    }) || null;
 
     this._updateContexts();
   }
@@ -1824,9 +1838,15 @@ class DependencyHealthProvider {
   }
 
   async getChildren(element) {
-    if (element) {
-      return element.getChildren();
+    if (this._disposed) return [];
+    const presentation = connectionPresentation(this._connectionManager?.getState?.());
+    if (presentation !== CONNECTION_PRESENTATIONS.CONNECTED) {
+      if (element || presentation === CONNECTION_PRESENTATIONS.DISPOSED) return [];
+      const node = createConnectionStatusNode(presentation);
+      return node ? [node] : [];
     }
+
+    if (element) return element.getChildren();
 
     const operationNode = this._getScanOperationNode();
     if (operationNode && !this._hasSuccessfulScan) {
@@ -1874,20 +1894,6 @@ class DependencyHealthProvider {
     }
 
     if (!this._hasSuccessfulScan && this._scanOperation.status === SCAN_STATES.IDLE) {
-      const state = this._connectionManager && this._connectionManager.getState();
-      if (!state || !state.sessionConnected) {
-        return [
-          new InfoNode(
-            "Connect to Cloudsmith",
-            "Use the key icon above to set up authentication.",
-            "Set up Cloudsmith authentication to get started.",
-            "plug",
-            undefined,
-            { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-          ),
-        ];
-      }
-
       return [
         new InfoNode(
           "Scan dependencies",
@@ -2035,6 +2041,7 @@ class DependencyHealthProvider {
     if (this._disposed) return;
     this._disposed = true;
     this._vulnerabilityStateSubscription?.dispose?.();
+    this._connectionSubscription?.dispose?.();
     for (const subscription of this._treeExpansionSubscriptions) subscription.dispose?.();
     this._vulnerabilitySummaries.clear();
     this._clearVulnerabilityRefreshTimers();

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -169,14 +169,30 @@ class DependencyHealthProvider {
     this._dependencyOperationRunning = false;
     this._scanOperation = createScanOperation(SCAN_STATES.IDLE, 0);
     this._hasSuccessfulScan = false;
+    this._accountResetOrchestrated = options.accountResetOrchestrated === true;
+    this._accountIdentity = accountIdentity(this._connectionManager?.getState?.());
+    this._pendingAccountIdentity = null;
     this._connectionPresentation = connectionPresentation(
       this._connectionManager?.getState?.()
     );
     this._connectionSubscription = this._connectionManager?.onDidChange?.(state => {
+      const nextIdentity = accountIdentity(state);
+      const identityChanged = !sameAccountIdentity(nextIdentity, this._accountIdentity);
       const nextPresentation = connectionPresentation(state);
-      if (nextPresentation === this._connectionPresentation) return;
+      const presentationChanged = nextPresentation !== this._connectionPresentation;
+      this._accountIdentity = nextIdentity;
       this._connectionPresentation = nextPresentation;
-      this.refresh();
+      if (identityChanged && this._accountResetOrchestrated) {
+        this._pendingAccountIdentity = nextIdentity;
+        this._invalidateAccountState();
+        this.refresh();
+        return;
+      }
+      if (identityChanged) {
+        void this.resetForAccountChange(state).catch(() => {});
+        return;
+      }
+      if (presentationChanged) this.refresh();
     }) || null;
 
     this._updateContexts();
@@ -274,7 +290,7 @@ class DependencyHealthProvider {
     };
   }
 
-  async resetForAccountChange() {
+  _invalidateAccountState() {
     this._nextScanOperationId += 1;
     if (this._activeScanCancellation) {
       this._activeScanCancellation.cancel();
@@ -299,8 +315,35 @@ class DependencyHealthProvider {
     if (this._diagnosticsPublisher) {
       this._diagnosticsPublisher.clear();
     }
-    await this._updateContexts();
-    this.refresh();
+  }
+
+  async resetForAccountChange(expectedState = null) {
+    const expectedIdentity = accountIdentity(expectedState);
+    if (
+      this._accountResetOrchestrated
+      && !sameAccountIdentity(expectedIdentity, this._pendingAccountIdentity)
+    ) {
+      return;
+    }
+    const alreadyInvalidated = this._accountResetOrchestrated
+      && sameAccountIdentity(expectedIdentity, this._pendingAccountIdentity);
+    if (!alreadyInvalidated) this._invalidateAccountState();
+    try {
+      await this._updateContexts();
+    } finally {
+      if (this._accountResetOrchestrated) {
+        const currentIdentity = accountIdentity(this._connectionManager?.getState?.());
+        if (
+          sameAccountIdentity(expectedIdentity, currentIdentity)
+          && sameAccountIdentity(this._pendingAccountIdentity, currentIdentity)
+        ) {
+          this._pendingAccountIdentity = null;
+          this.refresh();
+        }
+      } else {
+        this.refresh();
+      }
+    }
   }
 
   async setViewMode(mode) {
@@ -467,6 +510,7 @@ class DependencyHealthProvider {
 
   async scan(cloudsmithWorkspace, cloudsmithRepo, projectFolder) {
     if (this._disposed) return { status: "blocked" };
+    if (this._pendingAccountIdentity) return { status: "blocked" };
     if (this._dependencyOperationRunning) {
       this._userInteraction.showWarningMessage("Wait for the current dependency operation to finish.");
       return { status: "blocked" };
@@ -1453,6 +1497,7 @@ class DependencyHealthProvider {
 
   async pullDependencies() {
     if (this._disposed) return;
+    if (this._pendingAccountIdentity) return;
     if (this.isScanRunning() || this._dependencyOperationRunning) {
       this._userInteraction.showWarningMessage("Wait for the current dependency operation to finish.");
       return;
@@ -1559,6 +1604,7 @@ class DependencyHealthProvider {
 
   async pullSingleDependency(item) {
     if (this._disposed) return;
+    if (this._pendingAccountIdentity) return;
     if (this.isScanRunning() || this._dependencyOperationRunning) {
       this._userInteraction.showWarningMessage("Wait for the current dependency operation to finish.");
       return;
@@ -1839,6 +1885,10 @@ class DependencyHealthProvider {
 
   async getChildren(element) {
     if (this._disposed) return [];
+    if (this._pendingAccountIdentity) {
+      if (element) return [];
+      return [createConnectionStatusNode(CONNECTION_PRESENTATIONS.CONNECTING)];
+    }
     const presentation = connectionPresentation(this._connectionManager?.getState?.());
     if (presentation !== CONNECTION_PRESENTATIONS.CONNECTED) {
       if (element || presentation === CONNECTION_PRESENTATIONS.DISPOSED) return [];
@@ -2076,6 +2126,31 @@ class DependencyHealthProvider {
     });
     this.dependencies = this._displayTrees.flatMap((tree) => tree.dependencies);
   }
+}
+
+function accountIdentity(state) {
+  if (
+    !state
+    || typeof state.activationId !== "string"
+    || state.activationId.length === 0
+    || !Number.isSafeInteger(state.accountEpoch)
+    || state.accountEpoch < 0
+  ) {
+    return null;
+  }
+  return Object.freeze({
+    activationId: state.activationId,
+    accountEpoch: state.accountEpoch,
+  });
+}
+
+function sameAccountIdentity(left, right) {
+  return Boolean(
+    left
+    && right
+    && left.activationId === right.activationId
+    && left.accountEpoch === right.accountEpoch
+  ) || (!left && !right);
 }
 
 function normalizeRepositoryCollection(value) {

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -7,6 +7,11 @@ const { PaginatedFetch } = require("../util/paginatedFetch");
 const SearchResultNode = require("../models/searchResultNode");
 const LoadMoreNode = require("../models/loadMoreNode");
 const InfoNode = require("../models/infoNode");
+const { createConnectionStatusNode } = require("../models/connectionStatusNode");
+const {
+    CONNECTION_PRESENTATIONS,
+    connectionPresentation,
+} = require("../util/connectionPresentation");
 const { formatApiError } = require("../util/errorFormatter");
 const {
     getPackagePolicyFlags,
@@ -78,15 +83,21 @@ class SearchProvider {
         this._activePage = null;
         this._disposed = false;
         this._account = this._readConnectedAccount();
+        this._connectionPresentation = connectionPresentation(
+            this.connectionManager.getState?.()
+        );
 
         this._connectionSubscription = this.connectionManager.onDidChange?.(state => {
             const nextAccount = normalizeConnectedAccount(state);
+            const nextPresentation = connectionPresentation(state);
+            const presentationChanged = nextPresentation !== this._connectionPresentation;
+            this._connectionPresentation = nextPresentation;
             if ((nextAccount || this._account) && !sameAccount(nextAccount, this._account)) {
                 this._account = nextAccount;
                 this.clear();
                 return;
             }
-            this.refresh();
+            if (presentationChanged) this.refresh();
         });
     }
 
@@ -945,20 +956,20 @@ class SearchProvider {
     }
 
     async getChildren(element) {
-        if (element) {
-            return element.getChildren();
+        if (this._disposed) return [];
+        const connectionState = this.connectionManager.getState?.();
+        const presentation = connectionPresentation(connectionState);
+        if (presentation !== CONNECTION_PRESENTATIONS.CONNECTED) {
+            if (element || presentation === CONNECTION_PRESENTATIONS.DISPOSED) return [];
+            const node = createConnectionStatusNode(presentation);
+            return node ? [node] : [];
         }
 
-        const account = this._readConnectedAccount();
+        if (element) return element.getChildren();
+
+        const account = normalizeConnectedAccount(connectionState);
         if (!account) {
-            return [new InfoNode(
-                "Connect to Cloudsmith",
-                "Use the key icon above to set up a personal or service account API key, CLI import, or SSO.",
-                "Set up Cloudsmith authentication to get started.",
-                "plug",
-                undefined,
-                { command: "cloudsmith-vsc.configureCredentials", title: "Set up authentication" }
-            )];
+            return [createConnectionStatusNode(CONNECTION_PRESENTATIONS.UNAVAILABLE)];
         }
         const committed = this._currentCommitted(account);
         const pending = sameAccount(account, this._state.pending) ? this._state.pending : null;
@@ -1533,7 +1544,8 @@ function disconnectedConnectionManager() {
             activationId: null,
             accountEpoch: 0,
             sessionConnected: false,
-            status: "absent",
+            credentialPresent: null,
+            status: "indeterminate",
         }),
         onDidChange: () => Object.freeze({ dispose() {} }),
     });


### PR DESCRIPTION
## Summary

- Show truthful initializing, connected, absent, failed, and unavailable authentication states across Cloudsmith views.
- Invalidate account-scoped trees synchronously and release refetches only after identity resets complete.
- Clear superseded loading ownership and block stale dependency actions during account transitions.

## Validation

- `npm run lint` - passed
- `npm test` - passed (737 tests)
- `npm run check` - passed
- `git diff --check` - passed
- `npm audit --omit=dev` - passed
- `npm run audit:runtime` - passed
- `npm run audit:dev` - passed
- `npm run package` - passed
- `npm run package:verify` - passed
- Existing authenticated startup, reload, and repository loading verified in the Extension Development Host.