### PR TITLE
perf: reduce npm dependency graph traversal

### DIFF
--- a/test/dependencyAdapterRegistry.test.js
+++ b/test/dependencyAdapterRegistry.test.js
@@ -338,6 +338,11 @@ suite("dependencyAdapterRegistry", () => {
     assert.strictEqual(express.sourceManifest.filePath, manifestPath);
     assert.strictEqual(express.resolutionSource.kind, RESOLUTION_SOURCE_KINDS.LOCKFILE);
     assert.strictEqual(express.resolutionSource.filePath, lockfilePath);
+    assert.ok(result.dependencyGraph);
+    assert.strictEqual(result.dependencyGraph.kind, "package-lock");
+    assert.ok(result.dependencyGraph.entries.length > result.dependencies.length);
+    assert.strictEqual(result.dependencyGraph.maxEdges, 500000);
+    assert.deepStrictEqual(express.transitives, []);
   });
 
   test("classifies npm partial and wildcard declarations as ranges", async () => {

--- a/test/lockfileParsers/npmParser.test.js
+++ b/test/lockfileParsers/npmParser.test.js
@@ -19,6 +19,33 @@ suite("npmParser Test Suite", () => {
     return workspace;
   }
 
+  async function resolveGeneratedPackageLock(manifest, packages, options = {}) {
+    const workspace = await createWorkspace();
+    const manifestPath = path.join(workspace, "package.json");
+    const lockfilePath = path.join(workspace, "package-lock.json");
+    let metrics = null;
+
+    await writeTextFile(manifestPath, JSON.stringify(manifest));
+    await writeTextFile(lockfilePath, JSON.stringify({ lockfileVersion: 3, packages }));
+    const tree = await npmParser.resolve({
+      lockfilePath,
+      manifestPath,
+      workspaceFolder: workspace,
+      options: {
+        ...options,
+        onNpmGraphMetrics(snapshot) {
+          metrics = snapshot;
+        },
+      },
+    });
+
+    return { tree, metrics };
+  }
+
+  function dependencyKeys(tree) {
+    return tree.dependencies.map((dependency) => `${dependency.name}@${dependency.version}`);
+  }
+
   suiteTeardown(async () => {
     await Promise.all(tempDirs.map((tempDir) => removeDirectory(tempDir)));
   });
@@ -499,6 +526,291 @@ suite("npmParser Test Suite", () => {
     assert.ok(packageKeys.includes("accepts@1.0.0"));
   });
 
+  test("expands a shared package-lock DAG once per structural occurrence", async () => {
+    const rootCount = 16;
+    const sharedCount = 12;
+    const dependencies = {};
+    const packages = { "": { dependencies } };
+
+    for (let index = 0; index < rootCount; index += 1) {
+      const name = `root-${String(index).padStart(2, "0")}`;
+      dependencies[name] = "1.0.0";
+      packages[`node_modules/${name}`] = {
+        version: "1.0.0",
+        dependencies: { "shared-00": "1.0.0" },
+      };
+    }
+    for (let index = 0; index < sharedCount; index += 1) {
+      const name = `shared-${String(index).padStart(2, "0")}`;
+      const nextName = index + 1 < sharedCount
+        ? `shared-${String(index + 1).padStart(2, "0")}`
+        : null;
+      packages[`node_modules/${name}`] = {
+        version: "1.0.0",
+        ...(nextName ? { dependencies: { [nextName]: "1.0.0" } } : {}),
+      };
+    }
+
+    const { tree, metrics } = await resolveGeneratedPackageLock(
+      { dependencies },
+      packages
+    );
+    const structuralNodes = rootCount + sharedCount;
+    const structuralEdges = rootCount + sharedCount - 1;
+    const lastShared = tree.dependencies.find((dependency) => dependency.name === "shared-11");
+
+    assert.strictEqual(tree.dependencies.length, structuralNodes);
+    assert.strictEqual(tree.dependencies.filter((dependency) => dependency.isDirect).length, rootCount);
+    assert.deepStrictEqual(
+      tree.dependencies.find((dependency) => dependency.name === "shared-00").parentChain,
+      ["root-00"]
+    );
+    assert.strictEqual(lastShared.parentChain.length, sharedCount);
+    assert.strictEqual(lastShared.parentChain[0], "root-00");
+    assert.deepStrictEqual(tree.warnings, []);
+    assert.strictEqual(metrics.indexedOccurrences, structuralNodes);
+    assert.ok(metrics.structuralOccurrencesExpanded <= structuralNodes);
+    assert.strictEqual(metrics.structuralEdgesExamined, structuralEdges);
+    assert.ok(metrics.repeatedOccurrenceEncounters >= rootCount - 1);
+    assert.ok(metrics.dependencyRecordsMaterialized <= structuralNodes + structuralEdges);
+  });
+
+  test("keeps same-version package-lock occurrences structurally distinct by installed path", async () => {
+    const { tree, metrics } = await resolveGeneratedPackageLock({
+      dependencies: { a: "1.0.0", b: "1.0.0" },
+    }, {
+      "": { dependencies: { a: "1.0.0", b: "1.0.0" } },
+      "node_modules/a": { version: "1.0.0", dependencies: { shared: "1.0.0" } },
+      "node_modules/a/node_modules/shared": {
+        version: "1.0.0",
+        dependencies: { "nested-leaf": "1.0.0" },
+      },
+      "node_modules/a/node_modules/nested-leaf": { version: "1.0.0" },
+      "node_modules/b": { version: "1.0.0", dependencies: { shared: "1.0.0" } },
+      "node_modules/shared": {
+        version: "1.0.0",
+        dependencies: { "hoisted-leaf": "1.0.0" },
+      },
+      "node_modules/hoisted-leaf": { version: "1.0.0" },
+    });
+    const a = tree.dependencies.find((dependency) => dependency.name === "a");
+    const b = tree.dependencies.find((dependency) => dependency.name === "b");
+    const shared = tree.dependencies.find((dependency) => dependency.name === "shared");
+
+    assert.deepStrictEqual(new Set(dependencyKeys(tree)), new Set([
+      "a@1.0.0",
+      "b@1.0.0",
+      "shared@1.0.0",
+      "nested-leaf@1.0.0",
+      "hoisted-leaf@1.0.0",
+    ]));
+    assert.deepStrictEqual(shared.parentChain, ["a"]);
+    assert.strictEqual(a.transitives[0].transitives[0].name, "nested-leaf");
+    assert.strictEqual(b.transitives[0].transitives[0].name, "hoisted-leaf");
+    assert.strictEqual(metrics.indexedOccurrences, 6);
+    assert.strictEqual(metrics.structuralOccurrencesExpanded, 6);
+    assert.strictEqual(metrics.structuralEdgesExamined, 4);
+  });
+
+  test("preserves inherited development state on repeated structural references", async () => {
+    const { tree, metrics } = await resolveGeneratedPackageLock({
+      dependencies: { prod: "1.0.0" },
+      devDependencies: { dev: "1.0.0" },
+    }, {
+      "": {
+        dependencies: { prod: "1.0.0" },
+        devDependencies: { dev: "1.0.0" },
+      },
+      "node_modules/prod": { version: "1.0.0", dependencies: { shared: "1.0.0" } },
+      "node_modules/dev": { version: "1.0.0", dev: true, dependencies: { shared: "1.0.0" } },
+      "node_modules/shared": { version: "1.0.0", dependencies: { leaf: "1.0.0" } },
+      "node_modules/leaf": { version: "1.0.0" },
+    });
+    const dev = tree.dependencies.find((dependency) => dependency.name === "dev");
+    const shared = tree.dependencies.find((dependency) => dependency.name === "shared");
+    const leaf = tree.dependencies.find((dependency) => dependency.name === "leaf");
+
+    assert.strictEqual(dev.isDirect, true);
+    assert.strictEqual(dev.isDevelopmentDependency, true);
+    assert.strictEqual(dev.transitives[0].name, "shared");
+    assert.strictEqual(dev.transitives[0].isDevelopmentDependency, true);
+    assert.strictEqual(shared.isDevelopmentDependency, false);
+    assert.strictEqual(leaf.isDevelopmentDependency, false);
+    assert.deepStrictEqual(shared.parentChain, ["prod"]);
+    assert.strictEqual(metrics.structuralOccurrencesExpanded, 4);
+    assert.strictEqual(metrics.repeatedOccurrenceEncounters, 1);
+  });
+
+  test("terminates package-lock cycles without dropping acyclic siblings", async () => {
+    const cases = [
+      {
+        manifest: { dependencies: { self: "1.0.0" } },
+        packages: {
+          "": { dependencies: { self: "1.0.0" } },
+          "node_modules/self": { version: "1.0.0", dependencies: { self: "1.0.0" } },
+        },
+        keys: ["self@1.0.0"],
+        chains: { self: [] },
+      },
+      {
+        manifest: { dependencies: { a: "1.0.0" } },
+        packages: {
+          "": { dependencies: { a: "1.0.0" } },
+          "node_modules/a": { version: "1.0.0", dependencies: { b: "1.0.0" } },
+          "node_modules/b": { version: "1.0.0", dependencies: { a: "1.0.0" } },
+        },
+        keys: ["a@1.0.0", "b@1.0.0"],
+        chains: { a: [], b: ["a"] },
+      },
+      {
+        manifest: { dependencies: { a: "1.0.0" } },
+        packages: {
+          "": { dependencies: { a: "1.0.0" } },
+          "node_modules/a": { version: "1.0.0", dependencies: { b: "1.0.0" } },
+          "node_modules/b": { version: "1.0.0", dependencies: { c: "1.0.0" } },
+          "node_modules/c": {
+            version: "1.0.0",
+            dependencies: { a: "1.0.0", tail: "1.0.0" },
+          },
+          "node_modules/tail": { version: "1.0.0" },
+        },
+        keys: ["a@1.0.0", "b@1.0.0", "c@1.0.0", "tail@1.0.0"],
+        chains: { a: [], b: ["a"], c: ["a", "b"], tail: ["a", "b", "c"] },
+      },
+    ];
+
+    for (const fixture of cases) {
+      const { tree, metrics } = await resolveGeneratedPackageLock(
+        fixture.manifest,
+        fixture.packages
+      );
+      assert.deepStrictEqual(new Set(dependencyKeys(tree)), new Set(fixture.keys));
+      for (const [name, parentChain] of Object.entries(fixture.chains)) {
+        assert.deepStrictEqual(
+          tree.dependencies.find((dependency) => dependency.name === name).parentChain,
+          parentChain
+        );
+      }
+      assert.strictEqual(metrics.cycleEdgesSkipped, 1);
+      assert.deepStrictEqual(tree.warnings, []);
+    }
+  });
+
+  test("keeps direct representatives free of transitive parent chains", async () => {
+    const { tree } = await resolveGeneratedPackageLock({
+      dependencies: { direct: "1.0.0", root: "1.0.0" },
+    }, {
+      "": { dependencies: { direct: "1.0.0", root: "1.0.0" } },
+      "node_modules/direct": { version: "1.0.0" },
+      "node_modules/root": { version: "1.0.0", dependencies: { shared: "1.0.0" } },
+      "node_modules/shared": { version: "1.0.0", dependencies: { direct: "1.0.0" } },
+    });
+    const direct = tree.dependencies.find((dependency) => dependency.name === "direct");
+
+    assert.strictEqual(direct.isDirect, true);
+    assert.strictEqual(direct.parent, null);
+    assert.deepStrictEqual(direct.parentChain, []);
+  });
+
+  test("supports lower-only package-lock depth and node bounds with semantic warnings", async () => {
+    const createChain = (count) => {
+      const packages = { "": { dependencies: { "bound-00": "1.0.0" } } };
+      for (let index = 0; index < count; index += 1) {
+        const name = `bound-${String(index).padStart(2, "0")}`;
+        const nextName = index + 1 < count
+          ? `bound-${String(index + 1).padStart(2, "0")}`
+          : null;
+        packages[`node_modules/${name}`] = {
+          version: "1.0.0",
+          ...(nextName ? { dependencies: { [nextName]: "1.0.0" } } : {}),
+        };
+      }
+      return packages;
+    };
+    const manifest = { dependencies: { "bound-00": "1.0.0" } };
+    const depthResult = await resolveGeneratedPackageLock(manifest, createChain(12), {
+      npmGraphMaxDepth: 4,
+    });
+
+    assert.strictEqual(depthResult.tree.dependencies.length, 12);
+    assert.deepStrictEqual(depthResult.tree.warnings, [
+      "Some dependency relationships could not be fully analyzed.",
+    ]);
+    assert.strictEqual(depthResult.metrics.maxDepth, 4);
+    assert.strictEqual(depthResult.metrics.depthLimitReached, true);
+    assert.strictEqual(depthResult.metrics.nodeLimitReached, false);
+    assert.ok(Math.max(...depthResult.tree.dependencies.map(
+      (dependency) => dependency.parentChain.length
+    )) <= 4);
+
+    const nodeResult = await resolveGeneratedPackageLock(manifest, createChain(8), {
+      npmGraphMaxNodes: 6,
+    });
+    assert.strictEqual(nodeResult.tree.dependencies.length, 8);
+    assert.deepStrictEqual(nodeResult.tree.warnings, [
+      "Some dependency relationships could not be fully analyzed.",
+    ]);
+    assert.strictEqual(nodeResult.metrics.maxNodes, 6);
+    assert.strictEqual(nodeResult.metrics.nodeLimitReached, true);
+
+    const clampedResult = await resolveGeneratedPackageLock(manifest, createChain(1), {
+      npmGraphMaxDepth: Number.MAX_SAFE_INTEGER,
+      npmGraphMaxNodes: Number.MAX_SAFE_INTEGER,
+    });
+    assert.strictEqual(clampedResult.metrics.maxDepth, 128);
+    assert.strictEqual(clampedResult.metrics.maxNodes, 50000);
+    assert.strictEqual(clampedResult.metrics.maxEdges, 500000);
+    assert.deepStrictEqual(clampedResult.tree.warnings, []);
+  });
+
+  test("retains late direct roots when relationship materialization reaches its bound", async () => {
+    const { tree } = await resolveGeneratedPackageLock({
+      dependencies: { first: "1.0.0", second: "1.0.0" },
+    }, {
+      "": { dependencies: { first: "1.0.0", second: "1.0.0" } },
+      "node_modules/first": { version: "1.0.0", dependencies: { child: "1.0.0" } },
+      "node_modules/child": { version: "1.0.0" },
+      "node_modules/second": { version: "1.0.0" },
+    }, {
+      npmGraphMaxNodes: 1,
+    });
+    const second = tree.dependencies.find((dependency) => dependency.name === "second");
+    const secondRoot = tree.dependencyGraph.roots.find((root) => root.declaredName === "second");
+
+    assert.ok(second);
+    assert.strictEqual(second.isDirect, true);
+    assert.deepStrictEqual(second.parentChain, []);
+    assert.strictEqual(secondRoot.entryKey, "node_modules/second");
+    assert.ok(!tree.dependencyGraph.entries.some((entry) => entry.key === secondRoot.entryKey));
+    assert.ok(tree.warnings.includes("Some dependency relationships could not be fully analyzed."));
+  });
+
+  test("bounds structural edge discovery before adapting the graph", async () => {
+    const dependencies = {};
+    const packages = {
+      "": { dependencies: { root: "1.0.0" } },
+      "node_modules/root": { version: "1.0.0", dependencies },
+    };
+    for (let index = 0; index < 5; index += 1) {
+      const name = `edge-${index}`;
+      dependencies[name] = "1.0.0";
+      packages[`node_modules/${name}`] = { version: "1.0.0" };
+    }
+
+    const { tree, metrics } = await resolveGeneratedPackageLock(
+      { dependencies: { root: "1.0.0" } },
+      packages,
+      { npmGraphMaxEdges: 2 }
+    );
+
+    assert.strictEqual(tree.dependencies.length, 6);
+    assert.strictEqual(tree.dependencyGraph.entries.flatMap((entry) => entry.edges).length, 2);
+    assert.strictEqual(metrics.structuralEdgesExamined, 2);
+    assert.strictEqual(metrics.edgeLimitReached, true);
+    assert.strictEqual(metrics.maxEdges, 2);
+    assert.ok(tree.warnings.includes("Some dependency relationships could not be fully analyzed."));
+  });
+
   test("bounds package-lock dependency graph expansion by depth", async () => {
     const workspace = await createWorkspace();
     const lockfilePath = path.join(workspace, "package-lock.json");
@@ -527,7 +839,7 @@ suite("npmParser Test Suite", () => {
       options: { maxDependenciesToScan: 10000 },
     });
 
-    assert.ok(tree.warnings.some((warning) => /graph expansion reached its bounded limit/.test(warning)));
+    assert.ok(tree.warnings.includes("Some dependency relationships could not be fully analyzed."));
     assert.ok(Math.max(...tree.dependencies.map((dependency) => dependency.parentChain.length)) <= 128);
   });
 });

--- a/test/treeVisualization.test.js
+++ b/test/treeVisualization.test.js
@@ -127,6 +127,67 @@ suite("tree visualization", () => {
     };
   }
 
+  function createStructuralTree() {
+    const tree = createTree();
+    const shared = tree.dependencies.find((dependency) => dependency.name === "shared-lib");
+    const leaf = {
+      ...shared,
+      name: "vulnerable-leaf",
+      normalizedName: "vulnerable-leaf",
+      parent: "shared-lib",
+      parentChain: ["alpha", "shared-lib"],
+      cloudsmithPackage: createFoundPackage("vulnerable-leaf"),
+    };
+    tree.dependencies = tree.dependencies.map((dependency) => ({
+      ...dependency,
+      transitives: [],
+    }));
+    tree.dependencies.push(leaf);
+    tree.dependencyGraph = Object.freeze({
+      kind: "package-lock",
+      incomplete: false,
+      roots: Object.freeze([
+        Object.freeze({ declaredName: "beta", entryKey: "node_modules/beta", isDevelopmentDependency: false }),
+        Object.freeze({ declaredName: "alpha", entryKey: "node_modules/alpha", isDevelopmentDependency: false }),
+      ]),
+      entries: Object.freeze([
+        Object.freeze({
+          key: "node_modules/beta",
+          name: "beta",
+          installedName: "beta",
+          version: "3.0.0",
+          isDevelopmentDependency: false,
+          edges: Object.freeze([Object.freeze({ declaredName: "shared-lib", childKey: "node_modules/shared-lib" })]),
+        }),
+        Object.freeze({
+          key: "node_modules/alpha",
+          name: "alpha",
+          installedName: "alpha",
+          version: "2.0.0",
+          isDevelopmentDependency: false,
+          edges: Object.freeze([Object.freeze({ declaredName: "shared-lib", childKey: "node_modules/shared-lib" })]),
+        }),
+        Object.freeze({
+          key: "node_modules/shared-lib",
+          name: "shared-lib",
+          installedName: "shared-lib",
+          version: "1.0.0",
+          isDevelopmentDependency: false,
+          edges: Object.freeze([Object.freeze({ declaredName: "vulnerable-leaf", childKey: "node_modules/vulnerable-leaf" })]),
+        }),
+        Object.freeze({
+          key: "node_modules/vulnerable-leaf",
+          name: "vulnerable-leaf",
+          installedName: "vulnerable-leaf",
+          version: "1.0.0",
+          isDevelopmentDependency: false,
+          edges: Object.freeze([]),
+        }),
+      ]),
+    });
+    return tree;
+  }
+
   test("tree mode expands direct dependencies and collapses duplicate diamonds", () => {
     const provider = new DependencyHealthProvider(createContext(), null);
     const tree = createTree();
@@ -167,6 +228,174 @@ suite("tree visualization", () => {
     assert.strictEqual(rootNodes[0].name, "alpha");
     assert.match(rootNodes[0].getTreeItem().description, /context/);
     assert.strictEqual(rootNodes[0].getChildren()[0].name, "shared-lib");
+  });
+
+  test("structural graph expands the first UI-sorted occurrence rather than parser order", () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const tree = createStructuralTree();
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+
+    assert.deepStrictEqual(roots.map((root) => root.name), ["alpha", "beta"]);
+    const alphaShared = roots[0].getChildren()[0];
+    assert.strictEqual(alphaShared.name, "shared-lib");
+    assert.strictEqual(alphaShared.getChildren()[0].name, "vulnerable-leaf");
+    const betaShared = roots[1].getChildren()[0];
+    assert.match(betaShared.getTreeItem().description, /see first occurrence/);
+  });
+
+  test("structural graph filtering retains every parent path to a shared match", async () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const tree = createStructuralTree();
+    provider._viewMode = "tree";
+    await provider.setFilterMode(FILTER_MODES.VULNERABLE);
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+
+    assert.deepStrictEqual(roots.map((root) => root.name), ["alpha", "beta"]);
+    assert.strictEqual(roots[0].getChildren()[0].getChildren()[0].name, "vulnerable-leaf");
+    assert.match(roots[1].getChildren()[0].getTreeItem().description, /see first occurrence/);
+  });
+
+  test("structural tree cannot render packages removed by the display cap", () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const tree = createStructuralTree();
+    tree.dependencies = tree.dependencies.filter(
+      (dependency) => dependency.name !== "vulnerable-leaf"
+    );
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+
+    assert.deepStrictEqual(roots.map((root) => root.name), ["alpha", "beta"]);
+    assert.deepStrictEqual(roots[0].getChildren()[0].getChildren(), []);
+  });
+
+  test("unresolved structural edges do not borrow enriched direct-package status", () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const directFoo = {
+      ...createTree().dependencies.find((dependency) => dependency.name === "alpha"),
+      name: "foo",
+      normalizedName: "foo",
+      declarationName: "foo",
+      version: "1.0.0",
+      resolvedVersion: "1.0.0",
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: createFoundPackage("foo"),
+      vulnerabilities: { count: 1, maxSeverity: "High" },
+    };
+    const alpha = {
+      ...createTree().dependencies.find((dependency) => dependency.name === "alpha"),
+      transitives: [],
+    };
+    const tree = {
+      ecosystem: "npm",
+      sourceFile: "package-lock.json",
+      warnings: [],
+      dependencies: [alpha, directFoo],
+      dependencyGraph: {
+        kind: "package-lock",
+        incomplete: false,
+        maxDepth: 128,
+        maxNodes: 50000,
+        roots: [
+          { declaredName: "alpha", entryKey: "node_modules/alpha", isDevelopmentDependency: false },
+          { declaredName: "foo", entryKey: "node_modules/foo", isDevelopmentDependency: false },
+        ],
+        entries: [
+          {
+            key: "node_modules/alpha",
+            name: "alpha",
+            installedName: "alpha",
+            version: "2.0.0",
+            isDevelopmentDependency: false,
+            edges: [{ declaredName: "foo", childKey: null }],
+          },
+          {
+            key: "node_modules/foo",
+            name: "foo",
+            installedName: "foo",
+            version: "1.0.0",
+            isDevelopmentDependency: false,
+            edges: [],
+          },
+        ],
+      },
+    };
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+    const unresolvedFoo = roots[0].getChildren()[0];
+
+    assert.strictEqual(unresolvedFoo.name, "foo");
+    assert.strictEqual(unresolvedFoo.resolvedVersion, null);
+    assert.strictEqual(unresolvedFoo.cloudsmithStatus, null);
+    assert.strictEqual(unresolvedFoo.vulnerabilities, null);
+    assert.strictEqual(roots[1].cloudsmithStatus, "FOUND");
+  });
+
+  test("resolved direct roots omitted from bounded adjacency remain resolved leaves", () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const direct = {
+      ...createTree().dependencies.find((dependency) => dependency.name === "alpha"),
+      resolvedVersion: "2.0.0",
+      versionState: "resolved",
+      transitives: [],
+    };
+    const tree = {
+      ecosystem: "npm",
+      sourceFile: "package-lock.json",
+      warnings: [],
+      dependencies: [direct],
+      dependencyGraph: {
+        kind: "package-lock",
+        incomplete: true,
+        maxDepth: 128,
+        maxNodes: 1,
+        roots: [{
+          declaredName: "alpha",
+          entryKey: "node_modules/alpha",
+          isDevelopmentDependency: false,
+        }],
+        entries: [],
+      },
+    };
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+
+    assert.strictEqual(roots.length, 1);
+    assert.strictEqual(roots[0].name, "alpha");
+    assert.strictEqual(roots[0].resolvedVersion, "2.0.0");
+    assert.deepStrictEqual(roots[0].getChildren(), []);
+  });
+
+  test("structural presentation bounds add a customer-visible warning", async () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const tree = createStructuralTree();
+    tree.dependencyGraph = { ...tree.dependencyGraph, maxDepth: 1, maxNodes: 50000 };
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+    await Promise.resolve();
+
+    assert.deepStrictEqual(roots[0].getChildren()[0].getChildren(), []);
+    assert.ok(provider._warnings.some((warning) => /could not be displayed/.test(warning)));
+  });
+
+  test("structural node-count exhaustion adds the same customer-visible warning", async () => {
+    const provider = new DependencyHealthProvider(createContext(), null);
+    const tree = createStructuralTree();
+    tree.dependencyGraph = { ...tree.dependencyGraph, maxDepth: 128, maxNodes: 1 };
+    provider._viewMode = "tree";
+
+    const roots = provider.buildDependencyNodesForTree(tree);
+    await Promise.resolve();
+
+    assert.strictEqual(roots.length, 1);
+    assert.deepStrictEqual(roots[0].getChildren(), []);
+    assert.ok(provider._warnings.some((warning) => /could not be displayed/.test(warning)));
   });
 
   test("dependency health report includes vulnerability and upstream sections", () => {

--- a/util/dependencyAdapterRegistry.js
+++ b/util/dependencyAdapterRegistry.js
@@ -26,6 +26,8 @@ const ADAPTER_RESULT_STATUSES = Object.freeze({
   UNSUPPORTED: "unsupported",
 });
 const ADAPTER_RESULT_STATUS_VALUES = new Set(Object.values(ADAPTER_RESULT_STATUSES));
+const MAX_STRUCTURAL_GRAPH_ENTRIES = 50000;
+const MAX_STRUCTURAL_GRAPH_EDGES = 500000;
 
 const RESOLUTION_AVAILABILITY = Object.freeze({
   AVAILABLE: "available",
@@ -319,13 +321,15 @@ function createResolverAdapter(resolver) {
           resolver.ecosystem,
           safeDetection.workspaceFolder
         );
+        const dependencyGraph = adaptPackageLockGraph(legacyTree && legacyTree.dependencyGraph);
         const dependencies = (legacyTree && legacyTree.dependencies || []).map((dependency) => (
           adaptLegacyDependency(
             dependency,
             legacyTree,
             sources,
             declaredConstraints,
-            safeDetection.workspaceFolder
+            safeDetection.workspaceFolder,
+            Boolean(dependencyGraph)
           )
         ));
         const warnings = Array.isArray(legacyTree && legacyTree.warnings)
@@ -341,6 +345,7 @@ function createResolverAdapter(resolver) {
           sourceFile: legacyTree && legacyTree.sourceFile || safeDetection.sourceFile,
           source: sources,
           dependencies,
+          dependencyGraph,
           warnings,
           resolutionAvailability: sources.resolution
             ? RESOLUTION_AVAILABILITY.AVAILABLE
@@ -596,7 +601,14 @@ async function readDeclaredConstraintIndex(sourceManifest, ecosystem, workspaceF
   return index;
 }
 
-function adaptLegacyDependency(dependency, tree, sources, declaredConstraints, workspaceFolder) {
+function adaptLegacyDependency(
+  dependency,
+  tree,
+  sources,
+  declaredConstraints,
+  workspaceFolder,
+  omitTransitives = false
+) {
   const ecosystem = dependency.ecosystem || tree.ecosystem;
   const format = dependency.format || canonicalFormat(ecosystem);
   const name = String(dependency.name || "").trim();
@@ -630,13 +642,14 @@ function adaptLegacyDependency(dependency, tree, sources, declaredConstraints, w
   } else if (resolvedVersion) {
     versionState = DEPENDENCY_VERSION_STATES.RESOLVED;
   }
-  const transitives = Array.isArray(dependency.transitives)
+  const transitives = !omitTransitives && Array.isArray(dependency.transitives)
     ? dependency.transitives.map((child) => adaptLegacyDependency(
       child,
       tree,
       sources,
       declaredConstraints,
-      workspaceFolder
+      workspaceFolder,
+      false
     ))
     : [];
   const sourceManifest = dependency.isDirect
@@ -661,6 +674,96 @@ function adaptLegacyDependency(dependency, tree, sources, declaredConstraints, w
     transitives,
     legacyVersion: dependency.version,
   });
+}
+
+function adaptPackageLockGraph(graph) {
+  if (graph == null) {
+    return null;
+  }
+  if (!graph || typeof graph !== "object" || Array.isArray(graph) || graph.kind !== "package-lock") {
+    throw new TypeError("Package-lock structural graph must use the package-lock contract.");
+  }
+  if (!Array.isArray(graph.entries) || graph.entries.length > MAX_STRUCTURAL_GRAPH_ENTRIES) {
+    throw new TypeError("Package-lock structural graph entries exceed the supported bound.");
+  }
+  if (!Array.isArray(graph.roots) || graph.roots.length > MAX_STRUCTURAL_GRAPH_ENTRIES) {
+    throw new TypeError("Package-lock structural graph roots exceed the supported bound.");
+  }
+
+  const keys = new Set();
+  let edgeCount = 0;
+  const entries = graph.entries.map((entry) => {
+    const key = requiredGraphString(entry && entry.key, "entry key");
+    if (keys.has(key)) {
+      throw new TypeError("Package-lock structural graph entry keys must be unique.");
+    }
+    keys.add(key);
+    if (!Array.isArray(entry.edges)) {
+      throw new TypeError("Package-lock structural graph entry edges must be an array.");
+    }
+    edgeCount += entry.edges.length;
+    if (edgeCount > MAX_STRUCTURAL_GRAPH_EDGES) {
+      throw new TypeError("Package-lock structural graph edges exceed the supported bound.");
+    }
+    return Object.freeze({
+      key,
+      name: requiredGraphString(entry.name, "package name"),
+      installedName: requiredGraphString(entry.installedName, "installed name"),
+      version: requiredGraphString(entry.version, "package version"),
+      isDevelopmentDependency: entry.isDevelopmentDependency === true,
+      edges: Object.freeze(entry.edges.map((edge) => Object.freeze({
+        declaredName: requiredGraphString(edge && edge.declaredName, "dependency name"),
+        childKey: edge && edge.childKey == null
+          ? null
+          : requiredGraphString(edge.childKey, "child key"),
+      }))),
+    });
+  });
+
+  const roots = graph.roots.map((root) => Object.freeze({
+    declaredName: requiredGraphString(root && root.declaredName, "root dependency name"),
+    entryKey: root && root.entryKey == null
+      ? null
+      : requiredGraphString(root.entryKey, "root entry key"),
+    isDevelopmentDependency: root && root.isDevelopmentDependency === true,
+  }));
+  for (const root of roots) {
+    if (root.entryKey && !keys.has(root.entryKey) && graph.incomplete !== true) {
+      throw new TypeError("Complete package-lock structural graph roots must reference known entries.");
+    }
+  }
+  for (const entry of entries) {
+    for (const edge of entry.edges) {
+      if (edge.childKey && !keys.has(edge.childKey) && graph.incomplete !== true) {
+        throw new TypeError("Complete package-lock structural graph edges must reference known entries.");
+      }
+    }
+  }
+
+  return Object.freeze({
+    kind: "package-lock",
+    entries: Object.freeze(entries),
+    roots: Object.freeze(roots),
+    incomplete: graph.incomplete === true,
+    maxDepth: requiredGraphLimit(graph.maxDepth, 128, "depth"),
+    maxNodes: requiredGraphLimit(graph.maxNodes, MAX_STRUCTURAL_GRAPH_ENTRIES, "node"),
+    maxEdges: requiredGraphLimit(graph.maxEdges, MAX_STRUCTURAL_GRAPH_EDGES, "edge"),
+  });
+}
+
+function requiredGraphLimit(value, maximum, label) {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new TypeError(`Package-lock structural graph ${label} limit is invalid.`);
+  }
+  return value;
+}
+
+function requiredGraphString(value, label) {
+  const normalized = String(value || "").trim();
+  if (!normalized || normalized.length > 8192) {
+    throw new TypeError(`Package-lock structural graph ${label} is invalid.`);
+  }
+  return normalized;
 }
 
 function adaptLegacyManifestDependency(dependency, ecosystem, sourceManifest) {
@@ -810,6 +913,7 @@ function createAdapterResult(values) {
     sourceFile: values.sourceFile || null,
     source: values.source || null,
     dependencies: Object.freeze(Array.isArray(values.dependencies) ? values.dependencies.slice() : []),
+    dependencyGraph: values.dependencyGraph || null,
     warnings: Object.freeze(Array.isArray(values.warnings) ? values.warnings.slice() : []),
     error,
     resolutionAvailability: values.resolutionAvailability || RESOLUTION_AVAILABILITY.NOT_APPLICABLE,

--- a/util/lockfileParsers/npmParser.js
+++ b/util/lockfileParsers/npmParser.js
@@ -18,6 +18,7 @@ const { parsePackageJsonManifest } = require("./manifestHelpers");
 const LOCKFILE_NAMES = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml"];
 const MAX_GRAPH_DEPTH = 128;
 const MAX_GRAPH_NODES = 50000;
+const MAX_GRAPH_EDGES = 500000;
 
 const npmParser = {
   name: "npmParser",
@@ -141,14 +142,26 @@ async function parsePackageLock(lockfilePath, manifest, workspaceFolder, options
 
   const directRoots = [];
   const seenDirectKeys = new Set();
-  const traversalState = createGraphTraversalState();
+  const traversalState = createGraphTraversalState(options);
+  const dependencyGraph = buildPackageLockGraph(entriesByPath, directNames, manifest, traversalState);
 
   for (const directName of directNames) {
     const entry = selectPackageLockEntry(entriesByPath, "", directName);
     const dependency = buildNpmDependency(entry, directName, [], entriesByPath, new Set(), {
       sourceFile: getSourceFileName(lockfilePath),
       devNames: manifest.devNames,
-    }, manifest.devNames.has(directName), traversalState);
+    }, manifest.devNames.has(directName), traversalState, true) || createNpmDependency({
+      name: entry ? entry.name : directName,
+      version: entry ? entry.version : "",
+      ecosystem: "npm",
+      isDirect: true,
+      parent: null,
+      parentChain: [],
+      transitives: [],
+      sourceFile: getSourceFileName(lockfilePath),
+      isDevelopmentDependency: manifest.devNames.has(directName)
+        || Boolean(entry && entry.isDevelopmentDependency),
+    }, entry ? entry.installedName : directName);
     const key = npmPackageVersionKey(dependency.name, dependency.version);
     if (!seenDirectKeys.has(key)) {
       seenDirectKeys.add(key);
@@ -185,8 +198,91 @@ async function parsePackageLock(lockfilePath, manifest, workspaceFolder, options
     );
   }
   appendGraphLimitWarning(warnings, traversalState);
+  publishGraphMetrics(options, traversalState, entriesByPath.size, uniqueEntries.size);
 
-  return buildTree("npm", getSourceFileName(lockfilePath), dependencies, warnings);
+  return {
+    ...buildTree("npm", getSourceFileName(lockfilePath), dependencies, warnings),
+    dependencyGraph,
+  };
+}
+
+function buildPackageLockGraph(entriesByPath, directNames, manifest, traversalState) {
+  const graphEntries = [];
+  const includedKeys = new Set();
+  let edgeCount = 0;
+
+  for (const entry of entriesByPath.values()) {
+    if (graphEntries.length >= traversalState.maxNodes) {
+      traversalState.nodeLimitReached = true;
+      traversalState.truncated = true;
+      break;
+    }
+    const edges = [];
+    for (const declaredName in entry.dependencies || {}) {
+      if (!Object.prototype.hasOwnProperty.call(entry.dependencies, declaredName)) {
+        continue;
+      }
+      if (edgeCount >= traversalState.maxEdges) {
+        traversalState.edgeLimitReached = true;
+        traversalState.truncated = true;
+        break;
+      }
+      const child = selectPackageLockEntry(entriesByPath, entry.packagePath, declaredName);
+      traversalState.structuralEdgesExamined += 1;
+      edgeCount += 1;
+      if (child) {
+        traversalState.resolvedEdges += 1;
+      } else {
+        traversalState.unresolvedEdges += 1;
+      }
+      edges.push(Object.freeze({
+        declaredName,
+        childKey: child ? child.key : null,
+      }));
+    }
+    includedKeys.add(entry.key);
+    graphEntries.push(Object.freeze({
+      key: entry.key,
+      name: entry.name,
+      installedName: entry.installedName,
+      version: entry.version,
+      isDevelopmentDependency: entry.isDevelopmentDependency,
+      edges: Object.freeze(edges),
+    }));
+  }
+
+  const roots = [...directNames].map((declaredName) => {
+    const entry = selectPackageLockEntry(entriesByPath, "", declaredName);
+    return Object.freeze({
+      declaredName,
+      // Keep the authoritative occurrence key even when the structural graph
+      // was truncated before indexing it. Consumers can then distinguish a
+      // resolved-but-omitted root from a genuinely unresolved declaration.
+      entryKey: entry ? entry.key : null,
+      isDevelopmentDependency: manifest.devNames.has(declaredName),
+    });
+  });
+
+  let hasOmittedRelationships = traversalState.nodeLimitReached
+    || traversalState.edgeLimitReached;
+  if (!hasOmittedRelationships) {
+    hasOmittedRelationships = graphEntries.some((entry) => entry.edges.some((edge) => (
+      edge.childKey && !includedKeys.has(edge.childKey)
+    )));
+  }
+  if (hasOmittedRelationships) {
+    traversalState.truncated = true;
+  }
+
+  return Object.freeze({
+    kind: "package-lock",
+    entries: Object.freeze(graphEntries),
+    roots: Object.freeze(roots),
+    incomplete: hasOmittedRelationships,
+    maxDepth: traversalState.maxDepth,
+    maxNodes: traversalState.maxNodes,
+    maxEdges: traversalState.maxEdges,
+  });
 }
 
 function collectDependencyKeys(dependencies, addedKeys) {
@@ -206,8 +302,12 @@ function buildNpmDependency(
   visiting,
   context,
   inheritedDevelopment,
-  traversalState
+  traversalState,
+  forceExpand = false
 ) {
+  if (!reserveMaterializedNode(parentChain, traversalState)) {
+    return null;
+  }
   if (!entry) {
     return createNpmDependency({
       name: fallbackName,
@@ -223,6 +323,7 @@ function buildNpmDependency(
   }
 
   if (visiting.has(entry.key)) {
+    traversalState.cycleEdgesSkipped += 1;
     return createNpmDependency({
       name: entry.name,
       version: entry.version,
@@ -244,7 +345,7 @@ function buildNpmDependency(
     || entry.isDevelopmentDependency
     || context.devNames.has(entry.installedName);
 
-  if (!canExpandGraphNode(parentChain, traversalState)) {
+  if (!canExpandGraphNode(parentChain, entry.key, traversalState, forceExpand)) {
     return createNpmDependency({
       name: entry.name,
       version: entry.version,
@@ -261,9 +362,10 @@ function buildNpmDependency(
   for (const dependencyName of Object.keys(entry.dependencies || {})) {
     const childEntry = selectPackageLockEntry(entriesByPath, entry.packagePath, dependencyName);
     if (childEntry && nextVisiting.has(childEntry.key)) {
+      traversalState.cycleEdgesSkipped += 1;
       continue;
     }
-    transitives.push(buildNpmDependency(
+    const childDependency = buildNpmDependency(
       childEntry,
       dependencyName,
       nextParentChain,
@@ -271,8 +373,12 @@ function buildNpmDependency(
       nextVisiting,
       context,
       isDevelopmentDependency,
-      traversalState
-    ));
+      traversalState,
+      false
+    );
+    if (childDependency) {
+      transitives.push(childDependency);
+    }
   }
 
   return createNpmDependency({
@@ -819,29 +925,103 @@ function buildPnpmDependency(
   }, entry.installedName || entry.name);
 }
 
-function createGraphTraversalState() {
-  return { expandedNodes: 0, truncated: false };
+function createGraphTraversalState(options = {}) {
+  return {
+    expandedNodes: 0,
+    materializedNodes: 0,
+    repeatedOccurrenceEncounters: 0,
+    directRootReexpansions: 0,
+    structuralEdgesExamined: 0,
+    resolvedEdges: 0,
+    unresolvedEdges: 0,
+    cycleEdgesSkipped: 0,
+    maxObservedDepth: 0,
+    depthLimitReached: false,
+    nodeLimitReached: false,
+    edgeLimitReached: false,
+    truncated: false,
+    expandedEntryKeys: new Set(),
+    maxDepth: lowerOnlyGraphLimit(options.npmGraphMaxDepth, MAX_GRAPH_DEPTH),
+    maxNodes: lowerOnlyGraphLimit(options.npmGraphMaxNodes, MAX_GRAPH_NODES),
+    maxEdges: lowerOnlyGraphLimit(options.npmGraphMaxEdges, MAX_GRAPH_EDGES),
+  };
 }
 
-function canExpandGraphNode(parentChain, state) {
+function lowerOnlyGraphLimit(requested, productionMaximum) {
+  return Number.isSafeInteger(requested) && requested > 0
+    ? Math.min(requested, productionMaximum)
+    : productionMaximum;
+}
+
+function reserveMaterializedNode(parentChain, state) {
   if (!state) {
     return true;
   }
-  if (parentChain.length >= MAX_GRAPH_DEPTH || state.expandedNodes >= MAX_GRAPH_NODES) {
+  state.maxObservedDepth = Math.max(state.maxObservedDepth, parentChain.length);
+  if (state.materializedNodes >= state.maxNodes) {
+    state.nodeLimitReached = true;
     state.truncated = true;
     return false;
   }
+  state.materializedNodes += 1;
+  return true;
+}
+
+function canExpandGraphNode(parentChain, entryKey, state, forceExpand) {
+  if (!state) {
+    return true;
+  }
+  if (parentChain.length >= state.maxDepth) {
+    state.depthLimitReached = true;
+    state.truncated = true;
+    return false;
+  }
+  if (state.expandedEntryKeys.has(entryKey) && !forceExpand) {
+    state.repeatedOccurrenceEncounters += 1;
+    return false;
+  }
+  if (state.expandedNodes >= state.maxNodes) {
+    state.nodeLimitReached = true;
+    state.truncated = true;
+    return false;
+  }
+  if (forceExpand && state.expandedEntryKeys.has(entryKey)) {
+    state.directRootReexpansions += 1;
+  }
+  state.expandedEntryKeys.add(entryKey);
   state.expandedNodes += 1;
   return true;
 }
 
 function appendGraphLimitWarning(warnings, state) {
   if (state && state.truncated) {
-    warnings.push(
-      `npm dependency graph expansion reached its bounded limit `
-      + `(${MAX_GRAPH_NODES} nodes or depth ${MAX_GRAPH_DEPTH}); deeper relationships were omitted.`
-    );
+    warnings.push("Some dependency relationships could not be fully analyzed.");
   }
+}
+
+function publishGraphMetrics(options, state, indexedOccurrences, uniquePackageIdentities) {
+  if (!options || typeof options.onNpmGraphMetrics !== "function") {
+    return;
+  }
+  options.onNpmGraphMetrics(Object.freeze({
+    indexedOccurrences,
+    uniquePackageIdentities,
+    structuralOccurrencesExpanded: state.expandedNodes,
+    dependencyRecordsMaterialized: state.materializedNodes,
+    repeatedOccurrenceEncounters: state.repeatedOccurrenceEncounters,
+    directRootReexpansions: state.directRootReexpansions,
+    structuralEdgesExamined: state.structuralEdgesExamined,
+    resolvedEdges: state.resolvedEdges,
+    unresolvedEdges: state.unresolvedEdges,
+    cycleEdgesSkipped: state.cycleEdgesSkipped,
+    maxObservedDepth: state.maxObservedDepth,
+    depthLimitReached: state.depthLimitReached,
+    nodeLimitReached: state.nodeLimitReached,
+    edgeLimitReached: state.edgeLimitReached,
+    maxDepth: state.maxDepth,
+    maxNodes: state.maxNodes,
+    maxEdges: state.maxEdges,
+  }));
 }
 
 function selectPnpmEntry(packageEntries, dependencyName, versionHint) {

--- a/util/lockfileParsers/shared.js
+++ b/util/lockfileParsers/shared.js
@@ -444,6 +444,7 @@ function deduplicateDeps(dependencies) {
     }
 
     if (
+      !existing.isDirect &&
       Array.isArray(existing.parentChain) &&
       existing.parentChain.length === 0 &&
       Array.isArray(dependency.parentChain) &&

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -845,6 +845,7 @@ class DependencyHealthProvider {
             sourceFile: result.sourceFile,
             source: result.source,
             dependencies: result.dependencies,
+            dependencyGraph: result.dependencyGraph || null,
             warnings: result.warnings,
           });
           const sourceManifestPath = result.source
@@ -1446,14 +1447,18 @@ class DependencyHealthProvider {
   }
 
   _buildTreeModeNodes(tree, group = null) {
-    const roots = getTreeRootDependencies(tree)
-      .sort((left, right) => compareDependencies(left, right, this._sortMode, false));
-
-    const filteredRoots = roots
-      .map((dependency) => buildFilteredTreeWrapper(dependency, this._filterMode, this._sortMode))
-      .filter(Boolean);
-
-    const duplicateAwareRoots = annotateDuplicateWrappers(filteredRoots, new Map(), []);
+    let duplicateAwareRoots;
+    if (tree.dependencyGraph?.kind === "package-lock") {
+      const rendered = buildPackageLockGraphWrappers(tree, this._filterMode, this._sortMode);
+      duplicateAwareRoots = rendered.wrappers;
+      const warning = "Some dependency relationships could not be displayed. Use list view to inspect the bounded dependency inventory.";
+      if (rendered.truncated && !this._warnings.includes(warning)) {
+        this._warnings.push(warning);
+        queueMicrotask(() => this.refresh());
+      }
+    } else {
+      duplicateAwareRoots = buildLegacyTreeWrappers(tree, this._filterMode, this._sortMode);
+    }
     return duplicateAwareRoots.map(wrapper => this._createTreeDependencyNode(wrapper, group));
   }
 
@@ -3068,13 +3073,17 @@ function limitDisplayTrees(trees, maxDependencies) {
   );
 
   const limitedTrees = trees
-    .map((tree) => ({
-      ...tree,
-      dependencies: tree.dependencies
+    .map((tree) => {
+      const dependencies = tree.dependencies
         .filter((dependency) => allowedKeys.has(displayDependencyKey(dependency)))
         .map((dependency) => pruneDependencyTree(dependency, allowedKeys))
-        .sort((left, right) => compareDependencies(left, right, SORT_MODES.ALPHABETICAL, true)),
-    }))
+        .sort((left, right) => compareDependencies(left, right, SORT_MODES.ALPHABETICAL, true));
+      return {
+        ...tree,
+        dependencies,
+        dependencyGraph: limitPackageLockGraph(tree.dependencyGraph, dependencies),
+      };
+    })
     .filter((tree) => tree.dependencies.length > 0);
 
   return {
@@ -3082,6 +3091,63 @@ function limitDisplayTrees(trees, maxDependencies) {
     truncated: true,
     totalDependencies: allDependencies.length,
   };
+}
+
+function limitPackageLockGraph(graph, dependencies) {
+  if (!graph || graph.kind !== "package-lock") {
+    return graph || null;
+  }
+  const allowedResolved = new Set();
+  const allowedUnresolved = new Set();
+  const allowedDirectDeclarations = new Set();
+  for (const dependency of dependencies) {
+    const concreteVersion = getConcreteDependencyVersion(dependency);
+    if (concreteVersion) {
+      allowedResolved.add(graphPackageIdentity(dependency.name, concreteVersion));
+    } else {
+      allowedUnresolved.add(String(dependency.name || "").trim().toLowerCase());
+    }
+    if (dependency.isDirect) {
+      allowedDirectDeclarations.add(String(
+        dependency.declarationName || dependency.name || ""
+      ).trim().toLowerCase());
+    }
+  }
+
+  const sourceEntries = new Map(graph.entries.map((entry) => [entry.key, entry]));
+  const entryAllowed = (entry) => Boolean(entry) && allowedResolved.has(
+    graphPackageIdentity(entry.name, entry.version)
+  );
+  const entries = graph.entries
+    .filter(entryAllowed)
+    .map((entry) => Object.freeze({
+      ...entry,
+      edges: Object.freeze(entry.edges.filter((edge) => {
+        if (!edge.childKey) {
+          return allowedUnresolved.has(String(edge.declaredName || "").trim().toLowerCase());
+        }
+        return entryAllowed(sourceEntries.get(edge.childKey));
+      })),
+    }));
+  const roots = graph.roots.filter((root) => {
+    const declarationAllowed = allowedDirectDeclarations.has(
+      String(root.declaredName || "").trim().toLowerCase()
+    );
+    if (!declarationAllowed) {
+      return false;
+    }
+    if (root.entryKey) {
+      const entry = sourceEntries.get(root.entryKey);
+      return !entry || entryAllowed(entry);
+    }
+    return allowedUnresolved.has(String(root.declaredName || "").trim().toLowerCase());
+  });
+
+  return Object.freeze({
+    ...graph,
+    entries: Object.freeze(entries),
+    roots: Object.freeze(roots),
+  });
 }
 
 function pruneDependencyTree(dependency, allowedKeys) {
@@ -3181,6 +3247,368 @@ function getTreeRootDependencies(tree) {
     const hasParentChain = Array.isArray(dependency.parentChain) && dependency.parentChain.length > 0;
     return !dependency.parent && !hasParentChain;
   });
+}
+
+function buildLegacyTreeWrappers(tree, filterMode, sortMode) {
+  const roots = getTreeRootDependencies(tree)
+    .sort((left, right) => compareDependencies(left, right, sortMode, false));
+  const filteredRoots = roots
+    .map((dependency) => buildFilteredTreeWrapper(dependency, filterMode, sortMode))
+    .filter(Boolean);
+  return annotateDuplicateWrappers(filteredRoots, new Map(), []);
+}
+
+function buildPackageLockGraphWrappers(tree, filterMode, sortMode) {
+  const graph = tree.dependencyGraph;
+  const baseDependencies = buildGraphDependencyIndex(tree.dependencies);
+  const entryMap = new Map(graph.entries
+    .filter((entry) => baseDependencies.has(graphPackageIdentity(entry.name, entry.version)))
+    .map((entry) => [entry.key, entry]));
+  const directDependencies = new Map(
+    tree.dependencies
+      .filter((dependency) => dependency.isDirect)
+      .map((dependency) => [
+        String(dependency.declarationName || dependency.name || "").toLowerCase(),
+        dependency,
+      ])
+  );
+  const entryDependencies = new Map();
+  for (const entry of graph.entries) {
+    entryDependencies.set(entry.key, graphDependencyForEntry(
+      entry,
+      entry.installedName,
+      [],
+      false,
+      entry.isDevelopmentDependency,
+      baseDependencies,
+      directDependencies
+    ));
+  }
+  const reachableMatches = computeGraphFilterReachability(
+    graph,
+    entryDependencies,
+    filterMode
+  );
+  const seen = new Map();
+  const presentation = {
+    materialized: 0,
+    maxNodes: graph.maxNodes || 50000,
+    truncated: false,
+  };
+
+  const roots = graph.roots
+    .filter((root) => directDependencies.has(String(root.declaredName || "").toLowerCase()))
+    .map((root) => ({
+      root,
+      dependency: graphDependencyForRoot(
+        root,
+        entryMap,
+        baseDependencies,
+        directDependencies
+      ),
+    }))
+    .sort((left, right) => compareDependencies(
+      left.dependency,
+      right.dependency,
+      sortMode,
+      false
+    ));
+
+  const wrappers = roots.map(({ root, dependency }) => materializeGraphWrapper({
+    root,
+    dependency,
+    entryMap,
+    baseDependencies,
+    directDependencies,
+    reachableMatches,
+    filterMode,
+    sortMode,
+    seen,
+    ancestry: [],
+    visiting: new Set(),
+    presentation,
+    maxDepth: graph.maxDepth || 128,
+  })).filter(Boolean);
+  return { wrappers, truncated: presentation.truncated };
+}
+
+function buildGraphDependencyIndex(dependencies) {
+  const index = new Map();
+  for (const dependency of dependencies || []) {
+    const key = graphPackageIdentity(dependency.name, dependency.version);
+    if (!index.has(key) || (!index.get(key).isDirect && dependency.isDirect)) {
+      index.set(key, dependency);
+    }
+  }
+  return index;
+}
+
+function graphDependencyForRoot(root, entryMap, baseDependencies, directDependencies) {
+  const direct = directDependencies.get(String(root.declaredName || "").toLowerCase());
+  if (!root.entryKey) {
+    return direct || graphUnresolvedDependency(root.declaredName, [], true, root.isDevelopmentDependency);
+  }
+  if (!entryMap.has(root.entryKey)) {
+    // A non-null missing key means the parser knew the resolved occurrence but
+    // omitted its adjacency at the graph bound. Preserve the authoritative
+    // direct record as a leaf instead of mislabelling it as unresolved.
+    return direct || graphUnresolvedDependency(root.declaredName, [], true, root.isDevelopmentDependency);
+  }
+  return graphDependencyForEntry(
+    entryMap.get(root.entryKey),
+    root.declaredName,
+    [],
+    true,
+    root.isDevelopmentDependency,
+    baseDependencies,
+    directDependencies
+  );
+}
+
+function graphDependencyForEntry(
+  entry,
+  declaredName,
+  parentChain,
+  isDirect,
+  inheritedDevelopment,
+  baseDependencies,
+  directDependencies
+) {
+  const direct = isDirect
+    ? directDependencies.get(String(declaredName || "").toLowerCase())
+    : null;
+  const base = direct || baseDependencies.get(graphPackageIdentity(entry.name, entry.version));
+  const parent = parentChain[parentChain.length - 1] || null;
+  return {
+    ...(base || {}),
+    ecosystem: base?.ecosystem || "npm",
+    format: base?.format || "npm",
+    name: entry.name,
+    normalizedName: base?.normalizedName || entry.name.toLowerCase(),
+    declarationName: declaredName || entry.installedName || entry.name,
+    resolvedVersion: base?.resolvedVersion || entry.version,
+    version: base?.version || entry.version,
+    legacyVersion: base?.legacyVersion || entry.version,
+    versionState: base?.versionState || "resolved",
+    isDirect,
+    isDevelopmentDependency: Boolean(
+      inheritedDevelopment || entry.isDevelopmentDependency
+    ),
+    devDependency: Boolean(inheritedDevelopment || entry.isDevelopmentDependency),
+    parent,
+    parentChain: parentChain.slice(),
+    transitives: [],
+    declaredConstraint: isDirect ? direct?.declaredConstraint || null : null,
+    environmentMarker: isDirect ? direct?.environmentMarker || null : null,
+    sourceManifest: isDirect ? direct?.sourceManifest || null : null,
+  };
+}
+
+function graphUnresolvedDependency(declaredName, parentChain, isDirect, inheritedDevelopment, base) {
+  const parent = parentChain[parentChain.length - 1] || null;
+  return {
+    ...(base || {}),
+    ecosystem: base?.ecosystem || "npm",
+    format: base?.format || "npm",
+    name: base?.name || declaredName,
+    normalizedName: base?.normalizedName || String(declaredName || "").toLowerCase(),
+    declarationName: declaredName,
+    resolvedVersion: null,
+    version: "",
+    legacyVersion: "",
+    versionState: base?.versionState || "incomplete",
+    isDirect,
+    isDevelopmentDependency: Boolean(inheritedDevelopment),
+    devDependency: Boolean(inheritedDevelopment),
+    parent,
+    parentChain: parentChain.slice(),
+    transitives: [],
+    sourceManifest: isDirect ? base?.sourceManifest || null : null,
+  };
+}
+
+function computeGraphFilterReachability(graph, entryDependencies, filterMode) {
+  const reachable = new Map();
+  const reverseEdges = new Map();
+  const queue = [];
+  for (const entry of graph.entries) {
+    const matches = !filterMode || matchesFilter(entryDependencies.get(entry.key), filterMode);
+    reachable.set(entry.key, matches);
+    if (matches) {
+      queue.push(entry.key);
+    }
+    for (const edge of entry.edges) {
+      if (!edge.childKey) {
+        continue;
+      }
+      if (!reverseEdges.has(edge.childKey)) {
+        reverseEdges.set(edge.childKey, []);
+      }
+      reverseEdges.get(edge.childKey).push(entry.key);
+    }
+  }
+  if (!filterMode) {
+    return reachable;
+  }
+
+  for (let index = 0; index < queue.length; index += 1) {
+    for (const parentKey of reverseEdges.get(queue[index]) || []) {
+      if (reachable.get(parentKey)) {
+        continue;
+      }
+      reachable.set(parentKey, true);
+      queue.push(parentKey);
+    }
+  }
+  return reachable;
+}
+
+function materializeGraphWrapper(context) {
+  const {
+    root,
+    dependency,
+    entryMap,
+    baseDependencies,
+    directDependencies,
+    reachableMatches,
+    filterMode,
+    sortMode,
+    seen,
+    ancestry,
+    visiting,
+    presentation,
+    maxDepth,
+  } = context;
+  if (presentation.materialized >= presentation.maxNodes) {
+    presentation.truncated = true;
+    return null;
+  }
+
+  const entryKey = root.entryKey;
+  const entry = entryKey ? entryMap.get(entryKey) : null;
+  const selfMatches = matchesFilter(dependency, filterMode);
+  if (filterMode && !selfMatches && (!entryKey || !reachableMatches.get(entryKey))) {
+    return null;
+  }
+  if (entryKey && visiting.has(entryKey)) {
+    return null;
+  }
+
+  presentation.materialized += 1;
+  const pathLabel = ancestry.concat(dependency.name).join(" > ");
+  const duplicateKey = buildDuplicateKey(dependency);
+  if (duplicateKey && seen.has(duplicateKey)) {
+    return {
+      dependency,
+      children: [],
+      duplicate: true,
+      firstOccurrencePath: seen.get(duplicateKey),
+      dimmedForFilter: Boolean(filterMode) && !selfMatches,
+    };
+  }
+  if (duplicateKey) {
+    seen.set(duplicateKey, pathLabel);
+  }
+
+  if (!entry) {
+    return {
+      dependency,
+      children: [],
+      duplicate: false,
+      firstOccurrencePath: null,
+      dimmedForFilter: Boolean(filterMode) && !selfMatches,
+    };
+  }
+
+  if (dependency.parentChain.length >= maxDepth && entry.edges.length > 0) {
+    presentation.truncated = true;
+    return {
+      dependency,
+      children: [],
+      duplicate: false,
+      firstOccurrencePath: null,
+      dimmedForFilter: Boolean(filterMode) && !selfMatches,
+    };
+  }
+
+  const nextVisiting = new Set(visiting);
+  nextVisiting.add(entry.key);
+  const nextParentChain = dependency.parentChain.concat(dependency.name);
+  const childCandidates = entry.edges.map((edge) => {
+    // A non-null key missing from the bounded structural graph represents an
+    // omitted resolved relationship. The parser warning already qualifies the
+    // result; do not fabricate an unresolved dependency for that edge.
+    if (edge.childKey && !entryMap.has(edge.childKey)) {
+      return null;
+    }
+    const childEntry = edge.childKey ? entryMap.get(edge.childKey) : null;
+    const childDependency = childEntry
+      ? graphDependencyForEntry(
+        childEntry,
+        edge.declaredName,
+        nextParentChain,
+        false,
+        dependency.isDevelopmentDependency,
+        baseDependencies,
+        directDependencies
+      )
+      : graphUnresolvedDependency(
+        edge.declaredName,
+        nextParentChain,
+        false,
+        dependency.isDevelopmentDependency
+      );
+    return {
+      root: {
+        declaredName: edge.declaredName,
+        entryKey: childEntry ? childEntry.key : null,
+        isDevelopmentDependency: dependency.isDevelopmentDependency,
+      },
+      dependency: childDependency,
+    };
+  }).filter(Boolean).filter(({ root: childRoot, dependency: child }) => (
+    !filterMode
+    || matchesFilter(child, filterMode)
+    || (childRoot.entryKey && reachableMatches.get(childRoot.entryKey))
+  )).sort((left, right) => compareDependencies(
+    left.dependency,
+    right.dependency,
+    sortMode,
+    false
+  ));
+
+  const children = childCandidates.map(({ root: childRoot, dependency: child }) => (
+    materializeGraphWrapper({
+      root: childRoot,
+      dependency: child,
+      entryMap,
+      baseDependencies,
+      directDependencies,
+      reachableMatches,
+      filterMode,
+      sortMode,
+      seen,
+      ancestry: ancestry.concat(dependency.name),
+      visiting: nextVisiting,
+      presentation,
+      maxDepth,
+    })
+  )).filter(Boolean);
+
+  return {
+    dependency,
+    children,
+    duplicate: false,
+    firstOccurrencePath: null,
+    dimmedForFilter: Boolean(filterMode) && !selfMatches,
+  };
+}
+
+function graphPackageIdentity(name, version) {
+  return JSON.stringify([
+    String(name || "").trim().toLowerCase(),
+    String(version || "").trim(),
+  ]);
 }
 
 function buildFilteredTreeWrapper(dependency, filterMode, sortMode) {


### PR DESCRIPTION
## Summary

- Reduced repeated npm dependency-graph expansion while preserving package-path resolution, dependency provenance, and tree relationships.
- Added a bounded structural graph for package-lock data and retained safe node, edge, depth, display, and cycle limits.
- Added shared-subgraph, hoisting, development-state, cycle, truncation, adapter, and tree-rendering regression coverage.

## Validation

- `npm run check` - passed
- `npm test` - passed (744 tests)
- `npm audit --omit=dev` - passed
- `npm run audit:dev` - passed
- `npm run package` and VSIX sidecar verification - passed