### PR TITLE
fix: contain invalid dependency package matches

### DIFF
--- a/domain/package.js
+++ b/domain/package.js
@@ -14,6 +14,7 @@ const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\
 const UNSAFE_PATH_PATTERN = /[\\/?#]/;
 const EXACT_PACKAGES = new WeakSet();
 const PACKAGE_COORDINATES = new WeakSet();
+const PACKAGE_DOMAIN_ERRORS = new WeakSet();
 const SEMANTIC_FIELDS = Object.freeze([
   "kind",
   "identityState",
@@ -59,6 +60,11 @@ class PackageDomainError extends TypeError {
     this.name = "PackageDomainError";
     this.code = code;
     this.field = field;
+    PACKAGE_DOMAIN_ERRORS.add(this);
+  }
+
+  static isTrusted(value) {
+    return PACKAGE_DOMAIN_ERRORS.has(value);
   }
 }
 

--- a/domain/packageAdapters.js
+++ b/domain/packageAdapters.js
@@ -12,6 +12,7 @@ const {
 } = require("./package");
 
 const MAX_WRAPPER_DEPTH = 2;
+const PACKAGE_ADAPTER_ERRORS = new WeakSet();
 const DETECTED_STATUS = "scan detected vulnerabilities";
 const CLEAN_STATUS = "scan detected no vulnerabilities";
 const SEMANTIC_FIELDS = Object.freeze([
@@ -77,12 +78,17 @@ const SEMANTIC_FIELDS = Object.freeze([
 ]);
 
 class PackageAdapterError extends TypeError {
-  constructor(code, field, message, cause = null) {
+  constructor(code, field, message, unexpected = false) {
     super(message);
     this.name = "PackageAdapterError";
     this.code = code;
     this.field = field;
-    if (cause) this.cause = cause;
+    this.unexpected = unexpected === true;
+    PACKAGE_ADAPTER_ERRORS.add(this);
+  }
+
+  static isTrusted(value) {
+    return PACKAGE_ADAPTER_ERRORS.has(value);
   }
 }
 
@@ -320,12 +326,12 @@ function fromExactPackageSelectionIfPresent(value) {
 }
 
 function fromApiPackageRecord(record, options = {}) {
-  if (isExactPackage(record)) {
-    validateExpectedScope(record, options);
-    return record;
-  }
-  requireRecord(record, "API package", { plain: true });
   try {
+    if (isExactPackage(record)) {
+      validateExpectedScope(record, options);
+      return record;
+    }
+    requireRecord(record, "API package", { plain: true });
     const result = adaptFlatExactRecord(record, {
       allowNumericVersion: true,
       allowWrappers: false,
@@ -349,9 +355,9 @@ function fromSearchResultNode(node) {
 }
 
 function fromDependencyHealthNode(node, options = {}) {
-  requireRecord(node, "dependency health node");
-  requireRecord(options, "dependency package adapter options", { plain: true });
   try {
+    requireRecord(node, "dependency health node");
+    requireRecord(options, "dependency package adapter options", { plain: true });
     if (isExactPackage(node) || isPackageCoordinate(node)) {
       for (const field of ["workspace", "repository"]) {
         const expected = consensusString(options, [field], field, {
@@ -516,7 +522,7 @@ function fromPackageSelection(value) {
           "malformed_applicable_adapter",
           "package selection",
           `The ${adapter} selection is malformed.`,
-          error
+          isUnexpectedPackageAdapterError(error)
         );
       }
     }
@@ -1356,15 +1362,22 @@ function requireRecord(value, field, options = {}) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw adapterError("invalid_record", field, `The ${field} value is invalid.`);
   }
-  if (options.plain) {
-    const prototype = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
-      throw adapterError("invalid_record", field, `The ${field} value is invalid.`);
+  try {
+    if (options.plain) {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw adapterError("invalid_record", field, `The ${field} value is invalid.`);
+      }
     }
+    assertNoSymbolProperties(value, field);
+    assertNoOwnAccessors(value, field);
+    assertNoInheritedSemanticProperties(value, field);
+  } catch (error) {
+    if (PACKAGE_ADAPTER_ERRORS.has(error)) throw error;
+    // Reflection traps are part of the untrusted record boundary. Normalize them
+    // without retaining or inspecting the adversarial thrown value.
+    throw adapterError("invalid_record", field, `The ${field} value is invalid.`);
   }
-  assertNoSymbolProperties(value, field);
-  assertNoOwnAccessors(value, field);
-  assertNoInheritedSemanticProperties(value, field);
   return value;
 }
 
@@ -1449,16 +1462,41 @@ function boundaryPathPart(value, field, maxLength) {
   return validated;
 }
 
-function adapterError(code, field, message, cause = null) {
-  return new PackageAdapterError(code, field, message, cause);
+function adapterError(code, field, message, unexpected = false) {
+  return new PackageAdapterError(code, field, message, unexpected);
 }
 
 function asAdapterError(error, code, field) {
-  if (error instanceof PackageAdapterError) return error;
-  if (error instanceof PackageDomainError) {
-    return adapterError(error.code, error.field, error.message, error);
+  if (PACKAGE_ADAPTER_ERRORS.has(error)) return error;
+  const domainError = snapshotPackageDomainError(error);
+  if (domainError) {
+    return adapterError(domainError.code, domainError.field, domainError.message);
   }
-  return adapterError(code, field, `The ${field} value is invalid.`, error);
+  return adapterError(code, field, `The ${field} value is invalid.`, true);
+}
+
+function isUnexpectedPackageAdapterError(error) {
+  if (!PACKAGE_ADAPTER_ERRORS.has(error)) return true;
+  try {
+    const unexpected = Object.getOwnPropertyDescriptor(error, "unexpected");
+    return Boolean(unexpected && "value" in unexpected && unexpected.value === true);
+  } catch {
+    return true;
+  }
+}
+
+function snapshotPackageDomainError(error) {
+  try {
+    if (!PackageDomainError.isTrusted(error)) return null;
+    const properties = Object.getOwnPropertyDescriptors(error);
+    const code = properties.code?.value;
+    const errorField = properties.field?.value;
+    const message = properties.message?.value;
+    if (![code, errorField, message].every(value => typeof value === "string")) return null;
+    return { code, field: errorField, message };
+  } catch {
+    return null;
+  }
 }
 
 module.exports = {

--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -11,9 +11,14 @@ const {
   normalizeDependencyDisplayValue,
 } = require("../util/dependencyRecord");
 const {
+  PackageAdapterError,
   fromApiPackageRecord,
   fromDependencyHealthNode,
 } = require("../domain/packageAdapters");
+const { PackageDomainError } = require("../domain/package");
+
+const UNEXPECTED_PACKAGE_MATCH_WARNING =
+  "[Cloudsmith] Unexpected dependency package match validation failure.";
 
 class DependencyHealthNode {
   constructor(dep, cloudsmithMatchOrContext, maybeContext, maybeOptions) {
@@ -559,12 +564,18 @@ class DependencyHealthNode {
     const PackageDetailsNode = require("./packageDetailsNode");
     const children = [];
 
-    children.push(new PackageDetailsNode({
-      id: "Status",
-      value: this.policy && this.policy.status
-        ? this.policy.status
-        : this.package.status,
-    }, this.context));
+    const statusSource = this.policy && this.policy.status
+      ? this.policy.status
+      : this.package.status;
+    const status = typeof statusSource === "string"
+      ? normalizeDependencyDisplayValue(statusSource)
+      : null;
+    if (status) {
+      children.push(new PackageDetailsNode({
+        id: "Status",
+        value: status,
+      }, this.context));
+    }
 
     children.push(new PackageDetailsNode({
       id: "Version",
@@ -755,8 +766,30 @@ function canonicalMatchedPackage(dep, explicitMatch) {
       if (descriptor) Object.defineProperty(boundary, field, descriptor);
     }
     return fromDependencyHealthNode(boundary);
-  } catch {
+  } catch (error) {
+    if (shouldReportUnexpectedPackageMatchError(error)) {
+      reportUnexpectedPackageMatchError();
+    }
     return null;
+  }
+}
+
+function shouldReportUnexpectedPackageMatchError(error) {
+  try {
+    if (PackageDomainError.isTrusted(error)) return false;
+    if (!PackageAdapterError.isTrusted(error)) return true;
+    const unexpected = Object.getOwnPropertyDescriptor(error, "unexpected");
+    return Boolean(unexpected && "value" in unexpected && unexpected.value === true);
+  } catch {
+    return true;
+  }
+}
+
+function reportUnexpectedPackageMatchError() {
+  try {
+    console.warn(UNEXPECTED_PACKAGE_MATCH_WARNING);
+  } catch {
+    // Tree rendering must remain available even if the internal reporting sink fails.
   }
 }
 

--- a/models/dependencyHealthNode.js
+++ b/models/dependencyHealthNode.js
@@ -10,7 +10,10 @@ const {
   getDependencySourceLabel,
   normalizeDependencyDisplayValue,
 } = require("../util/dependencyRecord");
-const { fromApiPackageRecord } = require("../domain/packageAdapters");
+const {
+  fromApiPackageRecord,
+  fromDependencyHealthNode,
+} = require("../domain/packageAdapters");
 
 class DependencyHealthNode {
   constructor(dep, cloudsmithMatchOrContext, maybeContext, maybeOptions) {
@@ -62,11 +65,18 @@ class DependencyHealthNode {
     this.parent = dep.parent || (Array.isArray(dep.parentChain) ? dep.parentChain[dep.parentChain.length - 1] : null);
     this.parentChain = Array.isArray(dep.parentChain) ? dep.parentChain.slice() : [];
     this.transitives = Array.isArray(dep.transitives) ? dep.transitives.slice() : [];
-    this.cloudsmithMatch = dep.cloudsmithPackage
-      || dep.cloudsmithMatch
-      || (hasExplicitCloudsmithMatch ? cloudsmithMatchOrContext : null);
-    this.package = canonicalMatchedPackage(this.cloudsmithMatch);
-    this.cloudsmithStatus = dep.cloudsmithStatus || (this.cloudsmithMatch ? "FOUND" : null);
+    const explicitPackageMatch = hasExplicitCloudsmithMatch ? cloudsmithMatchOrContext : null;
+    const packageMatchSupplied = hasDependencyPackageEvidence(dep)
+      || (explicitPackageMatch !== null && explicitPackageMatch !== undefined);
+    const canonicalPackage = canonicalMatchedPackage(dep, explicitPackageMatch);
+    const requestedCloudsmithStatus = dep.cloudsmithStatus || (packageMatchSupplied ? "FOUND" : null);
+    this.package = requestedCloudsmithStatus === "FOUND" ? canonicalPackage : null;
+    // Retain the compatibility projection only for trusted canonical values. A rejected
+    // optional match must not remain available as a second exact-identity authority.
+    this.cloudsmithMatch = this.package;
+    this.cloudsmithStatus = requestedCloudsmithStatus === "FOUND" && !this.package
+      ? "LOOKUP_FAILED"
+      : requestedCloudsmithStatus;
     this.vulnerabilities = dep.vulnerabilities || null;
     this.licenseData = dep.license || null;
     this.policy = dep.policy || null;
@@ -83,7 +93,7 @@ class DependencyHealthNode {
     this.licenseInfo = this._deriveLicenseInfo();
     this.state = this._deriveState();
 
-    if (this.cloudsmithMatch) {
+    if (this.package) {
       this.namespace = this.package.workspace;
       this.repository = this.package.repository;
       const packageIdentifier = this.package.packageIdentifier;
@@ -128,10 +138,6 @@ class DependencyHealthNode {
       });
     }
 
-    if (this.cloudsmithMatch) {
-      return LicenseClassifier.inspect(this.cloudsmithMatch);
-    }
-
     return LicenseClassifier.inspect(null);
   }
 
@@ -160,7 +166,7 @@ class DependencyHealthNode {
       return "lookup_incomplete";
     }
 
-    if (this.cloudsmithStatus !== "FOUND" || !this.cloudsmithMatch) {
+    if (this.cloudsmithStatus !== "FOUND" || !this.package) {
       return "unknown";
     }
 
@@ -395,7 +401,7 @@ class DependencyHealthNode {
       detail = this._buildMissingDescription();
     } else if (this._isQuarantined()) {
       detail = "Quarantined";
-    } else if (this._hasVulnerabilities()) {
+    } else if (this._hasVulnerabilities() || this._hasVulnerabilityUncertainty()) {
       detail = this._buildVulnerabilityDescription();
     } else if (this._shouldFlagRestrictiveLicenses() && this._hasRestrictiveLicense()) {
       detail = this._getLicenseLabel()
@@ -472,19 +478,19 @@ class DependencyHealthNode {
       } else {
         lines.push("This package may need to be uploaded or fetched through an upstream.");
       }
-    } else if (this.cloudsmithStatus !== "FOUND" || !this.cloudsmithMatch) {
+    } else if (this.cloudsmithStatus !== "FOUND" || !this.package) {
       lines.push(this._buildMissingDescription() + ".");
       const lookupDetail = normalizeDependencyDisplayValue(this.cloudsmithLookupDetail);
       if (lookupDetail) {
         lines.push(lookupDetail);
       }
     } else {
-      lines.push(`Found in Cloudsmith (${this.package?.repository ?? this.cloudsmithMatch.repository})`);
+      lines.push(`Found in Cloudsmith (${this.package.repository})`);
       const policy = this._getPolicyData();
       if (policy && policy.status) {
         lines.push(`Status: ${policy.status}`);
-      } else if (this.package?.status ?? this.cloudsmithMatch.status_str) {
-        lines.push(`Status: ${this.package?.status ?? this.cloudsmithMatch.status_str}`);
+      } else if (this.package.status) {
+        lines.push(`Status: ${this.package.status}`);
       }
 
       const vulnerabilities = this._getVulnerabilityData();
@@ -546,7 +552,7 @@ class DependencyHealthNode {
   }
 
   _buildDetailsChildren() {
-    if (!this.cloudsmithMatch || this.state === "checking") {
+    if (!this.package || this.state === "checking") {
       return [];
     }
 
@@ -557,12 +563,12 @@ class DependencyHealthNode {
       id: "Status",
       value: this.policy && this.policy.status
         ? this.policy.status
-        : this.package?.status ?? this.cloudsmithMatch.status_str,
+        : this.package.status,
     }, this.context));
 
     children.push(new PackageDetailsNode({
       id: "Version",
-      value: this.package?.version ?? this.cloudsmithMatch.version,
+      value: this.package.version,
     }, this.context));
 
     const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
@@ -611,7 +617,7 @@ class DependencyHealthNode {
       return this.vulnerabilities;
     }
 
-    if (!this.cloudsmithMatch) {
+    if (!this.package) {
       return null;
     }
 
@@ -650,7 +656,7 @@ class DependencyHealthNode {
       return this.policy;
     }
 
-    if (!this.cloudsmithMatch) {
+    if (!this.package) {
       return null;
     }
 
@@ -700,7 +706,7 @@ class DependencyHealthNode {
       return vscode.TreeItemCollapsibleState.Collapsed;
     }
 
-    return this.cloudsmithMatch
+    return this.package
       ? vscode.TreeItemCollapsibleState.Collapsed
       : vscode.TreeItemCollapsibleState.None;
   }
@@ -717,9 +723,51 @@ class DependencyHealthNode {
   }
 }
 
-function canonicalMatchedPackage(value) {
-  if (!value) return null;
-  return fromApiPackageRecord(value);
+function canonicalMatchedPackage(dep, explicitMatch) {
+  try {
+    const dependencyPackage = hasDependencyPackageEvidence(dep)
+      ? fromApiPackageRecord(fromDependencyHealthNode(dep))
+      : null;
+    const explicitPackage = explicitMatch === null || explicitMatch === undefined
+      ? null
+      : fromApiPackageRecord(explicitMatch);
+    if (dependencyPackage && explicitPackage) {
+      return fromDependencyHealthNode({
+        cloudsmithPackage: dependencyPackage,
+        cloudsmithMatch: explicitPackage,
+      });
+    }
+    if (dependencyPackage) return dependencyPackage;
+    if (!explicitPackage) return null;
+
+    const boundary = { package: explicitPackage };
+    for (const field of [
+      "workspace",
+      "namespace",
+      "cloudsmithWorkspace",
+      "repository",
+      "cloudsmithRepo",
+      "packageIdentifier",
+      "slug_perm",
+      "slug_perm_raw",
+    ]) {
+      const descriptor = Object.getOwnPropertyDescriptor(dep, field);
+      if (descriptor) Object.defineProperty(boundary, field, descriptor);
+    }
+    return fromDependencyHealthNode(boundary);
+  } catch {
+    return null;
+  }
+}
+
+function hasDependencyPackageEvidence(dep) {
+  return ["package", "cloudsmithPackage", "cloudsmithMatch"].some((field) => {
+    const descriptor = Object.getOwnPropertyDescriptor(dep, field);
+    return Boolean(descriptor && (
+      !Object.prototype.hasOwnProperty.call(descriptor, "value")
+      || (descriptor.value !== null && descriptor.value !== undefined)
+    ));
+  });
 }
 
 function canonicalVulnerabilityState(value) {

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -1021,6 +1021,45 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.match(provider._warnings[0], /reached its safety limit/);
   });
 
+  test("diagnostic preparation snapshots only the canonical found package", async () => {
+    let capturedCandidates = null;
+    const diagnostics = {
+      async prepare({ candidates }) {
+        capturedCandidates = candidates;
+        return { entries: [], warnings: [], stats: null };
+      },
+      replace() {},
+    };
+    const dependency = createFoundDependency("left-pad", "1.0.0");
+    dependency.cloudsmithPackage = fromApiPackageRecord({
+      namespace: "workspace",
+      repository: "repo",
+      slug_perm: "left-pad-1.0.0",
+      name: "left-pad",
+      version: "1.0.0",
+      format: "npm",
+      num_vulnerabilities: 2,
+      security_scan_status: "Scan Detected Vulnerabilities",
+    });
+    const provider = new DependencyHealthProvider(createContext(), diagnostics);
+    const scanWorker = {
+      _warnings: [],
+      _projectFolderPath: "/project",
+      _fullTrees: [{ ecosystem: "npm", sourceFile: "package.json", dependencies: [dependency] }],
+    };
+
+    await provider._prepareDiagnostics(scanWorker, { isCancellationRequested: false });
+
+    assert.strictEqual(capturedCandidates.length, 1);
+    assert.deepStrictEqual(capturedCandidates[0].cloudsmith, {
+      workspace: "workspace",
+      repository: "repo",
+      vulnerabilityEvidence: "detected",
+      vulnerabilitiesDetected: true,
+      vulnerabilityCount: 2,
+    });
+  });
+
   test("scope change can select a different project folder without mutating successful scope", async () => {
     const originalShowQuickPick = vscode.window.showQuickPick;
     const originalShowOpenDialog = vscode.window.showOpenDialog;

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -2111,7 +2111,10 @@ suite("DependencyHealthProvider Test Suite", () => {
     });
 
     assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
-    assert.strictEqual(isExactPackage(result.package), true);
+    assert.ok(isExactPackage(result.package));
+    assert.strictEqual(result.package.workspace, "workspace");
+    assert.strictEqual(result.package.repository, "repo");
+    assert.ok(result.package.packageIdentifier);
     assert.strictEqual(result.package.name, expectedPackage.name);
     assert.strictEqual(result.package.version, expectedPackage.version);
     assert.strictEqual(result.pagesFetched, 1);
@@ -2353,6 +2356,7 @@ suite("DependencyHealthProvider Test Suite", () => {
       });
       assert.notStrictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
       assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED);
+      assert.strictEqual(result.package, null);
     }
   });
 

--- a/test/diagnosticsPublisher.test.js
+++ b/test/diagnosticsPublisher.test.js
@@ -24,6 +24,7 @@ const {
   validateDependencyDeclarationSourceContract,
 } = require("../util/dependencyDeclarationIndex");
 const { canonicalFormat } = require("../util/packageNameNormalizer");
+const { fromApiPackageRecord } = require("../domain/packageAdapters");
 
 suite("DiagnosticsPublisher Test Suite", () => {
   let collection;
@@ -73,6 +74,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
     isDevelopmentDependency = false,
     environmentMarker = null,
     packageSource = { kind: DEPENDENCY_PACKAGE_SOURCE_KINDS.REGISTRY },
+    cloudsmithMatch = null,
   }) {
     const dependency = createDependencyRecord({
       ecosystem,
@@ -97,9 +99,42 @@ suite("DiagnosticsPublisher Test Suite", () => {
     return createDiagnosticCandidate(dependency, {
       state,
       displayVersion: resolvedVersion || declaredConstraint || null,
-      cloudsmithMatch: null,
+      cloudsmithMatch,
     });
   }
+
+  test("snapshots canonical dependency package metadata for vulnerability diagnostics", () => {
+    const packageModel = fromApiPackageRecord({
+      namespace: "workspace-a",
+      repository: "repository-a",
+      slug_perm: "package-a",
+      name: "alpha",
+      version: "1.0.0",
+      format: "npm",
+      num_vulnerabilities: 2,
+      security_scan_status: "Scan Detected Vulnerabilities",
+    });
+    const prepared = candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithMatch: packageModel,
+    });
+
+    assert.deepStrictEqual(prepared.cloudsmith, {
+      namespace: "workspace-a",
+      repository: "repository-a",
+      numVulnerabilities: 2,
+    });
+    assert.throws(() => candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithMatch: {
+        namespace: "workspace-a",
+        repository: "repository-a",
+        slug_perm: "package-a",
+      },
+    }), TypeError);
+  });
 
   function createMemoryPublisher(files, options = {}) {
     const reads = [];

--- a/test/diagnosticsPublisher.test.js
+++ b/test/diagnosticsPublisher.test.js
@@ -74,7 +74,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
     isDevelopmentDependency = false,
     environmentMarker = null,
     packageSource = { kind: DEPENDENCY_PACKAGE_SOURCE_KINDS.REGISTRY },
-    cloudsmithMatch = null,
+    cloudsmithPackage = null,
   }) {
     const dependency = createDependencyRecord({
       ecosystem,
@@ -99,7 +99,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
     return createDiagnosticCandidate(dependency, {
       state,
       displayVersion: resolvedVersion || declaredConstraint || null,
-      cloudsmithMatch,
+      cloudsmithPackage,
     });
   }
 
@@ -117,23 +117,124 @@ suite("DiagnosticsPublisher Test Suite", () => {
     const prepared = candidate({
       name: "alpha",
       state: "violated",
-      cloudsmithMatch: packageModel,
+      cloudsmithPackage: packageModel,
     });
 
     assert.deepStrictEqual(prepared.cloudsmith, {
-      namespace: "workspace-a",
+      workspace: "workspace-a",
       repository: "repository-a",
-      numVulnerabilities: 2,
+      vulnerabilityEvidence: "detected",
+      vulnerabilitiesDetected: true,
+      vulnerabilityCount: 2,
     });
     assert.throws(() => candidate({
       name: "alpha",
       state: "violated",
-      cloudsmithMatch: {
+      cloudsmithPackage: {
         namespace: "workspace-a",
         repository: "repository-a",
         slug_perm: "package-a",
       },
     }), TypeError);
+  });
+
+  test("requires branded canonical diagnostic packages and preserves vulnerability evidence", () => {
+    const rawBase = {
+      namespace: "workspace-a",
+      repository: "repository-a",
+      slug_perm: "package-a",
+      name: "alpha",
+      version: "1.0.0",
+      format: "npm",
+    };
+    const detected = fromApiPackageRecord({
+      ...rawBase,
+      num_vulnerabilities: 2,
+      security_scan_status: "Scan Detected Vulnerabilities",
+    });
+    const clean = fromApiPackageRecord({
+      ...rawBase,
+      num_vulnerabilities: 0,
+      security_scan_status: "Scan Detected No Vulnerabilities",
+    });
+    const unknown = fromApiPackageRecord(rawBase);
+    const detectedWithoutCount = fromApiPackageRecord({
+      ...rawBase,
+      has_vulnerabilities: true,
+      security_scan_status: "Scan Detected Vulnerabilities",
+    });
+
+    const detectedCandidate = candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithPackage: detected,
+    });
+    const cleanCandidate = candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithPackage: clean,
+    });
+    const unknownCandidate = candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithPackage: unknown,
+    });
+    const detectedWithoutCountCandidate = candidate({
+      name: "alpha",
+      state: "violated",
+      cloudsmithPackage: detectedWithoutCount,
+    });
+    assert.strictEqual(detectedCandidate.cloudsmith.vulnerabilityCount, 2);
+    assert.strictEqual(cleanCandidate.cloudsmith.vulnerabilityCount, 0);
+    assert.strictEqual(unknownCandidate.cloudsmith.vulnerabilityCount, null);
+    assert.deepStrictEqual(detectedWithoutCountCandidate.cloudsmith, {
+      workspace: "workspace-a",
+      repository: "repository-a",
+      vulnerabilityEvidence: "detected",
+      vulnerabilitiesDetected: true,
+      vulnerabilityCount: null,
+    });
+    assert.strictEqual(candidate({
+      name: "alpha",
+      state: "not_found",
+      cloudsmithPackage: null,
+    }).cloudsmith, null);
+
+    const publisher = new DiagnosticsPublisher({ createDiagnosticCollection });
+    const range = {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 5 },
+    };
+    assert.strictEqual(publisher._createDiagnostic(unknownCandidate, range).code, undefined);
+    assert.strictEqual(publisher._createDiagnostic(cleanCandidate, range).code, undefined);
+    assert.strictEqual(
+      publisher._createDiagnostic(detectedCandidate, range).code.value,
+      "2 vulnerabilities"
+    );
+    assert.match(publisher._getMessage(unknownCandidate), /unknown vulnerability status/);
+    assert.match(
+      publisher._getMessage(detectedWithoutCountCandidate),
+      /vulnerabilities detected/
+    );
+    assert.doesNotMatch(publisher._getMessage(unknownCandidate), /policy violations/);
+
+    for (const untrusted of [rawBase, { ...detected }]) {
+      assert.throws(() => candidate({
+        name: "alpha",
+        state: "violated",
+        cloudsmithPackage: untrusted,
+      }), TypeError);
+    }
+    const occurrence = candidate({
+      name: "alpha",
+      state: "not_found",
+      cloudsmithPackage: null,
+    }).occurrence;
+    assert.throws(() => createDiagnosticCandidate(occurrence, {
+      state: "violated",
+      displayVersion: "1.0.0",
+      cloudsmithMatch: detected,
+    }), /must use cloudsmithPackage/);
   });
 
   function createMemoryPublisher(files, options = {}) {
@@ -195,7 +296,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
       candidates: [createDiagnosticCandidate(healthOccurrence, {
         state: healthNode.state,
         displayVersion: healthNode.declaredVersion,
-        cloudsmithMatch: healthNode.cloudsmithMatch,
+        cloudsmithPackage: healthNode.package,
       })],
     });
     return { occurrence, prepared };
@@ -1192,7 +1293,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
       () => createDiagnosticCandidate(dependency, {
         state: "not_found",
         displayVersion: "1.0.0",
-        cloudsmithMatch: null,
+        cloudsmithPackage: null,
       }),
       /must not contain accessors/
     );
@@ -1220,7 +1321,7 @@ suite("DiagnosticsPublisher Test Suite", () => {
       () => createDiagnosticCandidate(forgedDependency, {
         state: "not_found",
         displayVersion: "1.0.0",
-        cloudsmithMatch: null,
+        cloudsmithPackage: null,
       }),
       /URI and path must identify the same file/
     );

--- a/test/packageDomain.test.js
+++ b/test/packageDomain.test.js
@@ -90,6 +90,120 @@ suite("Canonical package domain", () => {
     assert.ok(isExactPackage(pkg));
   });
 
+  test("normalizes reflection failures into trusted adapter errors", () => {
+    let hostileThrownValue;
+    hostileThrownValue = new Proxy({}, {
+      getPrototypeOf() {
+        throw hostileThrownValue;
+      },
+      ownKeys() {
+        throw hostileThrownValue;
+      },
+    });
+    for (const hostile of [
+      new Proxy({}, {
+        getPrototypeOf() {
+          throw new Error("untrusted getPrototypeOf trap");
+        },
+      }),
+      new Proxy({}, {
+        ownKeys() {
+          throw new Error("untrusted ownKeys trap");
+        },
+      }),
+      new Proxy({}, {
+        getPrototypeOf() {
+          throw hostileThrownValue;
+        },
+      }),
+    ]) {
+      assert.throws(() => fromApiPackageRecord(hostile), error => (
+        error instanceof PackageAdapterError
+        && !Object.prototype.hasOwnProperty.call(error, "cause")
+      ));
+      assert.throws(() => fromDependencyHealthNode({
+        cloudsmithPackage: hostile,
+      }), error => (
+        error instanceof PackageAdapterError
+        && !Object.prototype.hasOwnProperty.call(error, "cause")
+      ));
+    }
+
+    const unstableTarget = apiRecord();
+    const targetPropertyCount = Reflect.ownKeys(unstableTarget).length;
+    let descriptorReads = 0;
+    const falsyThrow = new Proxy(unstableTarget, {
+      getOwnPropertyDescriptor(target, field) {
+        descriptorReads += 1;
+        if (descriptorReads > targetPropertyCount) throw undefined;
+        return Reflect.getOwnPropertyDescriptor(target, field);
+      },
+    });
+    assert.throws(() => fromApiPackageRecord(falsyThrow), error => (
+      error instanceof PackageAdapterError
+      && error.unexpected === true
+      && !Object.prototype.hasOwnProperty.call(error, "cause")
+    ));
+
+    const forgedDomainError = Object.create(PackageDomainError.prototype);
+    Object.defineProperties(forgedDomainError, {
+      code: { value: "forged" },
+      field: { value: "forged" },
+      message: { value: "secret-bearing forged domain failure" },
+    });
+    const forgedTarget = apiRecord();
+    const forgedTargetPropertyCount = Reflect.ownKeys(forgedTarget).length;
+    let forgedDescriptorReads = 0;
+    const forgedThrow = new Proxy(forgedTarget, {
+      getOwnPropertyDescriptor(target, field) {
+        forgedDescriptorReads += 1;
+        if (forgedDescriptorReads > forgedTargetPropertyCount) throw forgedDomainError;
+        return Reflect.getOwnPropertyDescriptor(target, field);
+      },
+    });
+    assert.throws(() => fromApiPackageRecord(forgedThrow), error => (
+      error instanceof PackageAdapterError
+      && error.unexpected === true
+      && error.code === "invalid_api_package"
+      && !error.message.includes("secret-bearing")
+    ));
+
+    const unexpectedSelectionTarget = apiRecord();
+    let ownKeysCalls = 0;
+    let innerDescriptorReadsRemaining = null;
+    const unexpectedSelection = new Proxy(unexpectedSelectionTarget, {
+      ownKeys(target) {
+        ownKeysCalls += 1;
+        const keys = Reflect.ownKeys(target);
+        if (ownKeysCalls === 4) innerDescriptorReadsRemaining = keys.length;
+        return keys;
+      },
+      getOwnPropertyDescriptor(target, field) {
+        if (innerDescriptorReadsRemaining === 0) throw undefined;
+        if (innerDescriptorReadsRemaining !== null) innerDescriptorReadsRemaining -= 1;
+        return Reflect.getOwnPropertyDescriptor(target, field);
+      },
+    });
+    assert.throws(() => fromPackageSelection(unexpectedSelection), error => (
+      error instanceof PackageAdapterError
+      && error.code === "malformed_applicable_adapter"
+      && error.unexpected === true
+    ));
+
+    const exact = fromApiPackageRecord(apiRecord());
+    const hostileOptions = new Proxy({}, {
+      getOwnPropertyDescriptor() {
+        throw undefined;
+      },
+    });
+    assert.throws(() => fromApiPackageRecord(exact, hostileOptions), error => (
+      error instanceof PackageAdapterError
+      && error.code === "invalid_api_package"
+      && error.unexpected === true
+      && !Object.prototype.hasOwnProperty.call(error, "cause")
+    ));
+  });
+
   test("uses one exact, case-sensitive, delimiter-safe identity and immutable ref", () => {
     const upper = fromApiPackageRecord(apiRecord());
     const lower = fromApiPackageRecord(apiRecord({
@@ -371,7 +485,7 @@ suite("Canonical package domain", () => {
   test("requires exact identity and rejects unsafe encoded path identities", () => {
     assert.throws(
       () => fromApiPackageRecord(apiRecord({ slug_perm: undefined })),
-      PackageAdapterError
+      error => error instanceof PackageAdapterError && error.unexpected === false
     );
     for (const packageIdentifier of [
       "../package",

--- a/test/packageMetadataFlow.test.js
+++ b/test/packageMetadataFlow.test.js
@@ -7,6 +7,8 @@ const PackageNode = require("../models/packageNode");
 const SearchResultNode = require("../models/searchResultNode");
 const DependencyHealthNode = require("../models/dependencyHealthNode");
 const DependencySummaryNode = require("../models/dependencySummaryNode");
+const { fromApiPackageRecord } = require("../domain/packageAdapters");
+const { createPackageCoordinate } = require("../domain/package");
 
 suite("Package Metadata Flow Test Suite", () => {
   let originalGetConfiguration;
@@ -182,6 +184,304 @@ suite("Package Metadata Flow Test Suite", () => {
     });
   });
 
+  test("DependencyHealthNode preserves valid canonical and raw exact matches", () => {
+    const canonical = fromApiPackageRecord(pkg);
+    const dependency = {
+      name: "artifact",
+      version: "1.0.0",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+    };
+    const canonicalNode = new DependencyHealthNode({
+      ...dependency,
+      cloudsmithPackage: canonical,
+    }, null, {});
+    const rawNode = new DependencyHealthNode({
+      ...dependency,
+      cloudsmithPackage: pkg,
+    }, null, {});
+
+    assert.strictEqual(canonicalNode.package, canonical);
+    assert.strictEqual(canonicalNode.cloudsmithMatch, canonical);
+    assert.strictEqual(canonicalNode.cloudsmithStatus, "FOUND");
+    assert.strictEqual(canonicalNode.state, rawNode.state);
+    assert.strictEqual(canonicalNode.getTreeItem().contextValue, "dependencyHealthFound");
+    assert.match(canonicalNode.getTreeItem().description, /Vulnerability status unknown/);
+    assert.doesNotMatch(canonicalNode.getTreeItem().description, /No issues found/);
+    assert.deepStrictEqual(
+      rawNode.getChildren().map(child => child.getTreeItem().label),
+      canonicalNode.getChildren().map(child => child.getTreeItem().label)
+    );
+    assert.strictEqual(rawNode.package.workspace, canonical.workspace);
+    assert.strictEqual(rawNode.package.repository, canonical.repository);
+    assert.strictEqual(rawNode.package.packageIdentifier, canonical.packageIdentifier);
+  });
+
+  test("DependencyHealthNode contains malformed optional matches without restoring raw identity", () => {
+    let accessorCalls = 0;
+    const ownAccessor = { ...pkg };
+    Object.defineProperty(ownAccessor, "slug_perm", {
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return "unsafe-accessor";
+      },
+    });
+    const inheritedAccessor = Object.create({
+      get slug_perm() {
+        accessorCalls += 1;
+        return "unsafe-inherited";
+      },
+    });
+    for (const [key, value] of Object.entries(pkg)) {
+      if (key !== "slug_perm") {
+        Object.defineProperty(inheritedAccessor, key, {
+          configurable: true,
+          enumerable: true,
+          value,
+          writable: true,
+        });
+      }
+    }
+    const nonPlain = Object.assign(Object.create({ customPrototype: true }), pkg);
+    const malformedMatches = [
+      { ...pkg, slug_perm: undefined },
+      { ...pkg, name: undefined },
+      { ...pkg, version: undefined },
+      { ...pkg, format: undefined },
+      nonPlain,
+      ownAccessor,
+      inheritedAccessor,
+      new Proxy({}, {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf trap must be contained");
+        },
+      }),
+      new Proxy({}, {
+        ownKeys() {
+          throw new Error("ownKeys trap must be contained");
+        },
+      }),
+      { ...pkg, slug_perm_raw: "conflicting-package-id" },
+    ];
+
+    for (const malformedMatch of malformedMatches) {
+      let registeredSummaries = 0;
+      const node = new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+        cloudsmithPackage: malformedMatch,
+      }, null, {}, {
+        registerVulnerabilitySummary() {
+          registeredSummaries += 1;
+        },
+      });
+      const item = node.getTreeItem();
+
+      assert.strictEqual(node.package, null);
+      assert.strictEqual(node.cloudsmithMatch, null);
+      assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+      assert.strictEqual(node.state, "lookup_failed");
+      assert.strictEqual(node.namespace, undefined);
+      assert.strictEqual(node.repository, undefined);
+      assert.strictEqual(node.slug_perm, undefined);
+      assert.strictEqual(node.status_str, undefined);
+      assert.strictEqual(node.num_vulnerabilities, undefined);
+      assert.strictEqual(item.contextValue, "dependencyHealthUnknown");
+      assert.strictEqual(item.collapsibleState, vscode.TreeItemCollapsibleState.None);
+      assert.match(item.description, /Cloudsmith lookup failed/);
+      assert.doesNotMatch(item.description, /Not found|No issues found|Quarantined/);
+      assert.doesNotMatch(item.tooltip, /Found in Cloudsmith|Vulnerabilities: none known|Quarantined/);
+      assert.deepStrictEqual(node.getChildren(), []);
+      assert.strictEqual(registeredSummaries, 0);
+    }
+    assert.strictEqual(accessorCalls, 0);
+  });
+
+  test("DependencyHealthNode does not turn rejected zero-vulnerability evidence into clean state", () => {
+    const node = new DependencyHealthNode({
+      name: "artifact",
+      version: "1.0.0",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: {
+        ...pkg,
+        slug_perm: undefined,
+        num_vulnerabilities: 0,
+        security_scan_status: "Scan Detected No Vulnerabilities",
+        status_str: "Quarantined",
+      },
+    }, null, {});
+
+    assert.strictEqual(node.package, null);
+    assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+    assert.strictEqual(node._getVulnerabilityData(), null);
+    assert.strictEqual(node._getPolicyData(), null);
+    assert.doesNotMatch(node.getTreeItem().description, /No issues found|Quarantined/);
+    assert.deepStrictEqual(node.getChildren(), []);
+  });
+
+  test("DependencyHealthNode contains malformed matches from every compatibility input", () => {
+    const malformedMatch = {
+      ...pkg,
+      name: undefined,
+      slug_perm: "untrusted-package-id",
+      repository: "untrusted-repository",
+      slug_perm_raw: "untrusted-package-id",
+    };
+    const nodes = [
+      new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+        cloudsmithPackage: malformedMatch,
+      }, null, {}),
+      new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+        cloudsmithMatch: malformedMatch,
+      }, null, {}),
+      new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+      }, malformedMatch, {}),
+    ];
+
+    for (const node of nodes) {
+      assert.strictEqual(node.package, null);
+      assert.strictEqual(node.cloudsmithMatch, null);
+      assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+      assert.strictEqual(node.repository, undefined);
+      assert.strictEqual(node.slug_perm_raw, undefined);
+      assert.deepStrictEqual(node.getChildren(), []);
+    }
+  });
+
+  test("DependencyHealthNode requires consensus across simultaneous package evidence", () => {
+    const canonical = fromApiPackageRecord(pkg);
+    const conflicts = [
+      {
+        cloudsmithPackage: pkg,
+        cloudsmithMatch: { ...pkg, version: "9.9.9" },
+      },
+      {
+        cloudsmithPackage: "",
+        cloudsmithMatch: pkg,
+      },
+      {
+        cloudsmithPackage: pkg,
+        repository: "conflicting-repository",
+      },
+      {
+        package: createPackageCoordinate({
+          workspace: canonical.workspace,
+          repository: canonical.repository,
+          name: canonical.name,
+          version: canonical.version,
+          format: canonical.format,
+        }),
+      },
+    ];
+
+    for (const evidence of conflicts) {
+      const node = new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+        ...evidence,
+      }, null, {});
+      assert.strictEqual(node.package, null);
+      assert.strictEqual(node.cloudsmithMatch, null);
+      assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+      assert.deepStrictEqual(node.getChildren(), []);
+    }
+
+    const explicitConflict = new DependencyHealthNode({
+      name: "artifact",
+      version: "1.0.0",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: pkg,
+    }, { ...pkg, slug_perm: "conflicting-explicit-id" }, {});
+    assert.strictEqual(explicitConflict.package, null);
+    assert.strictEqual(explicitConflict.cloudsmithStatus, "LOOKUP_FAILED");
+  });
+
+  test("DependencyHealthNode preserves independent dependency license evidence after match rejection", () => {
+    const node = new DependencyHealthNode({
+      name: "artifact",
+      version: "1.0.0",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: {
+        ...pkg,
+        slug_perm: undefined,
+        license: "Rejected raw license",
+      },
+      license: {
+        display: "Apache-2.0",
+        spdx: "Apache-2.0",
+        raw: "Apache-2.0",
+        url: "https://spdx.org/licenses/Apache-2.0.html",
+      },
+    }, null, {});
+
+    assert.strictEqual(node.package, null);
+    assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+    assert.strictEqual(node.licenseInfo.displayValue, "Apache-2.0");
+    assert.notStrictEqual(node.licenseInfo.displayValue, "Rejected raw license");
+  });
+
+  test("DependencyHealthNode preserves no-match and explicit uncertainty states", () => {
+    for (const [cloudsmithStatus, expectedState] of [
+      ["LOOKUP_FAILED", "lookup_failed"],
+      ["NOT_FOUND", "not_found"],
+      [null, "unknown"],
+    ]) {
+      const node = new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus,
+      }, null, {});
+      assert.strictEqual(node.cloudsmithStatus, cloudsmithStatus);
+      assert.strictEqual(node.state, expectedState);
+      assert.strictEqual(node.package, null);
+      assert.ok(node.getTreeItem());
+    }
+  });
+
+  test("DependencyHealthNode does not retain exact enrichment for non-FOUND states", () => {
+    for (const cloudsmithStatus of ["LOOKUP_FAILED", "NOT_FOUND", "CHECKING"]) {
+      const node = new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus,
+        cloudsmithPackage: pkg,
+      }, null, {});
+
+      assert.strictEqual(node.cloudsmithStatus, cloudsmithStatus);
+      assert.strictEqual(node.package, null);
+      assert.strictEqual(node.cloudsmithMatch, null);
+      assert.strictEqual(node.namespace, undefined);
+      assert.strictEqual(node.repository, undefined);
+      assert.strictEqual(node.slug_perm, undefined);
+      assert.deepStrictEqual(node.getChildren(), []);
+      assert.notStrictEqual(node.getTreeItem().contextValue, "dependencyHealthFound");
+      assert.notStrictEqual(node.getTreeItem().contextValue, "dependencyHealthVulnerable");
+      assert.notStrictEqual(node.getTreeItem().contextValue, "dependencyHealthQuarantined");
+    }
+  });
+
   test("package, search, and dependency views preserve the same raw Cloudsmith license display", () => {
     const packageNode = new PackageNode(pkg, {});
     const searchNode = new SearchResultNode(pkg, {});
@@ -349,7 +649,7 @@ suite("Package Metadata Flow Test Suite", () => {
       status_str: "Quarantined",
     }, {});
 
-    assert.strictEqual(cleanNode.getTreeItem().description, "4.18.2 — No issues found");
+    assert.strictEqual(cleanNode.getTreeItem().description, "4.18.2 — Vulnerability status unknown");
     assert.strictEqual(vulnerableNode.getTreeItem().description, "4.18.2 — Vulnerabilities found (2 High)");
     assert.strictEqual(quarantinedNode.getTreeItem().description, "4.18.2 — Quarantined");
   });
@@ -395,7 +695,7 @@ suite("Package Metadata Flow Test Suite", () => {
       license_url: null,
     }, {});
 
-    assert.strictEqual(node.getTreeItem().description, "1.0.0 — No issues found");
+    assert.strictEqual(node.getTreeItem().description, "1.0.0 — Vulnerability status unknown");
     assert.match(node.getTreeItem().tooltip, /License: No license detected/);
   });
 
@@ -673,14 +973,18 @@ suite("Package Metadata Flow Test Suite", () => {
     for (const createNode of [
       () => new PackageNode({ ...pkg, is_copyable: "false" }, {}),
       () => new SearchResultNode({ ...pkg, is_copyable: "false" }, {}),
-      () => new DependencyHealthNode({
-        name: pkg.name,
-        version: pkg.version,
-        format: pkg.format,
-        cloudsmithPackage: { ...pkg, is_copyable: "false" },
-      }, null, {}),
     ]) {
       assert.throws(createNode, TypeError);
     }
+
+    const containedDependency = new DependencyHealthNode({
+      name: pkg.name,
+      version: pkg.version,
+      format: pkg.format,
+      cloudsmithStatus: "FOUND",
+      cloudsmithPackage: { ...pkg, is_copyable: "false" },
+    }, null, {});
+    assert.strictEqual(containedDependency.package, null);
+    assert.strictEqual(containedDependency.cloudsmithStatus, "LOOKUP_FAILED");
   });
 });

--- a/test/packageMetadataFlow.test.js
+++ b/test/packageMetadataFlow.test.js
@@ -7,7 +7,10 @@ const PackageNode = require("../models/packageNode");
 const SearchResultNode = require("../models/searchResultNode");
 const DependencyHealthNode = require("../models/dependencyHealthNode");
 const DependencySummaryNode = require("../models/dependencySummaryNode");
-const { fromApiPackageRecord } = require("../domain/packageAdapters");
+const {
+  PackageAdapterError,
+  fromApiPackageRecord,
+} = require("../domain/packageAdapters");
 const { createPackageCoordinate } = require("../domain/package");
 
 suite("Package Metadata Flow Test Suite", () => {
@@ -215,6 +218,114 @@ suite("Package Metadata Flow Test Suite", () => {
     assert.strictEqual(rawNode.package.workspace, canonical.workspace);
     assert.strictEqual(rawNode.package.repository, canonical.repository);
     assert.strictEqual(rawNode.package.packageIdentifier, canonical.packageIdentifier);
+  });
+
+  test("DependencyHealthNode renders only meaningful status details", () => {
+    const baseDependency = {
+      name: "artifact",
+      version: "1.0.0",
+      format: "raw",
+      cloudsmithStatus: "FOUND",
+    };
+    const packageWithStatus = fromApiPackageRecord(pkg);
+    const packageWithoutStatus = fromApiPackageRecord({
+      ...pkg,
+      status_str: undefined,
+    });
+    const statusNode = new DependencyHealthNode({
+      ...baseDependency,
+      cloudsmithPackage: packageWithStatus,
+    }, null, {});
+    const policyNode = new DependencyHealthNode({
+      ...baseDependency,
+      cloudsmithPackage: packageWithStatus,
+      policy: { status: "Policy quarantined" },
+    }, null, {});
+    const noStatusNode = new DependencyHealthNode({
+      ...baseDependency,
+      cloudsmithPackage: packageWithoutStatus,
+    }, null, {});
+    const invalidDisplayNodes = [{ unsafe: true }, 2].map(status => new DependencyHealthNode({
+      ...baseDependency,
+      cloudsmithPackage: packageWithoutStatus,
+      policy: { status },
+    }, null, {}));
+
+    const details = node => node.getChildren().map(child => child.getTreeItem());
+    assert.strictEqual(
+      details(statusNode).find(item => item.tooltip.startsWith("Status:")).label,
+      "Completed"
+    );
+    assert.strictEqual(
+      details(policyNode).find(item => item.tooltip.startsWith("Status:")).label,
+      "Policy quarantined"
+    );
+    for (const node of [noStatusNode, ...invalidDisplayNodes]) {
+      const items = details(node);
+      assert.strictEqual(items.some(item => item.tooltip.startsWith("Status:")), false);
+      assert.ok(items.some(item => item.tooltip.startsWith("Version:") && item.label === "1.0.0"));
+      assert.strictEqual(items.some(item => ["Not available", "Unknown", "undefined", "[object Object]"].includes(item.label)), false);
+    }
+    assert.throws(() => fromApiPackageRecord({ ...pkg, status_str: "" }), /status/);
+  });
+
+  test("DependencyHealthNode reports unclassified match failures without exposing input", () => {
+    const originalWarn = Object.getOwnPropertyDescriptor(console, "warn");
+    const warnings = [];
+    Object.defineProperty(console, "warn", {
+      configurable: true,
+      value: (...args) => warnings.push(args),
+      writable: true,
+    });
+    try {
+      const expectedBoundaryFailure = new DependencyHealthNode({
+        name: "artifact",
+        version: "1.0.0",
+        format: "raw",
+        cloudsmithStatus: "FOUND",
+        cloudsmithPackage: { ...pkg, slug_perm: undefined },
+      }, null, {});
+      assert.strictEqual(expectedBoundaryFailure.package, null);
+      assert.strictEqual(expectedBoundaryFailure.cloudsmithStatus, "LOOKUP_FAILED");
+      assert.deepStrictEqual(warnings, []);
+
+      const forgedAdapterError = Object.create(PackageAdapterError.prototype);
+      Object.defineProperty(forgedAdapterError, "unexpected", { value: false });
+      for (const thrownValue of [
+        new Error("secret-bearing unexpected validation detail"),
+        undefined,
+        forgedAdapterError,
+      ]) {
+        const unstableTarget = { ...pkg };
+        const targetPropertyCount = Reflect.ownKeys(unstableTarget).length;
+        let descriptorReads = 0;
+        const node = new DependencyHealthNode({
+          name: "artifact",
+          version: "1.0.0",
+          format: "raw",
+          cloudsmithStatus: "FOUND",
+          cloudsmithPackage: new Proxy(unstableTarget, {
+            getOwnPropertyDescriptor(target, field) {
+              descriptorReads += 1;
+              if (descriptorReads > targetPropertyCount) throw thrownValue;
+              return Reflect.getOwnPropertyDescriptor(target, field);
+            },
+          }),
+        }, null, {});
+
+        assert.strictEqual(node.package, null);
+        assert.strictEqual(node.cloudsmithStatus, "LOOKUP_FAILED");
+        assert.deepStrictEqual(node.getChildren(), []);
+      }
+      assert.deepStrictEqual(warnings, [
+        ["[Cloudsmith] Unexpected dependency package match validation failure."],
+        ["[Cloudsmith] Unexpected dependency package match validation failure."],
+        ["[Cloudsmith] Unexpected dependency package match validation failure."],
+      ]);
+      assert.doesNotMatch(JSON.stringify(warnings), /secret-bearing|validation detail/);
+    } finally {
+      Object.defineProperty(console, "warn", originalWarn);
+    }
   });
 
   test("DependencyHealthNode contains malformed optional matches without restoring raw identity", () => {

--- a/util/diagnosticsPublisher.js
+++ b/util/diagnosticsPublisher.js
@@ -3,6 +3,7 @@ const crypto = require("crypto");
 const path = require("path");
 const { pathToFileURL } = require("url");
 const vscode = require("vscode");
+const { assertExactPackage } = require("../domain/package");
 const {
   createDependencyRecord,
   createDependencySource,
@@ -559,20 +560,16 @@ function snapshotCloudsmithMetadata(value) {
   if (value == null) {
     return null;
   }
-  const properties = getPlainDataProperties(value, "Cloudsmith diagnostic metadata");
-  const namespace = boundedOptionalString(
-    ownDataValue(properties, "namespace", false),
-    "Cloudsmith namespace",
-    MAX_PACKAGE_NAME_LENGTH
-  );
-  const repository = boundedOptionalString(
-    ownDataValue(properties, "repository", false),
-    "Cloudsmith repository",
-    MAX_PACKAGE_NAME_LENGTH
-  );
-  const rawCount = ownDataValue(properties, "num_vulnerabilities", false);
-  const numVulnerabilities = Number.isInteger(rawCount) && rawCount > 0 ? rawCount : 0;
-  return Object.freeze({ namespace, repository, numVulnerabilities });
+  const pkg = assertExactPackage(value);
+  const numVulnerabilities = Number.isInteger(pkg.vulnerability.count)
+    && pkg.vulnerability.count > 0
+    ? pkg.vulnerability.count
+    : 0;
+  return Object.freeze({
+    namespace: pkg.workspace,
+    repository: pkg.repository,
+    numVulnerabilities,
+  });
 }
 
 function snapshotCandidateArray(candidates, maximum) {

--- a/util/diagnosticsPublisher.js
+++ b/util/diagnosticsPublisher.js
@@ -43,7 +43,9 @@ class DiagnosticPreparationCancelledError extends Error {
 
 /**
  * Create a bounded immutable diagnostic input without retaining mutable health
- * overlays or the dependency's transitive graph.
+ * overlays or the dependency's transitive graph. Optional Cloudsmith package
+ * metadata must be supplied as values.cloudsmithPackage and must be a branded
+ * canonical exact package.
  */
 function createDiagnosticCandidate(dependency, values = {}) {
   const dependencyProperties = getPlainDataProperties(dependency, "dependency occurrence");
@@ -138,6 +140,9 @@ function createDiagnosticCandidate(dependency, values = {}) {
   });
 
   const valuesProperties = getPlainDataProperties(values, "diagnostic candidate values");
+  if (Object.prototype.hasOwnProperty.call(valuesProperties, "cloudsmithMatch")) {
+    throw new TypeError("Diagnostic package metadata must use cloudsmithPackage.");
+  }
   const state = boundedString(
     ownDataValue(valuesProperties, "state", true),
     "diagnostic state",
@@ -151,8 +156,8 @@ function createDiagnosticCandidate(dependency, values = {}) {
     "diagnostic display version",
     MAX_IDENTITY_FIELD_LENGTH
   );
-  const cloudsmith = snapshotCloudsmithMetadata(
-    ownDataValue(valuesProperties, "cloudsmithMatch", false)
+  const cloudsmith = snapshotCanonicalPackageMetadata(
+    ownDataValue(valuesProperties, "cloudsmithPackage", false)
   );
   const candidate = Object.freeze({ occurrence, state, displayVersion, cloudsmith });
   DIAGNOSTIC_CANDIDATES.add(candidate);
@@ -418,12 +423,12 @@ class DiagnosticsPublisher {
     );
     diagnostic.source = "Cloudsmith";
 
-    if (candidate.cloudsmith && candidate.cloudsmith.numVulnerabilities > 0) {
+    if (candidate.cloudsmith && candidate.cloudsmith.vulnerabilityCount > 0) {
       const repositoryUrl = buildRepositoryUrl(
-        candidate.cloudsmith.namespace,
+        candidate.cloudsmith.workspace,
         candidate.cloudsmith.repository
       );
-      const vulnerabilityCode = `${candidate.cloudsmith.numVulnerabilities} vulnerabilities`;
+      const vulnerabilityCode = `${candidate.cloudsmith.vulnerabilityCount} vulnerabilities`;
       diagnostic.code = repositoryUrl
         ? { value: vulnerabilityCode, target: vscode.Uri.parse(repositoryUrl) }
         : vulnerabilityCode;
@@ -448,6 +453,12 @@ class DiagnosticsPublisher {
       case "quarantined":
         return `${candidate.occurrence.name}${version} is quarantined in Cloudsmith. Use "Find safe version" to find an alternative.`;
       case "violated":
+        if (candidate.cloudsmith?.vulnerabilitiesDetected) {
+          return `${candidate.occurrence.name}${version} has vulnerabilities detected in Cloudsmith.`;
+        }
+        if (candidate.cloudsmith?.vulnerabilityEvidence === "unknown") {
+          return `${candidate.occurrence.name}${version} has unknown vulnerability status in Cloudsmith.`;
+        }
         return `${candidate.occurrence.name}${version} has policy violations in Cloudsmith.`;
       default:
         return `${candidate.occurrence.name}${version} was not found in the configured Cloudsmith workspace.`;
@@ -556,19 +567,17 @@ function snapshotStringArray(values, label) {
   return Object.freeze(copy);
 }
 
-function snapshotCloudsmithMetadata(value) {
+function snapshotCanonicalPackageMetadata(value) {
   if (value == null) {
     return null;
   }
   const pkg = assertExactPackage(value);
-  const numVulnerabilities = Number.isInteger(pkg.vulnerability.count)
-    && pkg.vulnerability.count > 0
-    ? pkg.vulnerability.count
-    : 0;
   return Object.freeze({
-    namespace: pkg.workspace,
+    workspace: pkg.workspace,
     repository: pkg.repository,
-    numVulnerabilities,
+    vulnerabilityEvidence: pkg.vulnerability.evidence,
+    vulnerabilitiesDetected: pkg.vulnerability.detected,
+    vulnerabilityCount: pkg.vulnerability.count,
   });
 }
 

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -770,7 +770,7 @@ class DependencyHealthProvider {
         candidates.push(createDiagnosticCandidate(dependency, {
           state: healthNode.state,
           displayVersion: healthNode.declaredVersion || null,
-          cloudsmithMatch: healthNode.cloudsmithMatch || null,
+          cloudsmithPackage: healthNode.package || null,
         }));
       }
     }


### PR DESCRIPTION
## Summary

- Omit the optional Dependency Health Status detail when no meaningful canonical or policy status exists.
- Normalize hostile package-match reflection failures into trusted adapter errors while preserving fail-closed tree rendering and redacted internal reporting for unexpected failures.
- Make diagnostic candidates accept only canonical exact packages through the `cloudsmithPackage` field and preserve detected, clean, and unknown vulnerability evidence truthfully.

## Validation

- `npm run lint`
- `npm test` — 569 standalone Node tests and 785 VS Code tests
- `npm run verify:architecture` — 116 runtime files, 64 executable registrations, 61 invalid fixtures
- `npm run check`
- `git diff --check`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm run audit:runtime`
- direct VS Code zero-test entrypoint — confirmed `0 passing`, `1 test failed`, exit 1
- `npm run package`
- `npm run package:verify` — 1,190 VSIX entries verified
- Extension Development Host — npm and Python Dependency Health scans and rescans