### PR TITLE
fix: make dependency pull-through reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Reliability and security
 
 - Hardened Dependency Health across all 14 supported ecosystem families and their manifest and lockfile variants, improving direct/transitive relationships, provenance, large-graph handling, cancellation, and protection against false covered or complete results.
+- Made Dependency Health pull-through use registry-native artifact requests and exact target-repository verification across supported package formats.
 - Made broad package search and pagination reliable across overlapping requests, refreshes, account changes, and stale workspace or repository selections.
 - Made authentication startup and account switching atomic so valid stored credentials no longer appear disconnected during validation and old-account data cannot publish after a switch.
 - Hardened package identity, install-command input, file, path, URL, redirect, WebView message, and API processing boundaries so malformed or stale data cannot drive actions or expose credentials.

--- a/commands/packages.js
+++ b/commands/packages.js
@@ -18,10 +18,11 @@ const {
 } = require("./support");
 
 const MAX_FILTER_INPUT_LENGTH = 2048;
+const QUERY_CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
 
 function filterInputValidationMessage(value) {
   if (typeof value !== "string") return "Enter a filter query.";
-  if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)) {
+  if (QUERY_CONTROL_OR_BIDI_PATTERN.test(value)) {
     return "Filter queries cannot contain control characters.";
   }
   if (value.length > MAX_FILTER_INPUT_LENGTH) {

--- a/commands/search.js
+++ b/commands/search.js
@@ -7,7 +7,7 @@ const {
 } = require("../util/searchIntent");
 const {
   buildPresetQuery,
-  buildRawSearchQuery,
+  buildAdvancedSearchQuery,
   canonicalRepository,
   captureCommandAccount,
   createFilterPresets,
@@ -21,10 +21,11 @@ const {
 } = require("./support");
 
 const MAX_SEARCH_INPUT_LENGTH = 2048;
+const QUERY_CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
 
 function searchInputValidationMessage(value) {
   if (typeof value !== "string") return "Enter a search query.";
-  if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)) {
+  if (QUERY_CONTROL_OR_BIDI_PATTERN.test(value)) {
     return "Search queries cannot contain control characters.";
   }
   if (value.length > MAX_SEARCH_INPUT_LENGTH) {
@@ -115,7 +116,7 @@ function registerSearchCommands(deps) {
     await executeSearchIntent(searchProvider, {
       kind: "workspace",
       workspace,
-      query: buildRawSearchQuery(SearchQueryBuilder, query),
+      query: buildAdvancedSearchQuery(SearchQueryBuilder, query),
       page: 1,
     }, { recentSearches, record: true, isCurrent: account.isCurrent });
     if (!isCommandAccountCurrent(account)) return;
@@ -149,7 +150,7 @@ function registerSearchCommands(deps) {
     await executeSearchIntent(searchProvider, {
       kind: "workspace",
       workspace,
-      query: buildRawSearchQuery(SearchQueryBuilder, query),
+      query: buildAdvancedSearchQuery(SearchQueryBuilder, query),
       page: 1,
     }, { recentSearches, record: true, isCurrent });
     if (!isCurrent()) return;
@@ -273,13 +274,22 @@ function registerSearchCommands(deps) {
         .join(" OR ");
       queryParts.push(`(${formatQuery})`);
     }
-    const builder = new SearchQueryBuilder();
-    for (const part of queryParts) builder.raw(part);
+    const finalQuery = queryParts
+      .map(part => queryParts.length > 1 ? `(${part})` : part)
+      .join(" AND ") || "*";
+    const finalQueryError = searchInputValidationMessage(finalQuery);
+    if (finalQueryError) {
+      await deps.vscode.window.showWarningMessage(
+        "The combined search query exceeds the safe query limit. Shorten the custom query or select fewer formats."
+      );
+      return;
+    }
+    const builder = new SearchQueryBuilder().advanced(finalQuery);
     if (!isCommandAccountCurrent(account)) return;
     await executeSearchIntent(searchProvider, {
       kind: selectedRepos ? "repositories" : "workspace",
       workspace,
-      query: builder.build() || "*",
+      query: builder.build(),
       page: 1,
       ...(selectedRepos ? { repositories: selectedRepos } : {}),
     }, { recentSearches, record: true, isCurrent: account.isCurrent });

--- a/commands/support.js
+++ b/commands/support.js
@@ -676,14 +676,15 @@ function commentCommandNote(note) {
     .join("\n");
 }
 
-function buildRawSearchQuery(SearchQueryBuilder, query) {
-  return new SearchQueryBuilder().raw(query).build();
+function buildAdvancedSearchQuery(SearchQueryBuilder, query) {
+  if (query == null || query === "") return "";
+  return new SearchQueryBuilder().advanced(query).build();
 }
 
 function buildPresetQuery(SearchQueryBuilder, preset, customQuery) {
   if (!preset) return "";
   if (preset.applyBuilder === null) {
-    return buildRawSearchQuery(SearchQueryBuilder, customQuery || "");
+    return buildAdvancedSearchQuery(SearchQueryBuilder, customQuery || "");
   }
   const builder = new SearchQueryBuilder();
   const maybeString = preset.applyBuilder(builder);
@@ -731,7 +732,7 @@ module.exports = {
   adaptRepositoryResolutionSelection,
   buildInstallCommand,
   buildPresetQuery,
-  buildRawSearchQuery,
+  buildAdvancedSearchQuery,
   canonicalRepository,
   captureCommandAccount,
   isCommandAccountCurrent,

--- a/domain/package.js
+++ b/domain/package.js
@@ -9,6 +9,27 @@ const MAX_METADATA_LENGTH = 4096;
 const MAX_URL_LENGTH = 8192;
 const MAX_TAGS_PER_FIELD = 100;
 const MAX_TAG_LENGTH = 500;
+const MAX_COORDINATE_QUALIFIER_VALUE_LENGTH = 4096;
+const MAX_COORDINATE_QUALIFIER_ARRAY_LENGTH = 64;
+
+const PACKAGE_COORDINATE_QUALIFIER_KEYS = Object.freeze([
+  "alias",
+  "classifier",
+  "configurations",
+  "digest",
+  "environment",
+  "platform",
+  "pullPolicy",
+  "repository",
+  "scope",
+  "section",
+  "service",
+  "stage",
+  "tag",
+  "targetFramework",
+  "type",
+]);
+const PACKAGE_COORDINATE_QUALIFIER_KEY_SET = new Set(PACKAGE_COORDINATE_QUALIFIER_KEYS);
 
 const CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
 const UNSAFE_PATH_PATTERN = /[\\/?#]/;
@@ -24,6 +45,7 @@ const SEMANTIC_FIELDS = Object.freeze([
   "name",
   "version",
   "format",
+  "qualifiers",
   "slug",
   "status",
   "statusReason",
@@ -119,6 +141,7 @@ function createPackageCoordinate(input) {
     name: requiredString(source, "name", MAX_NAME_LENGTH, { trim: false }),
     version: requiredString(source, "version", MAX_VERSION_LENGTH, { trim: false }),
     format: requiredString(source, "format", MAX_FORMAT_LENGTH),
+    qualifiers: createPackageCoordinateQualifiers(readOwn(source, "qualifiers")),
   };
   Object.freeze(value);
   PACKAGE_COORDINATES.add(value);
@@ -207,6 +230,70 @@ function createTags(value) {
     info: createStringArray(readOwn(source, "info"), "tags.info"),
     version: createStringArray(readOwn(source, "version"), "tags.version"),
   });
+}
+
+function createPackageCoordinateQualifiers(value) {
+  if (value == null) return Object.freeze({});
+  const source = requireRecord(value, "package coordinate qualifiers");
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (!PACKAGE_COORDINATE_QUALIFIER_KEY_SET.has(key)) {
+      throw domainError(
+        "unknown_field",
+        `qualifiers.${key}`,
+        "The package coordinate qualifiers contain an unsupported field."
+      );
+    }
+  }
+
+  const qualifiers = {};
+  for (const key of PACKAGE_COORDINATE_QUALIFIER_KEYS) {
+    const qualifier = readOwn(source, key);
+    if (qualifier === undefined || qualifier === null || qualifier === "") continue;
+    if (key === "configurations") {
+      Object.defineProperty(qualifiers, key, {
+        value: createCoordinateQualifierArray(qualifier, `qualifiers.${key}`),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      continue;
+    }
+    Object.defineProperty(qualifiers, key, {
+      value: validateString(
+        qualifier,
+        `qualifiers.${key}`,
+        MAX_COORDINATE_QUALIFIER_VALUE_LENGTH
+      ),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return Object.freeze(qualifiers);
+}
+
+function createCoordinateQualifierArray(value, field) {
+  if (!Array.isArray(value) || value.length > MAX_COORDINATE_QUALIFIER_ARRAY_LENGTH) {
+    throw domainError("invalid_array", field, `The ${field} value is invalid.`);
+  }
+  assertNoSymbolProperties(value, field);
+  assertNoOwnAccessors(value, field);
+  if (Object.getPrototypeOf(value) !== Array.prototype) {
+    throw domainError("invalid_array", field, `The ${field} value is invalid.`);
+  }
+  const result = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor || !("value" in descriptor)) {
+      throw domainError("invalid_array", field, `The ${field} value is invalid.`);
+    }
+    result.push(validateString(
+      descriptor.value,
+      field,
+      MAX_COORDINATE_QUALIFIER_VALUE_LENGTH
+    ));
+  }
+  return Object.freeze(result);
 }
 
 function createStringArray(value, field) {

--- a/domain/packageAdapters.js
+++ b/domain/packageAdapters.js
@@ -32,6 +32,7 @@ const SEMANTIC_FIELDS = Object.freeze([
   "declaredVersion",
   "resolvedVersion",
   "format",
+  "qualifiers",
   "status",
   "status_str",
   "status_str_raw",
@@ -432,7 +433,15 @@ function fromDependencyHealthNode(node, options = {}) {
       required: true,
       unwrapDepth: MAX_WRAPPER_DEPTH,
     });
-    return createPackageCoordinate({ workspace, repository, name, version, format });
+    const qualifiers = readOwn(node, "qualifiers");
+    return createPackageCoordinate({
+      workspace,
+      repository,
+      name,
+      version,
+      format,
+      qualifiers,
+    });
   } catch (error) {
     throw asAdapterError(error, "invalid_dependency_package", "dependency package");
   }

--- a/test/commandRegistrars.test.js
+++ b/test/commandRegistrars.test.js
@@ -1599,6 +1599,7 @@ suite("Command registrars", () => {
       workspace: "workspace-a",
       repository: "repo-a",
       name: "left-pad",
+      qualifiers: Object.freeze({ targetFramework: "net8.0" }),
     });
     const exact = Object.freeze({
       identityState: "exact",

--- a/test/commandRegistrars.test.js
+++ b/test/commandRegistrars.test.js
@@ -802,6 +802,14 @@ suite("Command registrars", () => {
       searchValidator("name:flask\u0000"),
       "Search queries cannot contain control characters."
     );
+    assert.strictEqual(
+      searchValidator("name:flask\nOR name:other"),
+      "Search queries cannot contain control characters."
+    );
+    assert.strictEqual(
+      searchValidator("name:flask\u202e"),
+      "Search queries cannot contain control characters."
+    );
     assert.strictEqual(searchValidator("a".repeat(2048)), null);
     assert.strictEqual(
       searchValidator("a".repeat(2049)),
@@ -839,6 +847,14 @@ suite("Command registrars", () => {
     assert.strictEqual(filterValidator(" format:python "), null);
     assert.strictEqual(
       filterValidator("format:python\u0000"),
+      "Filter queries cannot contain control characters."
+    );
+    assert.strictEqual(
+      filterValidator("format:python\nOR format:npm"),
+      "Filter queries cannot contain control characters."
+    );
+    assert.strictEqual(
+      filterValidator("format:python\u202e"),
       "Filter queries cannot contain control characters."
     );
     assert.strictEqual(filterValidator("a".repeat(2048)), null);
@@ -1140,7 +1156,7 @@ suite("Command registrars", () => {
     const operations = [];
     const serviceFailure = Object.freeze({ ok: false, error: "search unavailable" });
     class SearchQueryBuilder {
-      raw(value) { this.value = value; return this; }
+      advanced(value) { this.value = value; return this; }
       build() { return this.value; }
     }
     class RecentSearches {
@@ -1190,6 +1206,7 @@ suite("Command registrars", () => {
       },
       workspaceAccess: harness.access,
       SearchQueryBuilder: class {
+        advanced() { return this; }
         raw() { return this; }
         build() { return "name:widget"; }
       },
@@ -1344,6 +1361,55 @@ suite("Command registrars", () => {
     assert.strictEqual(JSON.stringify(repositoryItems).includes("\u2066"), false);
   });
 
+  test("guided search rejects an oversized combined custom and format query gracefully", async () => {
+    const recorder = recordingRegistration();
+    const warnings = [];
+    let beginCalls = 0;
+    class RecentSearches {
+      async getAll() { return []; }
+    }
+    class SearchQueryBuilder {
+      advanced(value) { this.value = value; return this; }
+      format(value) { this.value = `format:${value}`; return this; }
+      build() { return this.value || ""; }
+    }
+    registerSearchCommands({
+      ...baseDependencies(recorder),
+      context: {},
+      FORMAT_OPTIONS: ["npm"],
+      SearchQueryBuilder,
+      RecentSearches,
+      vscode: {
+        workspace: { getConfiguration: () => ({ get: () => "workspace-a" }) },
+        window: {
+          async showInputBox() { return "x".repeat(2048); },
+          async showQuickPick(items, options) {
+            if (options.placeHolder === "Step 2: Select a search scope") {
+              return items.find(item => item.scope === "all");
+            }
+            if (options.placeHolder === "Step 3: Select a filter") {
+              return items.find(item => item.preset && item.preset.applyBuilder === null);
+            }
+            if (options.placeHolder === "Step 4: Filter by format (optional)") {
+              return [items.find(item => item.label === "npm")];
+            }
+            throw new Error(`Unexpected picker: ${options.placeHolder}`);
+          },
+          async showWarningMessage(message) { warnings.push(message); },
+        },
+      },
+      workspaceAccess: workspaceCollectionHarness().access,
+      searchProvider: { beginSearch() { beginCalls += 1; } },
+    });
+
+    await recorder.handlers.get("cloudsmith-vsc.guidedSearch")();
+
+    assert.strictEqual(beginCalls, 0);
+    assert.deepStrictEqual(warnings, [
+      "The combined search query exceeds the safe query limit. Shorten the custom query or select fewer formats.",
+    ]);
+  });
+
   test("workspace search shortcuts recheck provider ownership after recovery prompts", async () => {
     const recorder = recordingRegistration();
     let current = true;
@@ -1366,6 +1432,7 @@ suite("Command registrars", () => {
       workspaceAccess: workspaceCollectionHarness().access,
       RecentSearches,
       SearchQueryBuilder: class {
+        advanced() { return this; }
         raw() { return this; }
         build() { return "name:widget"; }
       },

--- a/test/dependencyAdapterRegistry.test.js
+++ b/test/dependencyAdapterRegistry.test.js
@@ -6,6 +6,7 @@ const {
   ADAPTER_RESULT_STATUSES,
   DependencyAdapterRegistry,
   createDefaultDependencyAdapterRegistry,
+  createSafeAdapterWarning,
 } = require("../util/dependencyAdapterRegistry");
 const {
   DEPENDENCY_VERSION_STATES,
@@ -43,6 +44,32 @@ suite("dependencyAdapterRegistry", () => {
       },
     };
   }
+
+  test("preserves code-owned Docker and Compose warning classes at the UI boundary", () => {
+    const fixtures = [
+      [
+        "A Dockerfile target platform could not be resolved, so dependency results are partial.",
+        "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.",
+      ],
+      [
+        "A Compose image reference could not be resolved, so dependency results are partial.",
+        "A Compose image reference could not be resolved; affected dependencies were omitted.",
+      ],
+      [
+        "A Compose image platform could not be resolved, so dependency results are partial.",
+        "A Compose image platform could not be resolved; affected dependencies remain incomplete.",
+      ],
+      [
+        "A Compose image platform was invalid and could not be checked.",
+        "A Compose image platform was invalid; affected dependencies remain incomplete.",
+      ],
+    ];
+
+    for (const [warning, expected] of fixtures) {
+      assert.strictEqual(createSafeAdapterWarning(warning), expected);
+      assert.strictEqual(createSafeAdapterWarning(expected), expected);
+    }
+  });
 
   suiteTeardown(async () => {
     await Promise.all(tempDirs.map((tempDir) => removeDirectory(tempDir)));

--- a/test/dependencyAdapterRegistry.test.js
+++ b/test/dependencyAdapterRegistry.test.js
@@ -58,6 +58,30 @@ suite("dependencyAdapterRegistry", () => {
     assert.strictEqual(adapter.ecosystem, "npm");
   });
 
+  test("keeps an unresolved Docker target platform ineligible after canonical adaptation", async () => {
+    const workspace = await createWorkspace();
+    const dockerfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(
+      dockerfilePath,
+      "FROM --platform=$TARGETPLATFORM example/api:1.2.3\n"
+    );
+
+    const result = await createDefaultDependencyAdapterRegistry().parseManifest({
+      filePath: dockerfilePath,
+      format: "docker",
+      workspaceFolder: workspace,
+    });
+
+    assert.strictEqual(result.status, ADAPTER_RESULT_STATUSES.PARTIAL);
+    assert.strictEqual(result.dependencies.length, 1);
+    assert.strictEqual(
+      result.dependencies[0].versionState,
+      DEPENDENCY_VERSION_STATES.INCOMPLETE
+    );
+    assert.strictEqual(result.dependencies[0].resolvedVersion, null);
+    assert.strictEqual(result.dependencies[0].lookupEligibility.state, "unresolved");
+  });
+
   test("accepts an empty adapter detection array", async () => {
     const registry = new DependencyAdapterRegistry([
       createContractAdapter("empty-detector", async () => []),

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -177,13 +177,14 @@ suite("DependencyHealthProvider Test Suite", () => {
     };
   }
 
-  function pullCoordinate(name, version, format = "npm") {
+  function pullCoordinate(name, version, format = "npm", qualifiers = {}) {
     return createPackageCoordinate({
       workspace: "workspace-a",
       repository: "repo-a",
       name,
       version,
       format,
+      qualifiers,
     });
   }
 
@@ -2072,6 +2073,170 @@ suite("DependencyHealthProvider Test Suite", () => {
     );
   });
 
+  test("_runCoverageChecks matches Docker dependencies by Cloudsmith version tag", async () => {
+    const dependency = createDependency("alpine", "3.20.3", "docker");
+    const provider = new DependencyHealthProvider(createContext());
+    provider._fullTrees = [{
+      ecosystem: "docker",
+      sourceFile: "docker-compose.yml",
+      dependencies: [dependency],
+    }];
+    provider._displayTrees = cloneTrees(provider._fullTrees);
+    provider._rebuildSummary = () => {};
+    provider.refresh = () => {};
+    let requestedQuery = "";
+    provider._services.createCloudsmithAPI = () => createLookupApi((endpoint) => {
+      requestedQuery = new URL(endpoint, "https://api.cloudsmith.io/v1/")
+        .searchParams.get("query");
+      return lookupPage([{
+        name: "library/alpine",
+        version: "a".repeat(64),
+        format: "docker",
+        tags: { info: ["upstream"], version: ["3.20.3"] },
+      }]);
+    });
+
+    await provider._runCoverageChecks(
+      "workspace",
+      "repo",
+      1,
+      { report() {} },
+      { isCancellationRequested: false }
+    );
+
+    assert.doesNotMatch(requestedQuery, /version:3\.20\.3/);
+    assert.strictEqual(provider._fullTrees[0].dependencies[0].cloudsmithStatus, "FOUND");
+    assert.deepStrictEqual(
+      provider._fullTrees[0].dependencies[0].cloudsmithPackage.tags.version,
+      ["3.20.3"]
+    );
+  });
+
+  test("coverage matching requires exact Docker, Maven, and Ruby qualifiers and normalizes NuGet", () => {
+    const dockerDependency = {
+      ...createDependency("example", "stable", "docker"),
+      qualifiers: { tag: "stable", digest: `sha256:${"a".repeat(64)}` },
+    };
+    assert.strictEqual(matchCoverageCandidates([{
+      name: "library/example",
+      version: "b".repeat(64),
+      format: "docker",
+      tags: { version: ["stable"] },
+    }], dockerDependency), null);
+    assert.ok(matchCoverageCandidates([{
+      name: "library/example",
+      version: "a".repeat(64),
+      format: "docker",
+      tags: { version: ["stable"] },
+    }], dockerDependency));
+    const dockerPlatformDependency = {
+      ...createDependency("example", "stable", "docker"),
+      qualifiers: { tag: "stable", platform: "linux/arm64" },
+    };
+    const dockerTagCandidate = {
+      name: "library/example",
+      version: "a".repeat(64),
+      format: "docker",
+      tags: { version: ["stable"] },
+    };
+    assert.strictEqual(matchCoverageCandidates([
+      {
+        ...dockerTagCandidate,
+        name: "library/example",
+        version: "b".repeat(64),
+        format: "docker",
+        tags: { version: ["stable"] },
+        architectures: [{ name: "amd64" }],
+        identifiers: { architecture: "amd64", docker_platform_os: "linux" },
+      },
+    ], dockerPlatformDependency), null);
+    assert.strictEqual(matchCoverageCandidates([
+      dockerTagCandidate,
+      {
+        name: "library/example",
+        version: "c".repeat(64),
+        format: "docker",
+        architectures: [{ name: "arm64" }],
+        identifiers: { architecture: "arm64", docker_platform_os: "linux" },
+      },
+    ], dockerPlatformDependency), null);
+    assert.ok(matchCoverageCandidates([{
+      ...dockerTagCandidate,
+      architectures: [{ name: "arm64" }],
+      identifiers: { architecture: "arm64", docker_platform_os: "linux" },
+    }], dockerPlatformDependency));
+
+    const mavenDependency = {
+      ...createDependency("com.example:demo", "1.2.3", "maven"),
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    };
+    const mavenCandidate = {
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      identifiers: { group_id: "com.example" },
+    };
+    assert.strictEqual(matchCoverageCandidates([{
+      ...mavenCandidate,
+      files: [{ filename: "demo-1.2.3.jar" }],
+    }], mavenDependency), null);
+    assert.ok(matchCoverageCandidates([{
+      ...mavenCandidate,
+      files: [{ filename: "demo-1.2.3-tests.jar" }],
+    }], mavenDependency));
+    assert.ok(matchCoverageCandidates([{
+      ...mavenCandidate,
+      files: [{ filename: "demo-1.2.3-tests.jar" }],
+    }], {
+      ...createDependency("com.example:demo", "1.2.3", "maven"),
+      qualifiers: { type: "test-jar" },
+    }));
+
+    assert.strictEqual(matchCoverageCandidates([{
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+    }], {
+      ...createDependency("native-gem", "1.0.0", "ruby"),
+      qualifiers: { platform: "x86_64-linux" },
+    }), null);
+    assert.ok(matchCoverageCandidates([{
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      architectures: [{ name: "x86_64-linux" }],
+    }], {
+      ...createDependency("native-gem", "1.0.0", "ruby"),
+      qualifiers: { platform: "x86_64-linux" },
+    }));
+
+    assert.ok(matchCoverageCandidates([{
+      name: "Example.Package",
+      version: "1.2.3-beta",
+      format: "nuget",
+    }], createDependency("Example.Package", "01.02.003.0-BETA+build.7", "nuget")));
+  });
+
+  test("exact NuGet coverage lookup queries the normalized package version", async () => {
+    const api = createLookupApi(() => lookupPage([{
+      name: "Example.Package",
+      version: "1.2.3-beta",
+      format: "nuget",
+    }]));
+    const result = await lookupExactDependency({
+      api,
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency("Example.Package", "01.02.003.0-BETA+build.7", "nuget"),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
+    const query = new URL(api.calls[0], "https://api.cloudsmith.io/v1/").searchParams.get("query");
+    assert.match(query, /version:1\.2\.3-beta/);
+    assert.doesNotMatch(query, /01\.02\.003/);
+  });
+
   test("_runCoverageChecks bounds exact lookup concurrency", async () => {
     const provider = new DependencyHealthProvider(createContext());
     const dependencies = Array.from({ length: 20 }, (_, index) => (
@@ -2342,7 +2507,7 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(apiCalls, 0);
   });
 
-  test("exact lookup finds a package on the first page with escaped name and version terms", async () => {
+  test("exact lookup finds a scoped package without escaping its registry-native slash", async () => {
     const expectedPackage = { name: "@scope/pkg", version: "1.0.0", format: "npm" };
     const api = createLookupApi(() => lookupPage([expectedPackage]));
 
@@ -2363,7 +2528,8 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(result.package.version, expectedPackage.version);
     assert.strictEqual(result.pagesFetched, 1);
     const query = new URL(api.calls[0], "https://api.cloudsmith.io/v1/").searchParams.get("query");
-    assert.ok(query.includes("name:@scope\\/pkg"));
+    assert.ok(query.includes("name:@scope/pkg"));
+    assert.ok(!query.includes("name:@scope\\/pkg"));
     assert.ok(query.includes("version:1.0.0"));
   });
 
@@ -3143,6 +3309,7 @@ suite("DependencyHealthProvider Test Suite", () => {
         slug_perm: "spring-boot-starter-web-3.2.0",
         status_str: "Completed",
         identifiers: { group_id: "org.springframework.boot" },
+        files: [{ filename: "spring-boot-starter-web-3.2.0.jar" }],
       }
     );
 
@@ -3515,6 +3682,67 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.deepStrictEqual(events, ["prepare", "confirm"]);
     assert.match(confirmationMessage, /target-package@1\.0\.0/);
     assert.match(confirmationMessage, /workspace-a\/repo-b/);
+  });
+
+  test("single pull resolves colliding coordinates by their exact dependency qualifiers", async () => {
+    const preparedDependencies = [];
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      upstreamPullService: {
+        async prepareSingle({ dependency }) {
+          preparedDependencies.push(dependency);
+          return null;
+        },
+      },
+    });
+    provider.lastWorkspace = "workspace-a";
+    provider.lastRepo = "repo-a";
+    provider._projectFolderPath = "/project";
+    provider._hasSuccessfulScan = true;
+    provider._updateContexts = async () => {};
+    provider.refresh = () => {};
+
+    const cases = [
+      {
+        format: "maven",
+        name: "com.example:artifact",
+        left: { type: "jar", classifier: "javadoc" },
+        right: { type: "test-jar", classifier: "tests" },
+      },
+      {
+        format: "docker",
+        name: "registry.example.test/team/image",
+        left: { tag: "latest", digest: "sha256:1111", service: "worker" },
+        right: { tag: "latest", digest: "sha256:2222", service: "api" },
+      },
+      {
+        format: "ruby",
+        name: "native-gem",
+        left: { platform: "java" },
+        right: { platform: "x86_64-linux" },
+      },
+      {
+        format: "nuget",
+        name: "Framework.Package",
+        left: { targetFramework: "net9.0" },
+        right: { targetFramework: "net8.0" },
+      },
+    ];
+
+    for (const entry of cases) {
+      const dependencies = [entry.left, entry.right].map(qualifiers => ({
+        ...createProblemDependency(entry.name, "1.0.0", "/project/manifest", entry.format),
+        qualifiers,
+      }));
+      provider._fullTrees = [{ dependencies }];
+      await provider.pullSingleDependency(
+        pullCoordinate(entry.name, "1.0.0", entry.format, entry.right)
+      );
+    }
+
+    assert.deepStrictEqual(
+      preparedDependencies.map(dependency => dependency.qualifiers),
+      cases.map(entry => entry.right)
+    );
   });
 
   test("coverage refresh waits for every enrichment sibling after one rejects", async () => {

--- a/test/dependencyHealthProvider.test.js
+++ b/test/dependencyHealthProvider.test.js
@@ -23,6 +23,7 @@ const {
   RESOLUTION_SOURCE_KINDS,
   createDependencyRecord,
   createDependencySource,
+  getDependencyArtifactKey,
 } = require("../util/dependencyRecord");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 const { bindConnectionManager } = require("../util/connectionManager");
@@ -1782,6 +1783,104 @@ suite("DependencyHealthProvider Test Suite", () => {
     }
   });
 
+  test("_performScan preserves identical file-level warnings from separate Dockerfiles", async () => {
+    const originalGetConfiguration = vscode.workspace.getConfiguration;
+    vscode.workspace.getConfiguration = () => ({ get: () => 10000 });
+    const warning = "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.";
+    const detections = ["/project/api/Dockerfile", "/project/worker/Dockerfile"].map(filePath => ({
+      adapterId: "dockerParser",
+      ecosystem: "docker",
+      filePath,
+    }));
+    const dependencyAdapters = {
+      async detectManifests() { return []; },
+      getDiscoveryWarnings() { return []; },
+      async detect() { return detections; },
+      async parse(detection) {
+        return {
+          status: ADAPTER_RESULT_STATUSES.PARTIAL,
+          adapterId: "dockerParser",
+          ecosystem: "docker",
+          sourceFile: detection.filePath,
+          source: null,
+          dependencies: [],
+          warnings: [warning],
+          error: null,
+        };
+      },
+    };
+
+    try {
+      const provider = new DependencyHealthProvider(createContext(), null, { dependencyAdapters });
+      provider._storeReportData = async () => {};
+
+      const result = await provider._performScan(
+        "workspace-a",
+        "repo-a",
+        "/project",
+        { report() {} },
+        { isCancellationRequested: false }
+      );
+
+      assert.deepStrictEqual(result, { canceled: false });
+      assert.deepStrictEqual(provider._warnings, [
+        "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.",
+        "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.",
+      ]);
+      const renderedLabels = (await provider.getChildren()).map(node => node.getTreeItem().label);
+      assert.strictEqual(renderedLabels.filter(label => label === warning).length, 1);
+      assert.ok(renderedLabels.includes("No dependencies found"));
+    } finally {
+      vscode.workspace.getConfiguration = originalGetConfiguration;
+    }
+  });
+
+  test("_performScan preserves fallback warnings from separate Dockerfiles", async () => {
+    const originalGetConfiguration = vscode.workspace.getConfiguration;
+    vscode.workspace.getConfiguration = () => ({
+      get(key) { return key === "resolveTransitiveDependencies" ? false : 10000; },
+    });
+    const warning = "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.";
+    const manifests = ["/project/api/Dockerfile", "/project/worker/Dockerfile"].map(filePath => ({
+      adapterId: "dockerParser",
+      ecosystem: "docker",
+      filePath,
+    }));
+    const dependencyAdapters = {
+      async detectManifests() { return manifests; },
+      getDiscoveryWarnings() { return []; },
+      async parseManifest(manifest) {
+        return {
+          status: ADAPTER_RESULT_STATUSES.PARTIAL,
+          adapterId: "dockerParser",
+          ecosystem: "docker",
+          sourceFile: manifest.filePath,
+          source: null,
+          dependencies: [],
+          warnings: [warning],
+          error: null,
+        };
+      },
+    };
+
+    try {
+      const provider = new DependencyHealthProvider(createContext(), null, { dependencyAdapters });
+      provider._storeReportData = async () => {};
+
+      await provider._performScan(
+        "workspace-a",
+        "repo-a",
+        "/project",
+        { report() {} },
+        { isCancellationRequested: false }
+      );
+
+      assert.deepStrictEqual(provider._warnings, [warning, warning]);
+    } finally {
+      vscode.workspace.getConfiguration = originalGetConfiguration;
+    }
+  });
+
   test("_performScan composes lock-backed and uncovered manifest-only projects", async () => {
     const originalGetConfiguration = vscode.workspace.getConfiguration;
     vscode.workspace.getConfiguration = () => ({ get: () => 10000 });
@@ -2139,16 +2238,14 @@ suite("DependencyHealthProvider Test Suite", () => {
       format: "docker",
       tags: { version: ["stable"] },
     };
+    const taggedManifestWithDifferentPlatformMetadata = {
+      ...dockerTagCandidate,
+      version: "b".repeat(64),
+      architectures: [{ name: "amd64" }],
+      identifiers: { architecture: "amd64", docker_platform_os: "linux" },
+    };
     assert.strictEqual(matchCoverageCandidates([
-      {
-        ...dockerTagCandidate,
-        name: "library/example",
-        version: "b".repeat(64),
-        format: "docker",
-        tags: { version: ["stable"] },
-        architectures: [{ name: "amd64" }],
-        identifiers: { architecture: "amd64", docker_platform_os: "linux" },
-      },
+      taggedManifestWithDifferentPlatformMetadata,
     ], dockerPlatformDependency), null);
     assert.strictEqual(matchCoverageCandidates([
       dockerTagCandidate,
@@ -2160,11 +2257,33 @@ suite("DependencyHealthProvider Test Suite", () => {
         identifiers: { architecture: "arm64", docker_platform_os: "linux" },
       },
     ], dockerPlatformDependency), null);
+
+    const digestHex = "d".repeat(64);
+    const algorithmQualifiedDependency = {
+      ...createDependency("example", `sha256:${digestHex}`, "docker"),
+      qualifiers: { digest: `sha256:${digestHex}` },
+    };
+    assert.strictEqual(matchCoverageCandidates([{
+      name: "library/example",
+      version: `sha512:${digestHex}`,
+      format: "docker",
+    }], algorithmQualifiedDependency), null);
     assert.ok(matchCoverageCandidates([{
-      ...dockerTagCandidate,
-      architectures: [{ name: "arm64" }],
-      identifiers: { architecture: "arm64", docker_platform_os: "linux" },
-    }], dockerPlatformDependency));
+      name: "library/example",
+      version: digestHex,
+      format: "docker",
+    }], algorithmQualifiedDependency));
+
+    const swiftCandidate = {
+      namespace: "acme",
+      name: "logging",
+      version: "1.2.3",
+      format: "swift",
+    };
+    assert.strictEqual(matchCoverageCandidates([swiftCandidate], {
+      ...createDependency("acme.logging", "1.2.3", "swift"),
+      qualifiers: { scope: "acme" },
+    }), null);
 
     const mavenDependency = {
       ...createDependency("com.example:demo", "1.2.3", "maven"),
@@ -2533,6 +2652,48 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.ok(query.includes("version:1.0.0"));
   });
 
+  test("exact lookup does not accept a cross-package result for a leading modifier-like name", async () => {
+    const api = createLookupApi(() => lookupPage([{
+      name: "target-package",
+      version: "1.0.0",
+      format: "npm",
+    }]));
+
+    const result = await lookupExactDependency({
+      api,
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency("+-target-package", "1.0.0"),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.ABSENT);
+    const query = new URL(api.calls[0], "https://api.cloudsmith.io/v1/")
+      .searchParams.get("query");
+    assert.ok(query.includes("name:\\+\\-target-package"));
+  });
+
+  test("exact lookup still finds an exact leading modifier-like identity", async () => {
+    const expectedPackage = {
+      name: "--target-package",
+      version: "1.0.0-beta+build",
+      format: "npm",
+    };
+    const api = createLookupApi(() => lookupPage([expectedPackage]));
+
+    const result = await lookupExactDependency({
+      api,
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: createDependency(expectedPackage.name, expectedPackage.version),
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
+    assert.strictEqual(result.package.name, expectedPackage.name);
+    assert.strictEqual(result.package.version, expectedPackage.version);
+  });
+
   test("exact lookup follows pagination until a later-page match is found", async () => {
     const expectedPackage = { name: "left-pad", version: "1.0.0", format: "npm" };
     const api = createLookupApi((endpoint) => {
@@ -2755,6 +2916,31 @@ suite("DependencyHealthProvider Test Suite", () => {
         namespace: "workspace",
         repository: "repo",
         slug_perm: null,
+      },
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: "left-pad\u202e",
+      },
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: "left-pad",
+        identifiers: { group_id: { hostile: true } },
+      },
+      {
+        name: "left-pad\u202e",
+        version: "1.0.0",
+        format: "npm",
+        namespace: "workspace",
+        repository: "repo",
+        slug_perm: "left-pad-bidi",
       },
     ]) {
       const result = await lookupExactDependency({
@@ -3037,6 +3223,7 @@ suite("DependencyHealthProvider Test Suite", () => {
       version: "1.0.0",
       format: "maven",
       identifiers: { group_id: "com.expected" },
+      files: [{ filename: "shared-artifact-1.0.0.jar" }],
     };
     const api = createLookupApi((endpoint) => {
       const page = Number(new URL(endpoint, "https://api.cloudsmith.io/v1/").searchParams.get("page"));
@@ -3046,6 +3233,7 @@ suite("DependencyHealthProvider Test Suite", () => {
           version: "1.0.0",
           format: "maven",
           identifiers: { group_id: "com.wrong" },
+          files: [{ filename: "shared-artifact-1.0.0.jar" }],
         }], 1, 2, 2, 1)
         : lookupPage([correct], 2, 2, 2, 1);
     });
@@ -3067,6 +3255,118 @@ suite("DependencyHealthProvider Test Suite", () => {
       "https://api.cloudsmith.io/v1/"
     ).searchParams.get("query").replace(/\\/g, "");
     assert.ok(firstQuery.includes("name:com.expected:shared-artifact"));
+  });
+
+  test("coverage lookup remains incomplete when exact qualifier evidence is omitted", async () => {
+    const api = createLookupApi(() => lookupPage([{
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      identifiers: { group_id: "com.example" },
+    }]));
+    const dependency = {
+      ...createDependency("com.example:demo", "1.2.3", "maven"),
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    };
+
+    const result = await lookupExactDependency({
+      api,
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency,
+      token: { isCancellationRequested: false },
+    });
+
+    assert.strictEqual(result.status, CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE);
+    assert.match(result.detail, /artifact evidence/i);
+  });
+
+  test("post-pull receipts preserve verified Docker platform and Swift scope coverage", async () => {
+    const dockerDependency = {
+      ...createDependency("alpine", "3.20.3", "docker"),
+      qualifiers: { tag: "3.20.3", platform: "linux/arm64" },
+    };
+    const dockerCandidate = {
+      name: "library/alpine",
+      version: "a".repeat(64),
+      format: "docker",
+      tags: { version: ["3.20.3"] },
+    };
+    const docker = await lookupExactDependency({
+      api: createLookupApi(() => lookupPage([dockerCandidate])),
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: dockerDependency,
+      token: { isCancellationRequested: false },
+      verificationReceipt: { dockerPlatformVerified: true },
+    });
+    assert.strictEqual(docker.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
+
+    const swiftDependency = {
+      ...createDependency("acme.logging", "1.2.3", "swift"),
+      qualifiers: { scope: "acme" },
+    };
+    const swift = await lookupExactDependency({
+      api: createLookupApi(() => lookupPage([{
+        name: "logging",
+        version: "1.2.3",
+        format: "swift",
+      }])),
+      cloudsmithWorkspace: "workspace",
+      cloudsmithRepo: "repo",
+      dependency: swiftDependency,
+      token: { isCancellationRequested: false },
+      verificationReceipt: { swiftScopeVerified: true },
+    });
+    assert.strictEqual(swift.status, CLOUDSMITH_COVERAGE_STATUS.FOUND);
+  });
+
+  test("bulk coverage refresh applies verification receipts only to their exact artifacts", async () => {
+    const alpha = {
+      ...createProblemDependency("alpha", "1.0", "/project/Dockerfile", "docker"),
+      qualifiers: { tag: "1.0", platform: "linux/arm64" },
+    };
+    const beta = {
+      ...createProblemDependency("beta", "1.0", "/project/Dockerfile", "docker"),
+      qualifiers: { tag: "1.0", platform: "linux/arm64" },
+    };
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      createCloudsmithAPI: () => createLookupApi((endpoint) => lookupPage([{
+        namespace: "workspace",
+        repository: "repository",
+        name: endpoint.includes("alpha") ? "library/alpha" : "library/beta",
+        version: "a".repeat(64),
+        format: "docker",
+        tags: { version: ["1.0"] },
+      }])),
+    });
+    provider._fullTrees = [{ ecosystem: "docker", dependencies: [alpha, beta] }];
+    provider._displayTrees = provider._fullTrees;
+    provider.refresh = () => {};
+
+    await provider._runCoverageResolution(
+      "workspace",
+      "repository",
+      { docker: [alpha, beta] },
+      2,
+      { report() {} },
+      { isCancellationRequested: false },
+      {
+        verificationReceipts: new Map([[
+          getDependencyArtifactKey(alpha),
+          { dockerPlatformVerified: true },
+        ]]),
+      }
+    );
+
+    assert.strictEqual(
+      provider._fullTrees[0].dependencies[0].cloudsmithStatus,
+      CLOUDSMITH_COVERAGE_STATUS.FOUND
+    );
+    assert.strictEqual(
+      provider._fullTrees[0].dependencies[1].cloudsmithStatus,
+      CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE
+    );
   });
 
   test("Maven and Go package identities preserve case", async () => {
@@ -3532,6 +3832,53 @@ suite("DependencyHealthProvider Test Suite", () => {
     assert.strictEqual(provider._displayTrees[0].dependencies[0].license.spdx, "Apache-2.0");
   });
 
+  test("pullDependencies transports per-artifact verification receipts into bulk refresh", async () => {
+    const dependency = createProblemDependency(
+      "bulk-package",
+      "1.0.0",
+      "/project/package.json"
+    );
+    const verificationReceipts = new Map([[
+      getDependencyArtifactKey(dependency),
+      { dockerPlatformVerified: true },
+    ]]);
+    let refreshOptions = null;
+    const provider = new DependencyHealthProvider(createContext(), null, {
+      userInteraction: createUserInteraction(),
+      upstreamPullService: {
+        async run() {
+          return {
+            workspace: "workspace-a",
+            repository: { slug: "repo-b" },
+            plan: { skippedDependencies: [] },
+            verificationReceipts,
+            pullResult: null,
+          };
+        },
+      },
+    });
+    provider.lastWorkspace = "workspace-a";
+    provider.lastRepo = "repo-a";
+    provider._projectFolderPath = "/project";
+    provider._hasSuccessfulScan = true;
+    provider._fullTrees = [{ dependencies: [dependency] }];
+    provider._updateContexts = async () => {};
+    provider.refresh = () => {};
+    provider._refreshCoverageAfterPull = async (
+      _workspace,
+      _repo,
+      _progress,
+      _token,
+      options
+    ) => {
+      refreshOptions = options;
+    };
+
+    await provider.pullDependencies();
+
+    assert.strictEqual(refreshOptions.verificationReceipts, verificationReceipts);
+  });
+
   test("pullSingleDependency refreshes coverage after a successful single-package pull", async () => {
     const originalWithProgress = vscode.window.withProgress;
     const originalShowInformationMessage = vscode.window.showInformationMessage;
@@ -3568,10 +3915,14 @@ suite("DependencyHealthProvider Test Suite", () => {
               plan: { skippedDependencies: [] },
             };
           },
-          async execute(_prepared, options) {
+          async execute(prepared, options) {
             assert.strictEqual(options.token, preparationToken);
             return {
               canceled: false,
+              verificationReceipts: new Map([[
+                getDependencyArtifactKey(prepared.dependency),
+                { swiftScopeVerified: true },
+              ]]),
               pullResult: {
                 total: 1,
                 cached: 1,
@@ -3612,8 +3963,15 @@ suite("DependencyHealthProvider Test Suite", () => {
       }];
       provider._updateContexts = async () => {};
       provider.refresh = () => {};
-      provider._refreshSingleDependencyAfterPull = async (workspace, repo, dependency) => {
-        refreshArgs = { workspace, repo, dependency };
+      provider._refreshSingleDependencyAfterPull = async (
+        workspace,
+        repo,
+        dependency,
+        _progress,
+        _token,
+        options
+      ) => {
+        refreshArgs = { workspace, repo, dependency, options };
       };
 
       await provider.pullSingleDependency(pullCoordinate("requests", "2.31.0", "python"));
@@ -3623,6 +3981,9 @@ suite("DependencyHealthProvider Test Suite", () => {
       assert.strictEqual(refreshArgs.dependency.name, "requests");
       assert.strictEqual(refreshArgs.dependency.version, "2.31.0");
       assert.strictEqual(refreshArgs.dependency.format, "python");
+      assert.deepStrictEqual(refreshArgs.options, {
+        verificationReceipt: { swiftScopeVerified: true },
+      });
       assert.ok(preparationToken);
       assert.strictEqual(provider.lastRepo, "repo-a");
       assert.deepStrictEqual(notifications, ["requests@2.31.0 cached in repo-b"]);

--- a/test/dependencyRecord.test.js
+++ b/test/dependencyRecord.test.js
@@ -416,6 +416,24 @@ suite("dependencyRecord", () => {
       getDependencyArtifactKey(createRuby("ruby")),
       getDependencyArtifactKey(createRuby("x86_64-linux"))
     );
+
+    const createMaven = qualifiers => createDependencyRecord({
+      ecosystem: "maven",
+      name: "com.example:demo",
+      resolvedVersion: "1.2.3",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      legacyVersion: "1.2.3",
+      qualifiers,
+      packageSource: { kind: "registry" },
+    });
+    assert.strictEqual(
+      getDependencyArtifactKey(createMaven({})),
+      getDependencyArtifactKey(createMaven({ type: "jar" }))
+    );
+    assert.strictEqual(
+      getDependencyArtifactKey(createMaven({ type: "test-jar" })),
+      getDependencyArtifactKey(createMaven({ type: "jar", classifier: "tests" }))
+    );
   });
 
   test("derives workspace-relative source labels", () => {

--- a/test/dependencyRecord.test.js
+++ b/test/dependencyRecord.test.js
@@ -434,6 +434,55 @@ suite("dependencyRecord", () => {
       getDependencyArtifactKey(createMaven({ type: "test-jar" })),
       getDependencyArtifactKey(createMaven({ type: "jar", classifier: "tests" }))
     );
+
+    const createDocker = platform => createDependencyRecord({
+      ecosystem: "docker",
+      name: "alpine",
+      resolvedVersion: "3.20.3",
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      legacyVersion: "3.20.3",
+      qualifiers: { tag: "3.20.3", platform },
+      packageSource: { kind: "registry" },
+    });
+    assert.strictEqual(
+      getDependencyArtifactKey(createDocker("linux/x86_64")),
+      getDependencyArtifactKey(createDocker("linux/amd64"))
+    );
+    assert.strictEqual(
+      getDependencyArtifactKey(createDocker("linux/aarch64/v8")),
+      getDependencyArtifactKey(createDocker("linux/arm64"))
+    );
+    const dockerDigestBase = {
+      ecosystem: "docker",
+      name: "alpine",
+      resolvedVersion: `sha256:${"a".repeat(64)}`,
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      legacyVersion: `sha256:${"a".repeat(64)}`,
+      packageSource: { kind: "registry" },
+    };
+    assert.strictEqual(
+      getDependencyArtifactKey(createDependencyRecord({
+        ...dockerDigestBase,
+        qualifiers: { digest: `SHA256:${"A".repeat(64)}` },
+      })),
+      getDependencyArtifactKey(createDependencyRecord({
+        ...dockerDigestBase,
+        qualifiers: { digest: `sha256:${"a".repeat(64)}` },
+      }))
+    );
+
+    const createNugetVersion = version => createDependencyRecord({
+      ecosystem: "nuget",
+      name: "Example.Package",
+      resolvedVersion: version,
+      versionState: DEPENDENCY_VERSION_STATES.RESOLVED,
+      legacyVersion: version,
+      packageSource: { kind: "registry" },
+    });
+    assert.strictEqual(
+      getDependencyArtifactKey(createNugetVersion("01.02.003.0-BETA+build.7")),
+      getDependencyArtifactKey(createNugetVersion("1.2.3-beta"))
+    );
   });
 
   test("derives workspace-relative source labels", () => {

--- a/test/licenseClassifier.test.js
+++ b/test/licenseClassifier.test.js
@@ -224,16 +224,16 @@ suite("LicenseClassifier Test Suite", () => {
       const inspection = LicenseClassifier.inspect("(MIT OR GPL-3.0)");
       assert.deepStrictEqual(inspection.identifiers, ["MIT", "GPL-3.0"]);
       assert.strictEqual(inspection.tier, "restrictive");
-      assert.strictEqual(inspection.searchQuery, "(license:MIT OR license:GPL\\-3.0)");
+      assert.strictEqual(inspection.searchQuery, "(license:MIT OR license:GPL-3.0)");
       assert.strictEqual(LicenseClassifier.buildLicenseQuery("(MIT OR GPL-3.0)"), inspection.searchQuery);
     });
 
     test("buildRestrictiveQuery uses the shared restrictive catalog", () => {
       const query = LicenseClassifier.buildRestrictiveQuery();
-      assert.ok(query.includes("license:AGPL\\-3.0"));
-      assert.ok(query.includes("license:GPL\\-3.0"));
-      assert.ok(query.includes("license:SSPL\\-1.0"));
-      assert.ok(query.includes("license:EUPL\\-1.2"));
+      assert.ok(query.includes("license:AGPL-3.0"));
+      assert.ok(query.includes("license:GPL-3.0"));
+      assert.ok(query.includes("license:SSPL-1.0"));
+      assert.ok(query.includes("license:EUPL-1.2"));
     });
 
     test("search quick-pick items reuse a precomputed searchQuery when present", () => {
@@ -355,13 +355,13 @@ suite("LicenseClassifier Test Suite", () => {
       assert.strictEqual(inspection.canonicalValue, "Apache-2.0");
       assert.strictEqual(inspection.canonicalSourceField, "spdx_license");
       assert.strictEqual(inspection.tier, "permissive");
-      assert.strictEqual(inspection.searchQuery, "license:Apache\\-2.0");
+      assert.strictEqual(inspection.searchQuery, "license:Apache-2.0");
       assert.strictEqual(inspection.licenseUrl, "https://spdx.org/licenses/Apache-2.0.html");
       assert.strictEqual(LicenseClassifier.buildLicenseQuery({
         spdx_license: "Apache-2.0",
         license: null,
         raw_license: null,
-      }), "license:Apache\\-2.0");
+      }), "license:Apache-2.0");
       assert.strictEqual(LicenseClassifier.resolveLicenseUrl({
         spdx_license: "Apache-2.0",
         license: null,
@@ -384,7 +384,7 @@ suite("LicenseClassifier Test Suite", () => {
       assert.strictEqual(inspection.canonicalSourceField, "spdx_license");
       assert.strictEqual(inspection.spdxIdentifier, "Apache-2.0");
       assert.strictEqual(inspection.tier, "permissive");
-      assert.strictEqual(inspection.searchQuery, "license:Apache\\-2.0");
+      assert.strictEqual(inspection.searchQuery, "license:Apache-2.0");
       assert.strictEqual(inspection.licenseUrl, "https://spdx.org/licenses/Apache-2.0.html");
     });
 
@@ -423,7 +423,40 @@ suite("LicenseClassifier Test Suite", () => {
       const restrictiveItems = LicenseClassifier.getSearchableLicensesByTier().restrictive;
       assert.ok(restrictiveItems.some((item) => item.license === "MIT" && item.overrideApplied));
       assert.ok(restrictiveItems.some((item) => item.license === "LicenseRef-Cloudsmith-Custom" && item.overrideApplied));
-      assert.ok(LicenseClassifier.buildRestrictiveQuery().includes("license:LicenseRef\\-Cloudsmith\\-Custom"));
+      assert.ok(LicenseClassifier.buildRestrictiveQuery().includes("license:LicenseRef-Cloudsmith-Custom"));
+    });
+
+    test("restrictive query overrides are bounded and reject control or bidi identifiers", () => {
+      vscode.workspace.getConfiguration = () => ({
+        get(key) {
+          if (key !== "restrictiveLicenses") return undefined;
+          return [
+            "LicenseRef-Safe-Custom",
+            "LicenseRef-Hostile\nOR status:quarantined",
+            "LicenseRef-Bidi\u202e",
+            "+LicenseRef$Hostile",
+            ...Array.from({ length: 100 }, (_, index) => `LicenseRef-Long-${index}-${"x".repeat(240)}`),
+          ];
+        },
+      });
+
+      const query = LicenseClassifier.buildRestrictiveQuery();
+
+      assert.match(query, /LicenseRef-Safe-Custom/);
+      assert.match(query, /\\\+LicenseRef\\\$Hostile/);
+      assert.doesNotMatch(query, /status:quarantined|Bidi|\u202e|\n/);
+      assert.ok(query.length <= 2048);
+    });
+
+    test("license query literals preserve SPDX punctuation and escape query operators", () => {
+      assert.strictEqual(
+        LicenseClassifier.buildQueryFromIdentifiers([
+          "AGPL-3.0",
+          "LicenseRef/vendor+custom",
+          "+leading$<>'",
+        ]),
+        "(license:AGPL-3.0 OR license:LicenseRef/vendor+custom OR license:\\+leading\\$\\<\\>\\')"
+      );
     });
   });
 });

--- a/test/lockfileParsers/dockerParser.test.js
+++ b/test/lockfileParsers/dockerParser.test.js
@@ -129,6 +129,54 @@ suite("dockerParser Test Suite", () => {
     assert.strictEqual(tree.dependencies[1].hasResolutionEvidence, true);
   });
 
+  test("preserves explicit Dockerfile and Compose target platforms", async () => {
+    const workspace = await createWorkspace();
+    const dockerfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(dockerfilePath, [
+      "FROM --platform=linux/arm64/v8 example/api:1.2.3",
+      "",
+    ].join("\n"));
+    const dockerfileTree = await dockerParser.resolve({
+      lockfilePath: dockerfilePath,
+      workspaceFolder: workspace,
+    });
+    assert.strictEqual(dockerfileTree.dependencies[0].qualifiers.platform, "linux/arm64/v8");
+
+    const composePath = path.join(workspace, "compose.yaml");
+    await writeTextFile(composePath, [
+      "services:",
+      "  api:",
+      "    image: example/api:1.2.3",
+      "    platform: linux/arm64",
+      "",
+    ].join("\n"));
+    const composeTree = await dockerParser.resolve({
+      lockfilePath: composePath,
+      workspaceFolder: workspace,
+    });
+    assert.strictEqual(composeTree.dependencies[0].qualifiers.platform, "linux/arm64");
+  });
+
+  test("marks unresolved Dockerfile target platforms as partial and unpullable", async () => {
+    const workspace = await createWorkspace();
+    const lockfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(lockfilePath, [
+      "FROM --platform=$TARGETPLATFORM example/api:1.2.3",
+      "",
+    ].join("\n"));
+
+    const tree = await dockerParser.resolve({ lockfilePath, workspaceFolder: workspace });
+
+    assert.strictEqual(tree.dependencies.length, 1);
+    assert.strictEqual(tree.dependencies[0].hasResolutionEvidence, false);
+    assert.strictEqual(tree.dependencies[0].resolvedVersion, null);
+    assert.strictEqual(tree.dependencies[0].versionState, "incomplete");
+    assert.strictEqual(tree.dependencies[0].qualifiers.platform, undefined);
+    assert.deepStrictEqual(tree.warnings, [
+      "A Dockerfile target platform could not be resolved, so dependency results are partial.",
+    ]);
+  });
+
   test("warns safely when Compose interpolation cannot be resolved", async () => {
     const workspace = await createWorkspace();
     const lockfilePath = path.join(workspace, "compose.yml");

--- a/test/lockfileParsers/dockerParser.test.js
+++ b/test/lockfileParsers/dockerParser.test.js
@@ -113,9 +113,10 @@ suite("dockerParser Test Suite", () => {
   test("preserves Docker tag and digest evidence without inventing latest", async () => {
     const workspace = await createWorkspace();
     const lockfilePath = path.join(workspace, "Dockerfile");
+    const digest = `sha256:${"a".repeat(64)}`;
     await writeTextFile(lockfilePath, [
       "FROM example/plain",
-      "FROM example/tagged:2.0@sha256:abcdef0123456789",
+      `FROM example/tagged:2.0@${digest}`,
       "",
     ].join("\n"));
 
@@ -125,8 +126,22 @@ suite("dockerParser Test Suite", () => {
     assert.strictEqual(tree.dependencies[0].hasResolutionEvidence, false);
     assert.strictEqual(tree.dependencies[1].version, "2.0");
     assert.strictEqual(tree.dependencies[1].qualifiers.tag, "2.0");
-    assert.strictEqual(tree.dependencies[1].qualifiers.digest, "sha256:abcdef0123456789");
+    assert.strictEqual(tree.dependencies[1].qualifiers.digest, digest);
     assert.strictEqual(tree.dependencies[1].hasResolutionEvidence, true);
+  });
+
+  test("rejects malformed and undersized Docker digests", async () => {
+    const workspace = await createWorkspace();
+    const lockfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(lockfilePath, [
+      `FROM example/short@sha256:${"a".repeat(32)}`,
+      `FROM example/nonhex@sha256:${"z".repeat(64)}`,
+      "",
+    ].join("\n"));
+
+    const tree = await dockerParser.resolve({ lockfilePath, workspaceFolder: workspace });
+
+    assert.deepStrictEqual(tree.dependencies, []);
   });
 
   test("preserves explicit Dockerfile and Compose target platforms", async () => {
@@ -177,6 +192,85 @@ suite("dockerParser Test Suite", () => {
     ]);
   });
 
+  test("reports one file-level warning for multiple unresolved Dockerfile target platforms", async () => {
+    const workspace = await createWorkspace();
+    const lockfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(lockfilePath, [
+      "FROM --platform=$TARGETPLATFORM example/api:1.2.3 AS api",
+      "FROM --platform=${SECOND_PLATFORM} example/worker:2.0 AS worker",
+      "FROM --platform=$THIRD_PLATFORM example/jobs:3.0 AS jobs",
+      "FROM api AS final",
+      "",
+    ].join("\n"));
+
+    const tree = await dockerParser.resolve({ lockfilePath, workspaceFolder: workspace });
+
+    assert.deepStrictEqual(
+      tree.dependencies.map((dependency) => dependency.name),
+      ["example/api", "example/worker", "example/jobs"]
+    );
+    assert.strictEqual(tree.dependencies.every((dependency) => (
+      dependency.versionState === "incomplete"
+      && dependency.hasResolutionEvidence === false
+      && dependency.resolvedVersion === null
+      && dependency.qualifiers.platform === undefined
+    )), true);
+    assert.deepStrictEqual(tree.warnings, [
+      "A Dockerfile target platform could not be resolved, so dependency results are partial.",
+    ]);
+  });
+
+  test("preserves per-dependency platform state for mixed Dockerfile stages", async () => {
+    const workspace = await createWorkspace();
+    const lockfilePath = path.join(workspace, "Dockerfile");
+    await writeTextFile(lockfilePath, [
+      "ARG RESOLVED_PLATFORM=linux/arm64/v8",
+      "FROM --platform=$RESOLVED_PLATFORM example/resolved:1.0 AS resolved",
+      "FROM --platform=$TARGETPLATFORM example/unresolved:2.0 AS unresolved",
+      "FROM --platform=not-a-platform example/invalid:3.0 AS invalid",
+      "FROM resolved AS final",
+      "",
+    ].join("\n"));
+
+    const tree = await dockerParser.resolve({ lockfilePath, workspaceFolder: workspace });
+
+    assert.deepStrictEqual(
+      tree.dependencies.map((dependency) => ({
+        name: dependency.name,
+        platform: dependency.qualifiers.platform,
+        versionState: dependency.versionState,
+        hasResolutionEvidence: dependency.hasResolutionEvidence,
+        resolvedVersion: dependency.resolvedVersion,
+      })),
+      [
+        {
+          name: "example/resolved",
+          platform: "linux/arm64/v8",
+          versionState: undefined,
+          hasResolutionEvidence: true,
+          resolvedVersion: "1.0",
+        },
+        {
+          name: "example/unresolved",
+          platform: undefined,
+          versionState: "incomplete",
+          hasResolutionEvidence: false,
+          resolvedVersion: null,
+        },
+        {
+          name: "example/invalid",
+          platform: undefined,
+          versionState: "incomplete",
+          hasResolutionEvidence: false,
+          resolvedVersion: null,
+        },
+      ]
+    );
+    assert.deepStrictEqual(tree.warnings, [
+      "A Dockerfile target platform could not be resolved, so dependency results are partial.",
+    ]);
+  });
+
   test("warns safely when Compose interpolation cannot be resolved", async () => {
     const workspace = await createWorkspace();
     const lockfilePath = path.join(workspace, "compose.yml");
@@ -195,5 +289,78 @@ suite("dockerParser Test Suite", () => {
     ]);
     assert.strictEqual(tree.warnings.join(" ").includes("secret-bearing"), false);
     assert.strictEqual(tree.warnings.join(" ").includes("UI_R7_MISSING_IMAGE"), false);
+  });
+
+  test("deduplicates generic Compose warnings per file while preserving distinct classes", async () => {
+    const workspace = await createWorkspace();
+    const firstPath = path.join(workspace, "compose.yml");
+    await writeTextFile(firstPath, [
+      "services:",
+      "  missing-image-one:",
+      "    image: example/${FIRST_IMAGE}",
+      "  missing-image-two:",
+      "    image: example/${SECOND_IMAGE}",
+      "  missing-platform-one:",
+      "    image: example/one:1.0",
+      "    platform: ${FIRST_PLATFORM}",
+      "  missing-platform-two:",
+      "    image: example/two:2.0",
+      "    platform: ${SECOND_PLATFORM}",
+      "  invalid-platform-one:",
+      "    image: example/three:3.0",
+      "    platform: linux",
+      "  invalid-platform-two:",
+      "    image: example/four:4.0",
+      "    platform: linux/amd64/extra/part",
+      "  valid:",
+      "    image: example/valid:5.0",
+      "    platform: linux/amd64",
+      "",
+    ].join("\n"));
+
+    const firstTree = await dockerParser.resolve({
+      lockfilePath: firstPath,
+      workspaceFolder: workspace,
+    });
+
+    assert.deepStrictEqual(
+      firstTree.dependencies.map((dependency) => dependency.name),
+      [
+        "example/one",
+        "example/two",
+        "example/three",
+        "example/four",
+        "example/valid",
+      ]
+    );
+    assert.strictEqual(firstTree.dependencies.slice(0, 4).every((dependency) => (
+      dependency.versionState === "incomplete"
+      && dependency.hasResolutionEvidence === false
+      && dependency.resolvedVersion === null
+      && dependency.qualifiers.platform === undefined
+    )), true);
+    assert.strictEqual(firstTree.dependencies[4].hasResolutionEvidence, true);
+    assert.strictEqual(firstTree.dependencies[4].qualifiers.platform, "linux/amd64");
+    assert.deepStrictEqual(firstTree.warnings, [
+      "A Compose image reference could not be resolved, so dependency results are partial.",
+      "A Compose image platform could not be resolved, so dependency results are partial.",
+      "A Compose image platform was invalid and could not be checked.",
+    ]);
+
+    const secondPath = path.join(workspace, "compose.yaml");
+    await writeTextFile(secondPath, [
+      "services:",
+      "  missing-again:",
+      "    image: example/${THIRD_IMAGE}",
+      "",
+    ].join("\n"));
+    const secondTree = await dockerParser.resolve({
+      lockfilePath: secondPath,
+      workspaceFolder: workspace,
+    });
+
+    assert.deepStrictEqual(secondTree.warnings, [
+      "A Compose image reference could not be resolved, so dependency results are partial.",
+    ]);
   });
 });

--- a/test/lockfileResolver.test.js
+++ b/test/lockfileResolver.test.js
@@ -161,6 +161,7 @@ suite("LockfileResolver Test Suite", () => {
       identifiers: {
         group_id: "org.springframework.boot",
       },
+      files: [{ filename: "spring-boot-starter-3.2.0.jar" }],
     };
     const index = buildPackageIndex([cloudsmithPackage], "maven");
 

--- a/test/packageDomain.test.js
+++ b/test/packageDomain.test.js
@@ -247,6 +247,72 @@ suite("Canonical package domain", () => {
     const repositoryCoordinate = packageCoordinateFromExact(fromApiPackageRecord(apiRecord()));
     assert.strictEqual(assertRepositoryPackageCoordinate(repositoryCoordinate), repositoryCoordinate);
     assert.strictEqual(repositoryCoordinate.repository, "Repository");
+    assert.deepStrictEqual(repositoryCoordinate.qualifiers, {});
+    assert.ok(Object.isFrozen(repositoryCoordinate.qualifiers));
+  });
+
+  test("snapshots bounded dependency qualifiers into canonical pull coordinates", () => {
+    const configurations = ["compile", "runtime"];
+    const qualifiers = {
+      alias: "declared-alias",
+      classifier: "sources",
+      configurations,
+      digest: "sha256:abcdef",
+      environment: "production",
+      platform: "x86_64-linux",
+      pullPolicy: "always",
+      repository: "registry.example.test",
+      scope: "com.example",
+      section: "dependencies",
+      service: "api",
+      stage: "builder",
+      tag: "latest",
+      targetFramework: "net8.0",
+      type: "jar",
+    };
+    const coordinate = createPackageCoordinate({
+      workspace: "workspace",
+      repository: "repository",
+      name: "artifact",
+      version: "1.0.0",
+      format: "maven",
+      qualifiers,
+    });
+
+    qualifiers.classifier = "javadoc";
+    configurations.push("test");
+    assert.deepStrictEqual(coordinate.qualifiers, {
+      alias: "declared-alias",
+      classifier: "sources",
+      configurations: ["compile", "runtime"],
+      digest: "sha256:abcdef",
+      environment: "production",
+      platform: "x86_64-linux",
+      pullPolicy: "always",
+      repository: "registry.example.test",
+      scope: "com.example",
+      section: "dependencies",
+      service: "api",
+      stage: "builder",
+      tag: "latest",
+      targetFramework: "net8.0",
+      type: "jar",
+    });
+    assert.ok(Object.isFrozen(coordinate.qualifiers));
+    assert.ok(Object.isFrozen(coordinate.qualifiers.configurations));
+
+    assert.throws(() => createPackageCoordinate({
+      workspace: "workspace",
+      repository: "repository",
+      name: "artifact",
+      version: "1.0.0",
+      format: "maven",
+      qualifiers: { unsupported: "identity" },
+    }), error => (
+      error instanceof PackageDomainError
+      && error.code === "unknown_field"
+      && error.field === "qualifiers.unsupported"
+    ));
   });
 
   test("provides a dedicated versionless upstream-resolution input", () => {
@@ -595,6 +661,7 @@ suite("Canonical package domain", () => {
     });
     assert.ok(isPackageCoordinate(coordinate));
     assert.strictEqual(coordinate.workspace, "workspace");
+    assert.deepStrictEqual(coordinate.qualifiers, {});
     const unmatchedResolution = fromPackageResolutionSelection({
       declarationName: "declared-alias",
       name: "normalized-name",
@@ -619,6 +686,36 @@ suite("Canonical package domain", () => {
       version: "1.0.0",
       format: "npm",
     }, { workspace: "workspace" }), PackageAdapterError);
+  });
+
+  test("preserves dependency node qualifiers when adapting unresolved pull coordinates", () => {
+    const coordinate = fromDependencyHealthNode({
+      name: "com.example:artifact",
+      resolvedVersion: "1.0.0",
+      format: "maven",
+      qualifiers: {
+        type: "test-jar",
+        classifier: "tests",
+        platform: "java",
+        tag: "release",
+        digest: "sha256:abcdef",
+        targetFramework: "net8.0",
+      },
+    }, {
+      workspace: "workspace",
+      repository: "repository",
+    });
+
+    assert.ok(isPackageCoordinate(coordinate));
+    assert.deepStrictEqual(coordinate.qualifiers, {
+      classifier: "tests",
+      digest: "sha256:abcdef",
+      platform: "java",
+      tag: "release",
+      targetFramework: "net8.0",
+      type: "test-jar",
+    });
+    assert.ok(Object.isFrozen(coordinate.qualifiers));
   });
 
   test("duplicate dependency and recent match aliases require full canonical consensus", () => {

--- a/test/recentSearches.test.js
+++ b/test/recentSearches.test.js
@@ -123,6 +123,18 @@ suite("RecentSearches", () => {
     })), /descriptor is invalid/);
   });
 
+  test("rejects control and bidi-bearing queries at persistence boundaries", async () => {
+    const searches = recent();
+    await assert.rejects(
+      searches.add(descriptor({ query: "name:flask\nOR name:django" })),
+      /descriptor is invalid/
+    );
+    await assert.rejects(
+      searches.add(descriptor({ query: "name:flask\u202e" })),
+      /descriptor is invalid/
+    );
+  });
+
   test("caps entries and keeps newest-first order", async () => {
     const searches = recent();
     for (let index = 0; index < 12; index += 1) {

--- a/test/registryEndpoints.test.js
+++ b/test/registryEndpoints.test.js
@@ -1,20 +1,24 @@
 const assert = require("assert");
 const {
   buildRegistryTriggerPlan,
-  createRegistryTrustScope,
+  dockerDigestMatches,
   findPythonDistributionUrl,
+  parseComposerDistUrl,
   parseCargoDownloadUrl,
   parseCargoIndexEntry,
+  parseDartArchiveUrl,
   parseDockerManifest,
   parseNpmTarballUrl,
   parseNuGetPackageUrl,
   resolveAndValidateDockerBlobRedirectUrl,
   resolveAndValidateScopedRegistryUrl,
 } = require("../util/registryEndpoints");
+const { getPackageLookupKeys } = require("../util/packageNameNormalizer");
 
 suite("registryEndpoints Test Suite", () => {
   const workspace = "workspace";
   const repository = "repo";
+  const trustScope = Object.freeze({ workspace, repository });
 
   test("npm uses exact-version metadata routes for unscoped, hyphenated, and scoped names", () => {
     const fixtures = [
@@ -114,6 +118,27 @@ suite("registryEndpoints Test Suite", () => {
     );
   });
 
+  test("registry plans reject deeply encoded path separators and traversal controls", () => {
+    const nested = (value) => {
+      let encoded = value;
+      for (let depth = 0; depth < 10; depth += 1) encoded = encodeURIComponent(encoded);
+      return encoded;
+    };
+    for (const unsafe of ["%2f", "%5c", "%3f", "%23", "%00", "%2e", "%2e%2e"].map(nested)) {
+      const dependency = { format: "npm", name: "safe-package", version: "1.0.0" };
+      assert.strictEqual(buildRegistryTriggerPlan(unsafe, repository, dependency), null, unsafe);
+      assert.strictEqual(buildRegistryTriggerPlan(workspace, unsafe, dependency), null, unsafe);
+      assert.strictEqual(buildRegistryTriggerPlan(workspace, repository, {
+        ...dependency,
+        name: unsafe,
+      }), null, unsafe);
+      assert.strictEqual(buildRegistryTriggerPlan(workspace, repository, {
+        ...dependency,
+        version: unsafe,
+      }), null, unsafe);
+    }
+  });
+
   test("Cargo uses native 1, 2, 3, and 4+ sparse index routing", () => {
     const fixtures = [
       ["a", "1/a"],
@@ -165,10 +190,34 @@ suite("registryEndpoints Test Suite", () => {
         entry.version,
         entry.checksum,
         baseUrl,
-        createRegistryTrustScope(workspace, repository)
+        trustScope
       ),
       `https://cargo.cloudsmith.io/workspace/repo/api/v1/crates/serde/1.0.200/${checksum}/download`
     );
+  });
+
+  test("Cargo download markers use directory prefixes and preserve crate-name case", () => {
+    const checksum = "c".repeat(64);
+    const configBody = JSON.stringify({
+      dl: "https://cargo.cloudsmith.io/workspace/repo/downloads/{prefix}/{lowerprefix}/{crate}/{version}",
+    });
+    const fixtures = [
+      ["a", "1/1/a"],
+      ["ab", "2/2/ab"],
+      ["AbC", "3/A/3/a/AbC"],
+      ["MyCrate", "My/Cr/my/cr/MyCrate"],
+    ];
+
+    for (const [crateName, expectedPath] of fixtures) {
+      assert.strictEqual(parseCargoDownloadUrl(
+        configBody,
+        crateName,
+        "1.2.3",
+        checksum,
+        "https://cargo.cloudsmith.io/workspace/repo/config.json",
+        trustScope
+      ), `https://cargo.cloudsmith.io/workspace/repo/downloads/${expectedPath}/1.2.3`);
+    }
   });
 
   test("Go, NuGet, Docker, Ruby, and Dart plans follow native coordinate rules", () => {
@@ -194,21 +243,28 @@ suite("registryEndpoints Test Suite", () => {
     assert.strictEqual(nugetPlan.packageName, "newtonsoft.json");
     assert.strictEqual(nugetPlan.packageVersion, "1.2.3-beta");
 
+    const dockerDigest = `sha256:${"a".repeat(64)}`;
     const dockerPlan = buildRegistryTriggerPlan(workspace, repository, {
         format: "docker",
         name: "docker.io/nginx",
         version: "stable",
-        qualifiers: { digest: "sha256:abcdef", tag: "stable" },
+        qualifiers: { digest: dockerDigest, tag: "stable" },
       });
     assert.strictEqual(
       dockerPlan.request.url,
-      "https://docker.cloudsmith.io/v2/workspace/repo/library/nginx/manifests/sha256%3Aabcdef"
+      `https://docker.cloudsmith.io/v2/workspace/repo/library/nginx/manifests/${encodeURIComponent(dockerDigest)}`
     );
     assert.strictEqual(dockerPlan.strategy, "docker-manifest");
     assert.strictEqual(
       dockerPlan.imageBaseUrl,
       "https://docker.cloudsmith.io/v2/workspace/repo/library/nginx"
     );
+    assert.strictEqual(buildRegistryTriggerPlan(workspace, repository, {
+      format: "docker",
+      name: "nginx",
+      version: "stable",
+      qualifiers: { digest: `sha256:${"a".repeat(32)}` },
+    }), null);
 
     assert.strictEqual(
       buildRegistryTriggerPlan(workspace, repository, {
@@ -249,7 +305,7 @@ suite("registryEndpoints Test Suite", () => {
         "@type": "PackageBaseAddress/3.0.0",
       }],
     }), "Newtonsoft.JSON", "01.02.003.0-BETA+build.7", indexUrl,
-    createRegistryTrustScope(workspace, repository));
+    trustScope);
     assert.strictEqual(
       packageUrl,
       "https://nuget.cloudsmith.io/workspace/repo/v3/flat/newtonsoft.json/1.2.3-beta/newtonsoft.json.1.2.3-beta.nupkg"
@@ -260,7 +316,7 @@ suite("registryEndpoints Test Suite", () => {
         "@type": "PackageBaseAddress/3.0.0",
       }],
     }), "safe", "1.0.0", indexUrl,
-    createRegistryTrustScope(workspace, repository)), null);
+    trustScope), null);
   });
 
   test("selects a bounded Docker platform manifest and its image blobs", () => {
@@ -310,20 +366,17 @@ suite("registryEndpoints Test Suite", () => {
     });
     assert.strictEqual(
       qualifiedPlan.request.url,
-      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3.pom"
-    );
-    assert.strictEqual(qualifiedPlan.strategy, "maven-artifact");
-    assert.strictEqual(
-      qualifiedPlan.artifactRequest.url,
       "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-tests.jar"
     );
+    assert.strictEqual(qualifiedPlan.strategy, "direct");
+    assert.strictEqual(qualifiedPlan.artifactRequest, undefined);
     assert.strictEqual(
       buildRegistryTriggerPlan(workspace, repository, {
         format: "maven",
         name: "com.example:bom",
         version: "1.2.3",
         qualifiers: { type: "pom" },
-      }).artifactRequest.url,
+      }).request.url,
       "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/bom/1.2.3/bom-1.2.3.pom"
     );
     const implicitClassifiers = [
@@ -339,10 +392,96 @@ suite("registryEndpoints Test Suite", () => {
           name: "com.example:demo",
           version: "1.2.3",
           qualifiers: { type },
-        }).artifactRequest.url,
+        }).request.url,
         `https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-${classifier}.jar`
       );
     }
+  });
+
+  test("Swift registry pins retain dotted scope identity in trigger coordinates", () => {
+    const plan = buildRegistryTriggerPlan(workspace, repository, {
+      format: "swift",
+      name: "Acme.Logging",
+      version: "1.2.3",
+      qualifiers: { scope: "acme" },
+    });
+
+    assert.ok(plan);
+    assert.strictEqual(
+      plan.request.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/swift/acme/logging/1.2.3.zip"
+    );
+    assert.strictEqual(buildRegistryTriggerPlan(workspace, repository, {
+      format: "swift",
+      name: "logging",
+      version: "1.2.3",
+    }), null);
+  });
+
+  test("Swift API lookup aliases preserve dots inside the unscoped package name", () => {
+    assert.deepStrictEqual(
+      getPackageLookupKeys("acme/foo.bar", "swift", { scope: "acme" }),
+      ["acme/foo.bar", "foo.bar"]
+    );
+  });
+
+  test("Docker manifest selection normalizes architecture aliases and implicit arm64 v8", () => {
+    const amd64Digest = `sha256:${"a".repeat(64)}`;
+    const arm64Digest = `sha256:${"b".repeat(64)}`;
+    const body = JSON.stringify({
+      schemaVersion: 2,
+      manifests: [
+        { digest: amd64Digest, platform: { os: "linux", architecture: "amd64" } },
+        { digest: arm64Digest, platform: { os: "linux", architecture: "arm64" } },
+      ],
+    });
+
+    assert.deepStrictEqual(
+      parseDockerManifest(body, { platform: "linux/x86_64" }),
+      { manifestDigest: amd64Digest, blobDigests: [] }
+    );
+    assert.deepStrictEqual(
+      parseDockerManifest(body, { platform: "linux/aarch64/v8" }),
+      { manifestDigest: arm64Digest, blobDigests: [] }
+    );
+  });
+
+  test("bare Docker digests prove only algorithms implied by their standard length", () => {
+    const sha256 = "a".repeat(64);
+    const sha512 = "b".repeat(128);
+    assert.strictEqual(dockerDigestMatches(sha256, `sha256:${sha256}`), true);
+    assert.strictEqual(dockerDigestMatches(sha512, `sha512:${sha512}`), true);
+    assert.strictEqual(dockerDigestMatches(sha256, `unknown:${sha256}`), false);
+  });
+
+  test("Dart and Composer metadata require exact package identity before selecting artifacts", () => {
+    const dartBase = "https://dart.cloudsmith.io/workspace/repo/api/packages/characters";
+    const dartArchive = "https://dart.cloudsmith.io/workspace/repo/api/archives/characters-1.3.0.tar.gz";
+    assert.strictEqual(parseDartArchiveUrl(JSON.stringify({
+      name: "other-package",
+      latest: { version: "1.3.0", archive_url: dartArchive },
+    }), "characters", "1.3.0", dartBase, trustScope), null);
+    assert.strictEqual(parseDartArchiveUrl(JSON.stringify({
+      name: "characters",
+      latest: { version: "1.3.0", archive_url: dartArchive },
+    }), "characters", "1.3.0", dartBase, trustScope), dartArchive);
+
+    const composerBase = "https://composer.cloudsmith.io/workspace/repo/p2/acme/widget.json";
+    const composerArchive = "https://composer.cloudsmith.io/workspace/repo/dist/acme/widget-1.2.3.zip";
+    assert.strictEqual(parseComposerDistUrl(JSON.stringify({
+      packages: {
+        "other/widget": [{ version: "1.2.3", dist: { url: composerArchive } }],
+      },
+    }), "acme/widget", "1.2.3", composerBase, trustScope), null);
+    assert.strictEqual(parseComposerDistUrl(JSON.stringify({
+      packages: {
+        "Acme/Widget": [{
+          name: "acme/widget",
+          version: "1.2.3",
+          dist: { url: composerArchive },
+        }],
+      },
+    }), "acme/widget", "1.2.3", composerBase, trustScope), composerArchive);
   });
 
   test("Python artifact discovery requires exact distribution identity and strips hash fragments", () => {
@@ -360,7 +499,7 @@ suite("registryEndpoints Test Suite", () => {
         "requests",
         "2.31.0",
         baseUrl,
-        createRegistryTrustScope(workspace, repository)
+        trustScope
       ),
       "https://dl.cloudsmith.io/basic/workspace/repo/python/packages/requests-2.31.0-py3-none-any.whl"
     );
@@ -370,8 +509,18 @@ suite("registryEndpoints Test Suite", () => {
     );
   });
 
+  test("Python artifact discovery rejects the legacy version-only call shape", () => {
+    const baseUrl = "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/requests/";
+    const html = '<a href="../../packages/evilrequests-2.31.0-py3-none-any.whl">wrong name</a>';
+
+    assert.strictEqual(
+      findPythonDistributionUrl(html, "2.31.0", baseUrl),
+      null
+    );
+  });
+
   test("metadata URLs are HTTPS, allowlisted, traversal-safe, and repository scoped", () => {
-    const scope = createRegistryTrustScope(workspace, repository);
+    const scope = trustScope;
     const baseUrl = "https://npm.cloudsmith.io/workspace/repo/package";
     assert.strictEqual(
       resolveAndValidateScopedRegistryUrl(
@@ -399,6 +548,10 @@ suite("registryEndpoints Test Suite", () => {
       "https://npm.cloudsmith.io/workspace/repo/package.tgz?redirect=registry"
     );
 
+    let overEncodedTraversal = "%2e%2e";
+    for (let depth = 0; depth < 10; depth += 1) {
+      overEncodedTraversal = encodeURIComponent(overEncodedTraversal);
+    }
     const rejected = [
       "http://npm.cloudsmith.io/workspace/repo/package.tgz",
       "https://example.com/workspace/repo/package.tgz",
@@ -406,6 +559,9 @@ suite("registryEndpoints Test Suite", () => {
       "https://npm.cloudsmith.io/other/repo/package.tgz",
       "https://npm.cloudsmith.io/workspace/repo/package.tgz?token=secret",
       "https://npm.cloudsmith.io/workspace/repo/%252e%252e/other/package.tgz",
+      "https://npm.cloudsmith.io/workspace/repo/%2525252e%2525252e/other/package.tgz",
+      `https://npm.cloudsmith.io/workspace/repo/${overEncodedTraversal}/other/package.tgz`,
+      `https://npm.cloudsmith.io/workspace/repo/${"x".repeat(17000)}`,
       "https://user@npm.cloudsmith.io/workspace/repo/package.tgz",
     ];
     for (const candidate of rejected) {
@@ -460,7 +616,7 @@ suite("registryEndpoints Test Suite", () => {
         "left-pad",
         "1.0.0",
         baseUrl,
-        createRegistryTrustScope(workspace, repository)
+        trustScope
       ),
       null
     );

--- a/test/registryEndpoints.test.js
+++ b/test/registryEndpoints.test.js
@@ -1,0 +1,468 @@
+const assert = require("assert");
+const {
+  buildRegistryTriggerPlan,
+  createRegistryTrustScope,
+  findPythonDistributionUrl,
+  parseCargoDownloadUrl,
+  parseCargoIndexEntry,
+  parseDockerManifest,
+  parseNpmTarballUrl,
+  parseNuGetPackageUrl,
+  resolveAndValidateDockerBlobRedirectUrl,
+  resolveAndValidateScopedRegistryUrl,
+} = require("../util/registryEndpoints");
+
+suite("registryEndpoints Test Suite", () => {
+  const workspace = "workspace";
+  const repository = "repo";
+
+  test("npm uses exact-version metadata routes for unscoped, hyphenated, and scoped names", () => {
+    const fixtures = [
+      ["left-pad", "https://npm.cloudsmith.io/workspace/repo/left-pad/1.2.3-beta.1"],
+      ["package-with-hyphens", "https://npm.cloudsmith.io/workspace/repo/package-with-hyphens/1.2.3-beta.1"],
+      ["@scope/widget-name", "https://npm.cloudsmith.io/workspace/repo/%40scope%2Fwidget-name/1.2.3-beta.1"],
+    ];
+
+    for (const [name, expectedUrl] of fixtures) {
+      const plan = buildRegistryTriggerPlan(workspace, repository, {
+        format: "npm",
+        name,
+        version: "1.2.3-beta.1",
+      });
+      assert.ok(plan);
+      assert.strictEqual(plan.strategy, "npm-packument");
+      assert.strictEqual(plan.packageName, name);
+      assert.strictEqual(plan.request.url, expectedUrl);
+      assert.match(plan.request.headers.Accept, /application\/vnd\.npm\.install-v1\+json/);
+    }
+  });
+
+  test("npm selects only the exact version tarball without assuming its filename", () => {
+    const plan = buildRegistryTriggerPlan(workspace, repository, {
+      format: "npm",
+      name: "@scope/widget-name",
+      version: "1.2.3-beta.1",
+    });
+    const arbitraryTarball = "https://npm.cloudsmith.io/workspace/repo/@scope/widget-name/-/content-addressed-7f3a.tgz";
+    const body = JSON.stringify({
+      name: "@scope/widget-name",
+      versions: {
+        "1.2.3": {
+          version: "1.2.3",
+          dist: { tarball: "https://npm.cloudsmith.io/workspace/repo/wrong.tgz" },
+        },
+        "1.2.3-beta.1": {
+          version: "1.2.3-beta.1",
+          dist: { tarball: arbitraryTarball },
+        },
+      },
+    });
+
+    assert.strictEqual(
+      parseNpmTarballUrl(
+        body,
+        plan.packageName,
+        "1.2.3-beta.1",
+        plan.request.url,
+        plan.trustScope
+      ),
+      arbitraryTarball
+    );
+    assert.strictEqual(
+      parseNpmTarballUrl(
+        JSON.stringify({
+          name: "@scope/widget-name",
+          version: "1.2.3-beta.1",
+          dist: { tarball: arbitraryTarball },
+        }),
+        plan.packageName,
+        "1.2.3-beta.1",
+        plan.request.url,
+        plan.trustScope
+      ),
+      arbitraryTarball
+    );
+    assert.strictEqual(
+      parseNpmTarballUrl(body, plan.packageName, "1.2.3-beta.2", plan.request.url, plan.trustScope),
+      null
+    );
+    assert.strictEqual(
+      parseNpmTarballUrl(
+        JSON.stringify({
+          version: "1.2.3-beta.1",
+          dist: { tarball: arbitraryTarball },
+        }),
+        plan.packageName,
+        "1.2.3-beta.1",
+        plan.request.url,
+        plan.trustScope
+      ),
+      null
+    );
+    assert.strictEqual(
+      parseNpmTarballUrl(
+        JSON.stringify({
+          name: "@scope/widget-name",
+          dist: { tarball: arbitraryTarball },
+        }),
+        plan.packageName,
+        "1.2.3-beta.1",
+        plan.request.url,
+        plan.trustScope
+      ),
+      null
+    );
+  });
+
+  test("Cargo uses native 1, 2, 3, and 4+ sparse index routing", () => {
+    const fixtures = [
+      ["a", "1/a"],
+      ["ab", "2/ab"],
+      ["abc", "3/a/abc"],
+      ["serde", "se/rd/serde"],
+    ];
+    for (const [name, expectedPath] of fixtures) {
+      const plan = buildRegistryTriggerPlan(workspace, repository, {
+        format: "cargo",
+        name,
+        version: "1.0.0",
+      });
+      assert.ok(plan);
+      assert.strictEqual(plan.strategy, "cargo-sparse-index");
+      assert.strictEqual(
+        plan.request.url,
+        `https://cargo.cloudsmith.io/workspace/repo/${expectedPath}`
+      );
+      assert.strictEqual(
+        plan.configRequest.url,
+        "https://cargo.cloudsmith.io/workspace/repo/config.json"
+      );
+    }
+  });
+
+  test("Cargo exact index metadata expands its repository-scoped download template", () => {
+    const checksum = "a".repeat(64);
+    const indexBody = [
+      JSON.stringify({ name: "serde", vers: "1.0.199", cksum: "b".repeat(64) }),
+      JSON.stringify({ name: "serde", vers: "1.0.200", cksum: checksum }),
+    ].join("\n");
+    const entry = parseCargoIndexEntry(indexBody, "serde", "1.0.200");
+    assert.deepStrictEqual(entry, {
+      name: "serde",
+      version: "1.0.200",
+      checksum,
+      yanked: false,
+    });
+
+    const baseUrl = "https://cargo.cloudsmith.io/workspace/repo/config.json";
+    const configBody = JSON.stringify({
+      dl: "https://cargo.cloudsmith.io/workspace/repo/api/v1/crates/{crate}/{version}/{sha256-checksum}/download",
+    });
+    assert.strictEqual(
+      parseCargoDownloadUrl(
+        configBody,
+        entry.name,
+        entry.version,
+        entry.checksum,
+        baseUrl,
+        createRegistryTrustScope(workspace, repository)
+      ),
+      `https://cargo.cloudsmith.io/workspace/repo/api/v1/crates/serde/1.0.200/${checksum}/download`
+    );
+  });
+
+  test("Go, NuGet, Docker, Ruby, and Dart plans follow native coordinate rules", () => {
+    assert.strictEqual(
+      buildRegistryTriggerPlan(workspace, repository, {
+        format: "go",
+        name: "github.com/MyOrg/MyModule",
+        version: "v1.2.3-RC1+BuildMeta",
+      }).request.url,
+      "https://golang.cloudsmith.io/workspace/repo/github.com/!my!org/!my!module/@v/v1.2.3-!r!c1%2B!build!meta.zip"
+    );
+
+    const nugetPlan = buildRegistryTriggerPlan(workspace, repository, {
+        format: "nuget",
+        name: "Newtonsoft.JSON",
+        version: "01.02.003.0-BETA+build.7",
+      });
+    assert.strictEqual(
+      nugetPlan.request.url,
+      "https://nuget.cloudsmith.io/workspace/repo/v3/index.json"
+    );
+    assert.strictEqual(nugetPlan.strategy, "nuget-service-index");
+    assert.strictEqual(nugetPlan.packageName, "newtonsoft.json");
+    assert.strictEqual(nugetPlan.packageVersion, "1.2.3-beta");
+
+    const dockerPlan = buildRegistryTriggerPlan(workspace, repository, {
+        format: "docker",
+        name: "docker.io/nginx",
+        version: "stable",
+        qualifiers: { digest: "sha256:abcdef", tag: "stable" },
+      });
+    assert.strictEqual(
+      dockerPlan.request.url,
+      "https://docker.cloudsmith.io/v2/workspace/repo/library/nginx/manifests/sha256%3Aabcdef"
+    );
+    assert.strictEqual(dockerPlan.strategy, "docker-manifest");
+    assert.strictEqual(
+      dockerPlan.imageBaseUrl,
+      "https://docker.cloudsmith.io/v2/workspace/repo/library/nginx"
+    );
+
+    assert.strictEqual(
+      buildRegistryTriggerPlan(workspace, repository, {
+        format: "ruby",
+        name: "nokogiri",
+        version: "1.16.5",
+        qualifiers: { platform: "x86_64-linux" },
+      }).request.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/ruby/gems/nokogiri-1.16.5-x86_64-linux.gem"
+    );
+    assert.strictEqual(
+      buildRegistryTriggerPlan(workspace, repository, {
+        format: "ruby",
+        name: "rake",
+        version: "13.2.1",
+        qualifiers: { platform: "ruby" },
+      }).request.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/ruby/gems/rake-13.2.1.gem"
+    );
+
+    const dartPlan = buildRegistryTriggerPlan(workspace, repository, {
+        format: "dart",
+        name: "collection",
+        version: "1.19.0",
+      });
+    assert.strictEqual(
+      dartPlan.request.headers.Accept,
+      "application/vnd.pub.v2+json"
+    );
+    assert.strictEqual(dartPlan.request.authScheme, "bearer");
+  });
+
+  test("NuGet resolves its exact package URL from the scoped v3 service index", () => {
+    const indexUrl = "https://nuget.cloudsmith.io/workspace/repo/v3/index.json";
+    const packageUrl = parseNuGetPackageUrl(JSON.stringify({
+      resources: [{
+        "@id": "https://nuget.cloudsmith.io/workspace/repo/v3/flat/",
+        "@type": "PackageBaseAddress/3.0.0",
+      }],
+    }), "Newtonsoft.JSON", "01.02.003.0-BETA+build.7", indexUrl,
+    createRegistryTrustScope(workspace, repository));
+    assert.strictEqual(
+      packageUrl,
+      "https://nuget.cloudsmith.io/workspace/repo/v3/flat/newtonsoft.json/1.2.3-beta/newtonsoft.json.1.2.3-beta.nupkg"
+    );
+    assert.strictEqual(parseNuGetPackageUrl(JSON.stringify({
+      resources: [{
+        "@id": "https://example.com/v3/flat/",
+        "@type": "PackageBaseAddress/3.0.0",
+      }],
+    }), "safe", "1.0.0", indexUrl,
+    createRegistryTrustScope(workspace, repository)), null);
+  });
+
+  test("selects a bounded Docker platform manifest and its image blobs", () => {
+    const amd64Digest = `sha256:${"a".repeat(64)}`;
+    const arm64Digest = `sha256:${"b".repeat(64)}`;
+    assert.deepStrictEqual(parseDockerManifest(JSON.stringify({
+      schemaVersion: 2,
+      manifests: [
+        { digest: arm64Digest, platform: { os: "linux", architecture: "arm64" } },
+        { digest: amd64Digest, platform: { os: "linux", architecture: "amd64" } },
+      ],
+    })), { manifestDigest: amd64Digest, blobDigests: [] });
+    assert.deepStrictEqual(parseDockerManifest(JSON.stringify({
+      schemaVersion: 2,
+      manifests: [
+        { digest: amd64Digest, platform: { os: "linux", architecture: "amd64" } },
+        { digest: arm64Digest, platform: { os: "linux", architecture: "arm64", variant: "v8" } },
+      ],
+    }), { platform: "linux/arm64/v8" }), { manifestDigest: arm64Digest, blobDigests: [] });
+    assert.strictEqual(parseDockerManifest(JSON.stringify({
+      schemaVersion: 2,
+      manifests: [
+        { digest: amd64Digest, platform: { os: "linux", architecture: "amd64" } },
+      ],
+    }), { platform: "linux/arm64" }), null);
+
+    const configDigest = `sha256:${"c".repeat(64)}`;
+    const layerDigest = `sha256:${"d".repeat(64)}`;
+    assert.deepStrictEqual(parseDockerManifest(JSON.stringify({
+      schemaVersion: 2,
+      config: { digest: configDigest },
+      layers: [{ digest: layerDigest }, { digest: layerDigest }],
+    })), { manifestDigest: null, blobDigests: [configDigest, layerDigest] });
+    assert.strictEqual(parseDockerManifest(JSON.stringify({
+      schemaVersion: 2,
+      config: { digest: "../invalid" },
+      layers: [],
+    })), null);
+  });
+
+  test("Maven preserves type and classifier in the exact artifact request", () => {
+    const qualifiedPlan = buildRegistryTriggerPlan(workspace, repository, {
+      format: "maven",
+      name: "com.example:demo",
+      version: "1.2.3",
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    });
+    assert.strictEqual(
+      qualifiedPlan.request.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3.pom"
+    );
+    assert.strictEqual(qualifiedPlan.strategy, "maven-artifact");
+    assert.strictEqual(
+      qualifiedPlan.artifactRequest.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-tests.jar"
+    );
+    assert.strictEqual(
+      buildRegistryTriggerPlan(workspace, repository, {
+        format: "maven",
+        name: "com.example:bom",
+        version: "1.2.3",
+        qualifiers: { type: "pom" },
+      }).artifactRequest.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/bom/1.2.3/bom-1.2.3.pom"
+    );
+    const implicitClassifiers = [
+      ["test-jar", "tests"],
+      ["java-source", "sources"],
+      ["javadoc", "javadoc"],
+      ["ejb-client", "client"],
+    ];
+    for (const [type, classifier] of implicitClassifiers) {
+      assert.strictEqual(
+        buildRegistryTriggerPlan(workspace, repository, {
+          format: "maven",
+          name: "com.example:demo",
+          version: "1.2.3",
+          qualifiers: { type },
+        }).artifactRequest.url,
+        `https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-${classifier}.jar`
+      );
+    }
+  });
+
+  test("Python artifact discovery requires exact distribution identity and strips hash fragments", () => {
+    const baseUrl = "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/requests/";
+    const digest = "c".repeat(64);
+    const html = [
+      '<a href="../../packages/evilrequests-2.31.0-py3-none-any.whl">wrong name</a>',
+      `<a href="../../packages/requests-2.31.0-py3-none-any.whl#sha256=${digest}">exact</a>`,
+      '<a href="../../packages/requests-2.30.0-py3-none-any.whl">wrong version</a>',
+    ].join("\n");
+
+    assert.strictEqual(
+      findPythonDistributionUrl(
+        html,
+        "requests",
+        "2.31.0",
+        baseUrl,
+        createRegistryTrustScope(workspace, repository)
+      ),
+      "https://dl.cloudsmith.io/basic/workspace/repo/python/packages/requests-2.31.0-py3-none-any.whl"
+    );
+    assert.strictEqual(
+      findPythonDistributionUrl(html, "other", "2.31.0", baseUrl),
+      null
+    );
+  });
+
+  test("metadata URLs are HTTPS, allowlisted, traversal-safe, and repository scoped", () => {
+    const scope = createRegistryTrustScope(workspace, repository);
+    const baseUrl = "https://npm.cloudsmith.io/workspace/repo/package";
+    assert.strictEqual(
+      resolveAndValidateScopedRegistryUrl(
+        "https://dl.cloudsmith.io/basic/workspace/repo/npm/package.tgz",
+        baseUrl,
+        scope
+      ),
+      "https://dl.cloudsmith.io/basic/workspace/repo/npm/package.tgz"
+    );
+    assert.strictEqual(
+      resolveAndValidateScopedRegistryUrl(
+        "https://dl.cloudsmith.io/signed/workspace/repo/upstream/filename/npm/package.tgz",
+        baseUrl,
+        scope
+      ),
+      "https://dl.cloudsmith.io/signed/workspace/repo/upstream/filename/npm/package.tgz"
+    );
+    assert.strictEqual(
+      resolveAndValidateScopedRegistryUrl(
+        "https://npm.cloudsmith.io/workspace/repo/package.tgz?redirect=registry",
+        baseUrl,
+        scope,
+        { allowQuery: true }
+      ),
+      "https://npm.cloudsmith.io/workspace/repo/package.tgz?redirect=registry"
+    );
+
+    const rejected = [
+      "http://npm.cloudsmith.io/workspace/repo/package.tgz",
+      "https://example.com/workspace/repo/package.tgz",
+      "https://npm.cloudsmith.io/workspace/other/package.tgz",
+      "https://npm.cloudsmith.io/other/repo/package.tgz",
+      "https://npm.cloudsmith.io/workspace/repo/package.tgz?token=secret",
+      "https://npm.cloudsmith.io/workspace/repo/%252e%252e/other/package.tgz",
+      "https://user@npm.cloudsmith.io/workspace/repo/package.tgz",
+    ];
+    for (const candidate of rejected) {
+      assert.strictEqual(
+        resolveAndValidateScopedRegistryUrl(candidate, baseUrl, scope),
+        null,
+        candidate
+      );
+    }
+  });
+
+  test("Docker blob redirects allow safe HTTPS storage URLs without widening registry trust", () => {
+    const baseUrl = "https://docker.cloudsmith.io/v2/workspace/repo/library/demo/blobs/sha256%3Aabc";
+    const signedUrl = "https://bucket.s3.amazonaws.com/blobs/content?signature=abc&expires=123";
+    assert.strictEqual(
+      resolveAndValidateDockerBlobRedirectUrl(signedUrl, baseUrl),
+      signedUrl
+    );
+    for (const rejected of [
+      "http://storage.example.com/blobs/content?signature=abc",
+      "https://127.0.0.1/blobs/content",
+      "https://localhost/blobs/content",
+      "https://localhost./blobs/content",
+      "https://metadata.google.internal./computeMetadata/v1/",
+      "https://169.254.169.254.nip.io/blobs/content",
+      "https://storage.example.com/blobs/content",
+      "https://storage.example.com/../private/content",
+      "https://user:secret@storage.example.com/blobs/content",
+      "https://storage.example.com/blobs/content#fragment",
+      "https://docker.cloudsmith.io/v2/workspace/other/library/demo/blobs/sha256%3Aabc",
+    ]) {
+      assert.strictEqual(resolveAndValidateDockerBlobRedirectUrl(rejected, baseUrl), null);
+    }
+  });
+
+  test("npm metadata cannot move an authenticated artifact request across repositories", () => {
+    const baseUrl = "https://npm.cloudsmith.io/workspace/repo/left-pad";
+    const body = JSON.stringify({
+      name: "left-pad",
+      versions: {
+        "1.0.0": {
+          version: "1.0.0",
+          dist: {
+            tarball: "https://npm.cloudsmith.io/workspace/other/left-pad/-/left-pad-1.0.0.tgz",
+          },
+        },
+      },
+    });
+    assert.strictEqual(
+      parseNpmTarballUrl(
+        body,
+        "left-pad",
+        "1.0.0",
+        baseUrl,
+        createRegistryTrustScope(workspace, repository)
+      ),
+      null
+    );
+  });
+});

--- a/test/searchProvider.test.js
+++ b/test/searchProvider.test.js
@@ -261,6 +261,27 @@ suite("SearchProvider atomic search state", () => {
     assert.strictEqual(provider.currentQuery, "second");
   });
 
+  test("beginSearch rejects control and bidi-bearing replay descriptors", async () => {
+    let fetchCount = 0;
+    const { provider } = createProvider({
+      fetchPage: async () => {
+        fetchCount += 1;
+        return page([]);
+      },
+    });
+    for (const query of ["name:foo\nOR name:bar", "name:foo\u202e"]) {
+      const operation = provider.beginSearch({
+        kind: "workspace",
+        workspace: "workspace-a",
+        query,
+      });
+      assert.match(operation.validationError, /search query was invalid/);
+      await provider.executeSearch(operation);
+      assert.strictEqual(provider.state.failure.kind, "invalid_request");
+    }
+    assert.strictEqual(fetchCount, 0);
+  });
+
   test("a stale root success cannot replace or refresh over the latest result", async () => {
     const slow = deferred();
     const fast = deferred();

--- a/test/searchQueryBuilder.test.js
+++ b/test/searchQueryBuilder.test.js
@@ -75,6 +75,22 @@ suite('SearchQueryBuilder Test Suite', () => {
 		assert.strictEqual(result, 'name:pkg\\:\\\"beta\\\"');
 	});
 
+	test('registry-native slash identities remain searchable while query operators are escaped', () => {
+		const builder = new SearchQueryBuilder();
+		assert.strictEqual(
+			builder.name('@scope/package OR status:quarantined').build(),
+			'name:"@scope/package OR status\\:quarantined"'
+		);
+	});
+
+	test('ordinary hyphen and plus identity characters remain searchable', () => {
+		const builder = new SearchQueryBuilder();
+		assert.strictEqual(
+			builder.name('@aws-sdk/client-s3').version('1.2.3-beta+build').build(),
+			'name:@aws-sdk/client-s3 AND version:1.2.3-beta+build'
+		);
+	});
+
 	test('empty build returns empty string', () => {
 		const builder = new SearchQueryBuilder();
 		assert.strictEqual(builder.build(), '');

--- a/test/searchQueryBuilder.test.js
+++ b/test/searchQueryBuilder.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { SearchQueryBuilder } = require('../util/searchQueryBuilder');
+const { buildAdvancedSearchQuery } = require('../commands/support');
 
 suite('SearchQueryBuilder Test Suite', () => {
 
@@ -64,6 +65,53 @@ suite('SearchQueryBuilder Test Suite', () => {
 		assert.strictEqual(result, 'name:flask AND NOT status:quarantined');
 	});
 
+	test('advanced() accepts a bounded query DSL without escaping its operators', () => {
+		const builder = new SearchQueryBuilder();
+		assert.strictEqual(
+			builder.advanced('name:^flask$ OR (format:python AND NOT status:quarantined)').build(),
+			'name:^flask$ OR (format:python AND NOT status:quarantined)'
+		);
+	});
+
+	test('advanced() rejects blank, control-bearing, bidi, and oversized query text', () => {
+		for (const query of ['', '   ', 'name:foo\nOR name:bar', 'name:foo\u202e', 'x'.repeat(2049)]) {
+			assert.throws(
+				() => new SearchQueryBuilder().advanced(query),
+				/Advanced Cloudsmith query/,
+				query
+			);
+		}
+	});
+
+	test('build() enforces the aggregate transport boundary across individually valid terms', () => {
+		const builder = new SearchQueryBuilder()
+			.advanced('x'.repeat(1024))
+			.advanced('y'.repeat(1024));
+
+		assert.throws(() => builder.build(), /safe transport boundary/);
+	});
+
+	test('user-authored advanced queries do not cross the trusted raw() boundary', () => {
+		let advancedInput = null;
+		class BoundaryBuilder {
+			advanced(value) {
+				advancedInput = value;
+				return this;
+			}
+			raw() {
+				throw new Error('raw() must remain limited to trusted internal fragments');
+			}
+			build() {
+				return advancedInput;
+			}
+		}
+
+		assert.strictEqual(
+			buildAdvancedSearchQuery(BoundaryBuilder, 'name:widget OR format:npm'),
+			'name:widget OR format:npm'
+		);
+	});
+
 	test('values with spaces are quoted', () => {
 		const builder = new SearchQueryBuilder();
 		assert.strictEqual(builder.name('my package').build(), 'name:"my package"');
@@ -73,6 +121,13 @@ suite('SearchQueryBuilder Test Suite', () => {
 		const builder = new SearchQueryBuilder();
 		const result = builder.name('pkg:"beta"').build();
 		assert.strictEqual(result, 'name:pkg\\:\\\"beta\\\"');
+	});
+
+	test('leading modifier hardening preserves established boolean-symbol escaping', () => {
+		assert.strictEqual(
+			new SearchQueryBuilder().name('foo&&bar||baz').build(),
+			'name:foo\\&&bar\\||baz'
+		);
 	});
 
 	test('registry-native slash identities remain searchable while query operators are escaped', () => {
@@ -88,6 +143,67 @@ suite('SearchQueryBuilder Test Suite', () => {
 		assert.strictEqual(
 			builder.name('@aws-sdk/client-s3').version('1.2.3-beta+build').build(),
 			'name:@aws-sdk/client-s3 AND version:1.2.3-beta+build'
+		);
+	});
+
+	test('escapes only leading plus and minus runs while preserving registry-native identity syntax', () => {
+		const cases = [
+			['foo-bar', 'foo-bar'],
+			['foo+bar', 'foo+bar'],
+			['1.2.3-beta+build', '1.2.3-beta+build'],
+			['@scope/package', '@scope/package'],
+			['@aws-sdk/client-s3', '@aws-sdk/client-s3'],
+			['+foo', '\\+foo'],
+			['-foo', '\\-foo'],
+			['++foo', '\\+\\+foo'],
+			['--foo', '\\-\\-foo'],
+			['+-foo', '\\+\\-foo'],
+			['-+foo', '\\-\\+foo'],
+			['+foo-bar', '\\+foo-bar'],
+			['-foo+bar', '\\-foo+bar'],
+			['value with spaces', '"value with spaces"'],
+			['+value with spaces', '"\\+value with spaces"'],
+			['-value with spaces', '"\\-value with spaces"'],
+			['path\\segment', 'path\\\\segment'],
+			['field:value', 'field\\:value'],
+			['end$anchor', 'end\\$anchor'],
+			['version>1<2', 'version\\>1\\<2'],
+			["'quoted'", "\\'quoted\\'"],
+			['say "hello"', '"say \\"hello\\""'],
+			['OR NOT status:quarantined', '"OR NOT status\\:quarantined"'],
+		];
+
+		for (const [input, escaped] of cases) {
+			assert.strictEqual(
+				new SearchQueryBuilder().name(input).build(),
+				`name:${escaped}`,
+				input
+			);
+		}
+	});
+
+	test('neutralizes leading modifiers consistently for every escaped builder field', () => {
+		const builderMethods = ['name', 'format', 'status', 'version', 'tag'];
+		for (const method of builderMethods) {
+			assert.strictEqual(
+				new SearchQueryBuilder()[method]('+-hostile').build(),
+				`${method}:\\+\\-hostile`,
+				method
+			);
+			assert.strictEqual(
+				new SearchQueryBuilder()[method]('literal$identity').build(),
+				`${method}:literal\\$identity`,
+				method
+			);
+			assert.strictEqual(
+				new SearchQueryBuilder()[method](">literal<'identity'").build(),
+				`${method}:\\>literal\\<\\'identity\\'`,
+				method
+			);
+		}
+		assert.strictEqual(
+			SearchQueryBuilder.permissible('--hostile'),
+			'name:\\-\\-hostile AND NOT status:quarantined AND deny_policy_violated:false'
 		);
 	});
 
@@ -115,5 +231,10 @@ suite('SearchQueryBuilder Test Suite', () => {
 	test('permissible() escapes special characters in package names', () => {
 		const result = SearchQueryBuilder.permissible('pkg:name');
 		assert.strictEqual(result, 'name:pkg\\:name AND NOT status:quarantined AND deny_policy_violated:false');
+	});
+
+	test('permissible() enforces the same final control and length boundary', () => {
+		assert.throws(() => SearchQueryBuilder.permissible('name\nOR status:quarantined'));
+		assert.throws(() => SearchQueryBuilder.permissible('x'.repeat(2048)));
 	});
 });

--- a/test/testInventories.js
+++ b/test/testInventories.js
@@ -27,6 +27,7 @@ const STANDALONE_NODE_TESTS = Object.freeze([
   "test/polishGate.test.js",
   "test/promotionContracts.test.js",
   "test/recentPackages.test.js",
+  "test/registryEndpoints.test.js",
   "test/releaseGate.test.js",
   "test/remediationHelper.test.js",
   "test/runtimeProcessGuard.test.js",

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -8,6 +8,7 @@ const {
 } = require("../util/upstreamPullService");
 const { UpstreamChecker } = require("../util/upstreamChecker");
 const { UpstreamOperationScheduler } = require("../util/upstreamOperationScheduler");
+const { getDependencyArtifactKey } = require("../util/dependencyRecord");
 const { apiFailure, apiSuccess } = require("./apiResultHelpers");
 
 function createResponse(status, body, headers = {}) {
@@ -173,12 +174,9 @@ suite("UpstreamPullService", () => {
     });
     assert.strictEqual(
       mavenPlan.request.url,
-      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo-app/1.2.3/demo-app-1.2.3.pom"
-    );
-    assert.strictEqual(
-      mavenPlan.artifactRequest.url,
       "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo-app/1.2.3/demo-app-1.2.3.jar"
     );
+    assert.strictEqual(mavenPlan.artifactRequest, undefined);
 
     const npmPlan = buildRegistryTriggerPlan("workspace", "repo", {
       name: "@scope/widget",
@@ -251,6 +249,7 @@ suite("UpstreamPullService", () => {
     const startedAt = Date.now();
     const result = findPythonDistributionUrl(
       hostileHtml,
+      "artifact",
       "1.0.0",
       "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/"
     );
@@ -343,6 +342,7 @@ suite("UpstreamPullService", () => {
       present: false,
       complete: true,
       stale: false,
+      observedIdentities: [],
     });
   });
 
@@ -373,6 +373,68 @@ suite("UpstreamPullService", () => {
 
     assert.match(requestedQuery, /name:@aws-sdk\/client-s3/);
     assert.doesNotMatch(requestedQuery, /@aws\\-sdk|client\\-s3|@aws-sdk\\\/client-s3/);
+    assert.strictEqual(result.present, true);
+    assert.strictEqual(result.absent, false);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("leading modifier-like names cannot broaden exact pull presence", async () => {
+    const queries = [];
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get(endpoint) {
+          queries.push(new URL(endpoint, "https://api.cloudsmith.io")
+            .searchParams.get("query"));
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "target-package",
+            version: "1.0.0",
+            format: "npm",
+            slug_perm: "different-package",
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: { name: "+-target-package", version: "1.0.0", format: "npm" },
+    });
+
+    assert.ok(queries[0].includes("name:\\+\\-target-package"));
+    assert.strictEqual(result.present, false);
+    assert.strictEqual(result.absent, true);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("leading modifier-like names still produce exact pull presence", async () => {
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get() {
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "--target-package",
+            version: "1.0.0-beta+build",
+            format: "npm",
+            slug_perm: "exact-package",
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: {
+        name: "--target-package",
+        version: "1.0.0-beta+build",
+        format: "npm",
+      },
+    });
+
     assert.strictEqual(result.present, true);
     assert.strictEqual(result.absent, false);
     assert.strictEqual(result.complete, true);
@@ -444,7 +506,7 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(result.complete, true);
   });
 
-  test("exact Docker presence requires the requested platform architecture", async () => {
+  test("platform-qualified Docker presence rejects unlinked split-row evidence before and after pull", async () => {
     const tagCandidate = {
       namespace: "workspace",
       repository: "repo-b",
@@ -464,7 +526,7 @@ suite("UpstreamPullService", () => {
       architectures: [{ name: architecture }],
       identifiers: { architecture, docker_platform_os: "linux" },
     });
-    const check = async candidates => new UpstreamPullService({}, {
+    const check = async (candidates, options = {}) => new UpstreamPullService({}, {
       api: { async get() { return apiSuccess(candidates); } },
     })._checkExactPackageAbsence({
       workspace: "workspace",
@@ -475,22 +537,165 @@ suite("UpstreamPullService", () => {
         format: "docker",
         qualifiers: { tag: "stable", platform: "linux/arm64" },
       },
+      ...options,
     });
 
-    const wrongPlatform = await check([{
-      ...tagCandidate,
-      ...architectureCandidate("amd64"),
-      tags: tagCandidate.tags,
-    }]);
-    assert.strictEqual(wrongPlatform.absent, true);
-    const unrelatedPlatform = await check([tagCandidate, architectureCandidate("arm64")]);
-    assert.strictEqual(unrelatedPlatform.absent, true);
-    const exactPlatform = await check([{
-      ...tagCandidate,
-      ...architectureCandidate("arm64"),
-      tags: tagCandidate.tags,
-    }]);
-    assert.strictEqual(exactPlatform.present, true);
+    const wrongPlatform = await check([
+      tagCandidate,
+      architectureCandidate("amd64"),
+    ]);
+    assert.strictEqual(wrongPlatform.complete, false);
+    const preexistingSplitShape = await check([
+      tagCandidate,
+      architectureCandidate("arm64"),
+    ]);
+    assert.strictEqual(preexistingSplitShape.complete, false);
+    const postTriggerSplitShape = await check([
+      tagCandidate,
+      architectureCandidate("arm64"),
+    ]);
+    assert.strictEqual(postTriggerSplitShape.present, false);
+    assert.strictEqual(postTriggerSplitShape.absent, false);
+    assert.strictEqual(postTriggerSplitShape.complete, false);
+    const verifiedRegistryManifest = await check([tagCandidate], {
+      dockerPlatformVerified: true,
+    });
+    assert.strictEqual(verifiedRegistryManifest.present, true);
+    assert.strictEqual(verifiedRegistryManifest.complete, true);
+  });
+
+  test("exact Docker digest presence preserves the digest algorithm when Cloudsmith supplies it", async () => {
+    const hex = "a".repeat(64);
+    const check = async observedVersion => new UpstreamPullService({}, {
+      api: {
+        async get() {
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "library/example",
+            version: observedVersion,
+            format: "docker",
+            slug_perm: "example-digest",
+            tags: { info: ["upstream"] },
+          }]);
+        },
+      },
+    })._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: {
+        name: "example",
+        version: `sha256:${hex}`,
+        format: "docker",
+        qualifiers: { digest: `sha256:${hex}` },
+      },
+    });
+
+    assert.strictEqual((await check(`sha512:${hex}`)).absent, true);
+    assert.strictEqual((await check(`unknown:${hex}`)).absent, true);
+    assert.strictEqual((await check(hex)).present, true);
+  });
+
+  test("exact Swift lookup uses the bare API name but fails closed without scope evidence", async () => {
+    let requestedQuery = "";
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get(endpoint) {
+          requestedQuery = new URL(endpoint, "https://api.cloudsmith.io/v1/")
+            .searchParams.get("query");
+          return apiSuccess([{
+            namespace: "acme",
+            repository: "repo-b",
+            name: "logging",
+            version: "1.2.3",
+            format: "swift",
+            slug_perm: "logging-1.2.3",
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "acme",
+      repository: "repo-b",
+      dependency: {
+        name: "acme.logging",
+        version: "1.2.3",
+        format: "swift",
+        qualifiers: { scope: "acme" },
+      },
+    });
+
+    assert.match(requestedQuery, /name:logging/);
+    assert.strictEqual(result.present, false);
+    assert.strictEqual(result.absent, false);
+    assert.strictEqual(result.complete, false);
+  });
+
+  test("exact Swift lookup accepts a newly observed bare row only after proven absence", async () => {
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get() {
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "logging",
+            version: "1.2.3",
+            format: "swift",
+            slug_perm: "logging-1.2.3",
+          }]);
+        },
+      },
+    });
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: {
+        name: "acme.logging",
+        version: "1.2.3",
+        format: "swift",
+        qualifiers: { scope: "acme" },
+      },
+      baselineIdentities: new Set(),
+    });
+
+    assert.strictEqual(result.present, true);
+    assert.strictEqual(result.absent, false);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("exact Swift lookup accepts embedded dotted and slash scope evidence", async () => {
+    for (const candidateName of ["acme.logging", "acme/logging"]) {
+      const service = new UpstreamPullService({}, {
+        api: {
+          async get() {
+            return apiSuccess([{
+              namespace: "workspace",
+              repository: "repo-b",
+              name: candidateName,
+              version: "1.2.3",
+              format: "swift",
+              slug_perm: `logging-${candidateName.includes(".") ? "dot" : "slash"}`,
+            }]);
+          },
+        },
+      });
+
+      const result = await service._checkExactPackageAbsence({
+        workspace: "workspace",
+        repository: "repo-b",
+        dependency: {
+          name: "acme.logging",
+          version: "1.2.3",
+          format: "swift",
+          qualifiers: { scope: "acme" },
+        },
+      });
+
+      assert.strictEqual(result.present, true, candidateName);
+      assert.strictEqual(result.absent, false, candidateName);
+      assert.strictEqual(result.complete, true, candidateName);
+    }
   });
 
   test("exact presence normalizes NuGet versions and verifies Maven and Ruby artifact qualifiers", async () => {
@@ -570,6 +775,39 @@ suite("UpstreamPullService", () => {
     });
     assert.strictEqual(mavenImplicitClassifier.present, true);
 
+    const mavenDefaultJar = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "maven-demo-default",
+      identifiers: { group_id: "com.example", name: "demo" },
+      files: [{ filename: "demo-1.2.3.jar" }],
+    });
+    assert.strictEqual(mavenDefaultJar.present, true);
+
+    const mavenPomOnly = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "maven-demo-pom-only",
+      identifiers: { group_id: "com.example", name: "demo" },
+      files: [{ filename: "demo-1.2.3.pom" }],
+    });
+    assert.strictEqual(mavenPomOnly.present, false);
+    assert.strictEqual(mavenPomOnly.absent, true);
+
     const rubyMissingPlatform = await check({
       name: "native-gem",
       version: "1.0.0",
@@ -583,7 +821,24 @@ suite("UpstreamPullService", () => {
       format: "ruby",
       slug_perm: "ruby-native-gem",
     });
-    assert.strictEqual(rubyMissingPlatform.absent, true);
+    assert.strictEqual(rubyMissingPlatform.absent, false);
+    assert.strictEqual(rubyMissingPlatform.complete, false);
+
+    const rubyDefaultAgainstNative = await check({
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      slug_perm: "ruby-native-only",
+      architectures: [{ name: "arm64-darwin" }],
+    });
+    assert.strictEqual(rubyDefaultAgainstNative.present, false);
+    assert.strictEqual(rubyDefaultAgainstNative.absent, true);
 
     const rubyArchitectureArray = await check({
       name: "native-gem",
@@ -600,6 +855,52 @@ suite("UpstreamPullService", () => {
       architectures: [{ name: "x86_64-linux" }],
     });
     assert.strictEqual(rubyArchitectureArray.present, true);
+  });
+
+  test("exact absence fails closed when qualifier evidence is omitted from a plausible row", async () => {
+    async function check(dependency, candidate) {
+      const service = new UpstreamPullService({}, {
+        api: { async get() { return apiSuccess([candidate]); } },
+      });
+      return service._checkExactPackageAbsence({
+        workspace: "workspace",
+        repository: "repo-b",
+        dependency,
+      });
+    }
+
+    const maven = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "demo-1.2.3",
+      identifiers: { group_id: "com.example" },
+    });
+    assert.strictEqual(maven.complete, false);
+    assert.strictEqual(maven.absent, false);
+
+    const ruby = await check({
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      qualifiers: { platform: "x86_64-linux" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      slug_perm: "native-gem-1.0.0",
+    });
+    assert.strictEqual(ruby.complete, false);
+    assert.strictEqual(ruby.absent, false);
   });
 
   test("exact pull absence lookup fails closed on partial, error, and wrong-repository data", async () => {
@@ -630,6 +931,50 @@ suite("UpstreamPullService", () => {
           slug_perm: "target-package-1",
         }]),
       },
+      {
+        name: "malformed stable identifier",
+        response: apiSuccess([{
+          namespace: "workspace",
+          repository: "repo-b",
+          name: "target-package",
+          version: "1.0.0",
+          format: "npm",
+          slug_perm: "target-package\u202e",
+        }]),
+      },
+      {
+        name: "missing stable identifier",
+        response: apiSuccess([{
+          namespace: "workspace",
+          repository: "repo-b",
+          name: "target-package",
+          version: "1.0.0",
+          format: "npm",
+        }]),
+      },
+      {
+        name: "malformed consumed identifier evidence",
+        response: apiSuccess([{
+          namespace: "workspace",
+          repository: "repo-b",
+          name: "target-package",
+          version: "1.0.0",
+          format: "npm",
+          slug_perm: "target-package-1",
+          identifiers: { group_id: { hostile: true } },
+        }]),
+      },
+      {
+        name: "bidi-bearing primary identity",
+        response: apiSuccess([{
+          namespace: "workspace",
+          repository: "repo-b",
+          name: "target-package\u202e",
+          version: "1.0.0",
+          format: "npm",
+          slug_perm: "target-package-1",
+        }]),
+      },
     ];
 
     for (const testCase of cases) {
@@ -643,6 +988,47 @@ suite("UpstreamPullService", () => {
       });
       assert.strictEqual(result.absent, false, testCase.name);
       assert.strictEqual(result.complete, false, testCase.name);
+    }
+  });
+
+  test("exact pull lookup accepts only canonical package identifier aliases", async () => {
+    async function check(identifierFields) {
+      const service = new UpstreamPullService({}, {
+        api: {
+          async get() {
+            return apiSuccess([{
+              namespace: "workspace",
+              repository: "repo-b",
+              name: "target-package",
+              version: "1.0.0",
+              format: "npm",
+              ...identifierFields,
+            }]);
+          },
+        },
+      });
+      return service._checkExactPackageAbsence({
+        workspace: "workspace",
+        repository: "repo-b",
+        dependency: { name: "target-package", version: "1.0.0", format: "npm" },
+      });
+    }
+
+    for (const identifierFields of [
+      { packageIdentifier: "target-package-1" },
+      { slug_perm_raw: "target-package-1" },
+    ]) {
+      assert.strictEqual((await check(identifierFields)).present, true);
+    }
+    for (const identifierFields of [
+      { identifier: "target-package-1" },
+      { slug_perm: "unsafe/identifier" },
+      { slug_perm: "%252f" },
+      { slug_perm: "target-package-1", slug_perm_raw: "conflict" },
+    ]) {
+      const result = await check(identifierFields);
+      assert.strictEqual(result.present, false);
+      assert.strictEqual(result.complete, false);
     }
   });
 
@@ -1157,6 +1543,45 @@ suite("UpstreamPullService", () => {
     }
   });
 
+  test("scoped Swift execution emits exact-scope verification evidence", async () => {
+    let exactChecks = 0;
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async () => new Response(null, { status: 200 }),
+    });
+    const dependency = {
+      name: "acme.logging",
+      version: "1.2.3",
+      format: "swift",
+      qualifiers: { scope: "acme" },
+      cloudsmithStatus: "NOT_FOUND",
+    };
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: { pullableDependencies: [dependency], skippedDependencies: [] },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual([...result.verificationReceipts.entries()], [[
+      getDependencyArtifactKey(dependency),
+      { swiftScopeVerified: true },
+    ]]);
+  });
+
   test("successful registry trigger with permanent exact absence returns a non-cached error", async () => {
     let exactChecks = 0;
     let registryCalls = 0;
@@ -1444,7 +1869,7 @@ suite("UpstreamPullService", () => {
     assert.ok(prepared);
     assert.deepStrictEqual(
       prepared.plan.pullableDependencies.map(item => (
-        buildRegistryTriggerPlan("workspace", "repo", item).artifactRequest.url
+        buildRegistryTriggerPlan("workspace", "repo", item).request.url
       )),
       [
         "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-javadoc.jar",
@@ -1720,10 +2145,9 @@ suite("UpstreamPullService", () => {
     assert.deepStrictEqual(calls, [indexUrl, configUrl, artifactUrl]);
   });
 
-  test("pulls the Maven POM before the qualifier-selected artifact", async () => {
+  test("pulls only the qualifier-selected Maven artifact", async () => {
     const calls = [];
     let exactChecks = 0;
-    const pomUrl = "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3.pom";
     const jarUrl = "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-tests.jar";
     const service = new UpstreamPullService({}, {
       credentialManager: { async getApiKey() { return "api-key"; } },
@@ -1740,7 +2164,6 @@ suite("UpstreamPullService", () => {
       },
       fetchImpl: async (url) => {
         calls.push(url);
-        if (url === pomUrl) return createResponse(200, "<project />");
         if (url === jarUrl) return createResponse(200, "artifact");
         throw new Error(`Unexpected URL: ${url}`);
       },
@@ -1763,13 +2186,14 @@ suite("UpstreamPullService", () => {
 
     assert.strictEqual(result.pullResult.cached, 1);
     assert.strictEqual(exactChecks, 2);
-    assert.deepStrictEqual(calls, [pomUrl, jarUrl]);
+    assert.deepStrictEqual(calls, [jarUrl]);
   });
 
   test("pulls a Docker platform manifest and every referenced image blob", async () => {
     const calls = [];
     const requestTimeouts = [];
     let exactChecks = 0;
+    const platformReceipts = [];
     const manifestDigest = `sha256:${"a".repeat(64)}`;
     const configDigest = `sha256:${"b".repeat(64)}`;
     const layerDigest = `sha256:${"c".repeat(64)}`;
@@ -1780,8 +2204,9 @@ suite("UpstreamPullService", () => {
     const layerUrl = `${baseUrl}/blobs/${encodeURIComponent(layerDigest)}`;
     const service = new UpstreamPullService({}, {
       credentialManager: { async getApiKey() { return "api-key"; } },
-      checkPackageAbsence: async ({ workspace, repository }) => {
+      checkPackageAbsence: async ({ workspace, repository, dockerPlatformVerified }) => {
         exactChecks += 1;
+        platformReceipts.push(dockerPlatformVerified === true);
         return {
           workspace,
           repository,
@@ -1827,6 +2252,7 @@ suite("UpstreamPullService", () => {
           name: "redis",
           version: "7.2",
           format: "docker",
+          qualifiers: { tag: "7.2", platform: "linux/amd64" },
           cloudsmithStatus: "NOT_FOUND",
         }],
         skippedDependencies: [],
@@ -1835,6 +2261,10 @@ suite("UpstreamPullService", () => {
 
     assert.strictEqual(result.pullResult.cached, 1);
     assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(platformReceipts, [false, true]);
+    assert.deepStrictEqual([...result.verificationReceipts.values()], [{
+      dockerPlatformVerified: true,
+    }]);
     assert.deepStrictEqual(calls, [tagUrl, manifestUrl, configUrl, layerUrl]);
     assert.deepStrictEqual(requestTimeouts, [30000, 30000, 120000, 120000]);
   });
@@ -1986,6 +2416,7 @@ suite("UpstreamPullService", () => {
         calls.push({ url, authorization: options.headers.Authorization });
         if (url === metadataUrl) {
           return createResponse(200, JSON.stringify({
+            name: "collection",
             versions: [{ version: "1.19.0", archive_url: archiveUrl }],
           }));
         }

--- a/test/upstreamPullService.test.js
+++ b/test/upstreamPullService.test.js
@@ -175,6 +175,10 @@ suite("UpstreamPullService", () => {
       mavenPlan.request.url,
       "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo-app/1.2.3/demo-app-1.2.3.pom"
     );
+    assert.strictEqual(
+      mavenPlan.artifactRequest.url,
+      "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo-app/1.2.3/demo-app-1.2.3.jar"
+    );
 
     const npmPlan = buildRegistryTriggerPlan("workspace", "repo", {
       name: "@scope/widget",
@@ -183,7 +187,7 @@ suite("UpstreamPullService", () => {
     });
     assert.strictEqual(
       npmPlan.request.url,
-      "https://npm.cloudsmith.io/workspace/repo/%40scope/widget/-/widget-4.5.6.tgz"
+      "https://npm.cloudsmith.io/workspace/repo/%40scope%2Fwidget/4.5.6"
     );
 
     const goPlan = buildRegistryTriggerPlan("workspace", "repo", {
@@ -193,7 +197,7 @@ suite("UpstreamPullService", () => {
     });
     assert.strictEqual(
       goPlan.request.url,
-      "https://golang.cloudsmith.io/workspace/repo/github.com/!my!org/!my!module/@v/v1.0.0.info"
+      "https://golang.cloudsmith.io/workspace/repo/github.com/!my!org/!my!module/@v/v1.0.0.zip"
     );
 
     const cargoPlan = buildRegistryTriggerPlan("workspace", "repo", {
@@ -340,6 +344,262 @@ suite("UpstreamPullService", () => {
       complete: true,
       stale: false,
     });
+  });
+
+  test("exact pull presence lookup preserves scoped npm slash identity", async () => {
+    let requestedQuery = "";
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get(endpoint) {
+          requestedQuery = new URL(endpoint, "https://api.cloudsmith.io")
+            .searchParams.get("query");
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "@aws-sdk/client-s3",
+            version: "3.600.0",
+            format: "npm",
+            slug_perm: "node-8-9-2",
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: { name: "@aws-sdk/client-s3", version: "3.600.0", format: "npm" },
+    });
+
+    assert.match(requestedQuery, /name:@aws-sdk\/client-s3/);
+    assert.doesNotMatch(requestedQuery, /@aws\\-sdk|client\\-s3|@aws-sdk\\\/client-s3/);
+    assert.strictEqual(result.present, true);
+    assert.strictEqual(result.absent, false);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("exact Docker presence matches the requested tag instead of the stored manifest digest", async () => {
+    let requestedQuery = "";
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get(endpoint) {
+          requestedQuery = new URL(endpoint, "https://api.cloudsmith.io")
+            .searchParams.get("query");
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "library/hello-world",
+            version: "a".repeat(64),
+            format: "docker",
+            slug_perm: "hello-world-linux",
+            tags: { version: ["linux"] },
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: { name: "hello-world", version: "linux", format: "docker" },
+    });
+
+    assert.match(requestedQuery, /name:hello-world/);
+    assert.doesNotMatch(requestedQuery, /version:linux/);
+    assert.strictEqual(result.present, true);
+    assert.strictEqual(result.absent, false);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("exact Docker digest presence cannot be satisfied by the same tag on another digest", async () => {
+    const service = new UpstreamPullService({}, {
+      api: {
+        async get() {
+          return apiSuccess([{
+            namespace: "workspace",
+            repository: "repo-b",
+            name: "library/example",
+            version: "b".repeat(64),
+            format: "docker",
+            slug_perm: "example-stable",
+            tags: { version: ["stable"] },
+          }]);
+        },
+      },
+    });
+
+    const result = await service._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: {
+        name: "example",
+        version: "stable",
+        format: "docker",
+        qualifiers: { tag: "stable", digest: `sha256:${"a".repeat(64)}` },
+      },
+    });
+
+    assert.strictEqual(result.present, false);
+    assert.strictEqual(result.absent, true);
+    assert.strictEqual(result.complete, true);
+  });
+
+  test("exact Docker presence requires the requested platform architecture", async () => {
+    const tagCandidate = {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "library/example",
+      version: "a".repeat(64),
+      format: "docker",
+      slug_perm: "example-stable",
+      tags: { version: ["stable"] },
+    };
+    const architectureCandidate = architecture => ({
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "library/example",
+      version: `${architecture}-${"b".repeat(48)}`,
+      format: "docker",
+      slug_perm: `example-${architecture}`,
+      architectures: [{ name: architecture }],
+      identifiers: { architecture, docker_platform_os: "linux" },
+    });
+    const check = async candidates => new UpstreamPullService({}, {
+      api: { async get() { return apiSuccess(candidates); } },
+    })._checkExactPackageAbsence({
+      workspace: "workspace",
+      repository: "repo-b",
+      dependency: {
+        name: "example",
+        version: "stable",
+        format: "docker",
+        qualifiers: { tag: "stable", platform: "linux/arm64" },
+      },
+    });
+
+    const wrongPlatform = await check([{
+      ...tagCandidate,
+      ...architectureCandidate("amd64"),
+      tags: tagCandidate.tags,
+    }]);
+    assert.strictEqual(wrongPlatform.absent, true);
+    const unrelatedPlatform = await check([tagCandidate, architectureCandidate("arm64")]);
+    assert.strictEqual(unrelatedPlatform.absent, true);
+    const exactPlatform = await check([{
+      ...tagCandidate,
+      ...architectureCandidate("arm64"),
+      tags: tagCandidate.tags,
+    }]);
+    assert.strictEqual(exactPlatform.present, true);
+  });
+
+  test("exact presence normalizes NuGet versions and verifies Maven and Ruby artifact qualifiers", async () => {
+    async function check(dependency, candidate) {
+      const service = new UpstreamPullService({}, {
+        api: { async get() { return apiSuccess([candidate]); } },
+      });
+      return service._checkExactPackageAbsence({
+        workspace: "workspace",
+        repository: "repo-b",
+        dependency,
+      });
+    }
+
+    const nuget = await check({
+      name: "Example.Package",
+      version: "01.02.003.0-BETA+build.7",
+      format: "nuget",
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "Example.Package",
+      version: "1.2.3-beta",
+      format: "nuget",
+      slug_perm: "nuget-example",
+    });
+    assert.strictEqual(nuget.present, true);
+
+    const mavenWrongClassifier = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "maven-demo",
+      identifiers: { group_id: "com.example", name: "demo" },
+      files: [{ filename: "demo-1.2.3.jar" }],
+    });
+    assert.strictEqual(mavenWrongClassifier.absent, true);
+
+    const mavenExactClassifier = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+      qualifiers: { type: "test-jar", classifier: "tests" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "maven-demo-tests",
+      identifiers: { group_id: "com.example", name: "demo" },
+      files: [{ filename: "demo-1.2.3-tests.jar" }],
+    });
+    assert.strictEqual(mavenExactClassifier.present, true);
+
+    const mavenImplicitClassifier = await check({
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+      qualifiers: { type: "test-jar" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "demo",
+      version: "1.2.3",
+      format: "maven",
+      slug_perm: "maven-demo-tests-implicit",
+      identifiers: { group_id: "com.example", name: "demo" },
+      files: [{ filename: "demo-1.2.3-tests.jar" }],
+    });
+    assert.strictEqual(mavenImplicitClassifier.present, true);
+
+    const rubyMissingPlatform = await check({
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      qualifiers: { platform: "x86_64-linux" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      slug_perm: "ruby-native-gem",
+    });
+    assert.strictEqual(rubyMissingPlatform.absent, true);
+
+    const rubyArchitectureArray = await check({
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      qualifiers: { platform: "x86_64-linux" },
+    }, {
+      namespace: "workspace",
+      repository: "repo-b",
+      name: "native-gem",
+      version: "1.0.0",
+      format: "ruby",
+      slug_perm: "ruby-native-gem-architecture-array",
+      architectures: [{ name: "x86_64-linux" }],
+    });
+    assert.strictEqual(rubyArchitectureArray.present, true);
   });
 
   test("exact pull absence lookup fails closed on partial, error, and wrong-repository data", async () => {
@@ -737,7 +997,7 @@ suite("UpstreamPullService", () => {
     }
   });
 
-  test("a package appearing after confirmation prevents every registry write", async () => {
+  test("a package appearing after confirmation becomes already-exists without a registry write", async () => {
     let absenceChecks = 0;
     let pullCalls = 0;
     const service = new UpstreamPullService({}, {
@@ -786,15 +1046,263 @@ suite("UpstreamPullService", () => {
 
     assert.strictEqual(absenceChecks, 2);
     assert.strictEqual(pullCalls, 0);
-    assert.deepStrictEqual(result, {
-      workspace: "workspace",
-      repository: { slug: "repo-b", name: "Repo B" },
-      plan: result.plan,
-      account: null,
-      repositorySearchComplete: true,
-      canceled: true,
-      absenceUnverified: true,
+    assert.strictEqual(result.canceled, false);
+    assert.strictEqual(result.pullResult.cached, 0);
+    assert.strictEqual(result.pullResult.alreadyExisted, 1);
+    assert.strictEqual(result.pullResult.details[0].status, "exists");
+  });
+
+  test("single-package execution preflight reports already-exists before credentials or registry access", async () => {
+    let credentialCalls = 0;
+    let registryCalls = 0;
+    const statuses = [];
+    const service = new UpstreamPullService({}, {
+      credentialManager: {
+        async getApiKey() {
+          credentialCalls += 1;
+          return "api-key";
+        },
+      },
+      checkPackageAbsence: async ({ workspace, repository }) => ({
+        workspace,
+        repository,
+        absent: false,
+        present: true,
+        complete: true,
+        stale: false,
+      }),
+      fetchImpl: async () => {
+        registryCalls += 1;
+        throw new Error("registry request must not run");
+      },
     });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "target-package",
+          version: "1.0.0",
+          format: "ruby",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    }, {
+      onStatus(detail) { statuses.push(detail.status); },
+    });
+
+    assert.strictEqual(result.canceled, false);
+    assert.strictEqual(result.pullResult.cached, 0);
+    assert.strictEqual(result.pullResult.alreadyExisted, 1);
+    assert.strictEqual(credentialCalls, 0);
+    assert.strictEqual(registryCalls, 0);
+    assert.deepStrictEqual(statuses, ["exists"]);
+  });
+
+  test("2xx, 304, and 409 registry responses wait for delayed exact presence before cached", async () => {
+    for (const statusCode of [200, 204, 304, 409]) {
+      let exactChecks = 0;
+      let registryCalls = 0;
+      const delays = [];
+      const statuses = [];
+      const service = new UpstreamPullService({}, {
+        credentialManager: { async getApiKey() { return "api-key"; } },
+        checkPackageAbsence: async ({ workspace, repository }) => {
+          exactChecks += 1;
+          if (exactChecks < 3) {
+            assert.strictEqual(statuses.includes("cached"), false, String(statusCode));
+          }
+          return {
+            workspace,
+            repository,
+            absent: exactChecks < 3,
+            present: exactChecks >= 3,
+            complete: true,
+            stale: false,
+          };
+        },
+        postTriggerPollDelaysMs: [0, 17],
+        postTriggerDelay: async delayMs => { delays.push(delayMs); },
+        fetchImpl: async () => {
+          registryCalls += 1;
+          return new Response(null, { status: statusCode });
+        },
+      });
+
+      const result = await service.execute({
+        workspace: "workspace",
+        repository: { slug: "repo" },
+        plan: {
+          pullableDependencies: [{
+            name: "target-package",
+            version: "1.0.0",
+            format: "ruby",
+            cloudsmithStatus: "NOT_FOUND",
+          }],
+          skippedDependencies: [],
+        },
+      }, {
+        onStatus(detail) { statuses.push(detail.status); },
+      });
+
+      assert.strictEqual(result.canceled, false, String(statusCode));
+      assert.strictEqual(result.pullResult.cached, 1, String(statusCode));
+      assert.strictEqual(result.pullResult.alreadyExisted, 0, String(statusCode));
+      assert.strictEqual(exactChecks, 3, String(statusCode));
+      assert.strictEqual(registryCalls, 1, String(statusCode));
+      assert.deepStrictEqual(delays, [17], String(statusCode));
+      assert.deepStrictEqual(statuses, ["pulling", "cached"], String(statusCode));
+    }
+  });
+
+  test("successful registry trigger with permanent exact absence returns a non-cached error", async () => {
+    let exactChecks = 0;
+    let registryCalls = 0;
+    const delays = [];
+    const statuses = [];
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: true,
+          present: false,
+          complete: true,
+          stale: false,
+        };
+      },
+      postTriggerPollDelaysMs: [0, 5, 10],
+      postTriggerDelay: async delayMs => { delays.push(delayMs); },
+      fetchImpl: async () => {
+        registryCalls += 1;
+        return createResponse(200, "");
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "target-package",
+          version: "1.0.0",
+          format: "ruby",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    }, {
+      onStatus(detail) { statuses.push(detail.status); },
+    });
+
+    assert.strictEqual(result.canceled, false);
+    assert.strictEqual(result.pullResult.cached, 0);
+    assert.strictEqual(result.pullResult.alreadyExisted, 0);
+    assert.strictEqual(result.pullResult.errors, 1);
+    assert.match(result.pullResult.details[0].errorMessage, /did not confirm the package/i);
+    assert.strictEqual(exactChecks, 4);
+    assert.strictEqual(registryCalls, 1);
+    assert.deepStrictEqual(delays, [5, 10]);
+    assert.deepStrictEqual(statuses, ["pulling", "error"]);
+  });
+
+  test("post-trigger polling cancellation cannot publish stale cached success", async () => {
+    const token = cancellationToken();
+    let exactChecks = 0;
+    const statuses = [];
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: true,
+          present: false,
+          complete: true,
+          stale: false,
+        };
+      },
+      postTriggerPollDelaysMs: [0, 1],
+      postTriggerDelay: async () => { token.cancel(); },
+      fetchImpl: async () => createResponse(200, ""),
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "target-package",
+          version: "1.0.0",
+          format: "ruby",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    }, {
+      token,
+      onStatus(detail) { statuses.push(detail.status); },
+    });
+
+    assert.deepStrictEqual(result, { canceled: true });
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(statuses, ["pulling"]);
+  });
+
+  test("post-trigger polling account supersession cannot publish stale cached success", async () => {
+    let accountState = {
+      activationId: "account-a",
+      accountEpoch: 1,
+      sessionConnected: true,
+    };
+    let exactChecks = 0;
+    const statuses = [];
+    const service = new UpstreamPullService({}, {
+      connectionManager: { getState() { return { ...accountState }; } },
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: true,
+          present: false,
+          complete: true,
+          stale: false,
+        };
+      },
+      postTriggerPollDelaysMs: [0, 1],
+      postTriggerDelay: async () => {
+        accountState = { ...accountState, activationId: "account-b", accountEpoch: 2 };
+      },
+      fetchImpl: async () => createResponse(200, ""),
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      account: { activationId: "account-a", accountEpoch: 1 },
+      plan: {
+        pullableDependencies: [{
+          name: "target-package",
+          version: "1.0.0",
+          format: "ruby",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    }, {
+      onStatus(detail) { statuses.push(detail.status); },
+    });
+
+    assert.deepStrictEqual(result, { canceled: true, stale: true });
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(statuses, ["pulling"]);
   });
 
   test("prepare builds a mixed-ecosystem confirmation with skipped formats", async () => {
@@ -897,8 +1405,57 @@ suite("UpstreamPullService", () => {
     );
   });
 
+  test("prepare preserves same-version pull targets with distinct artifact qualifiers", async () => {
+    const service = new UpstreamPullService({}, {
+      fetchRepositories: async () => ({
+        items: [{ slug: "repo", name: "Repo" }],
+        complete: true,
+      }),
+      upstreamRuntime: {
+        async getRepositoryUpstreamStateForFormats() {
+          return completeRepositoryState({
+            maven: [safeUpstream("maven", "maven", { is_active: true })],
+          });
+        },
+      },
+      showQuickPick: async items => items[0],
+      showWarningMessage: async (_message, _options, action) => action,
+    });
+    const dependency = {
+      name: "com.example:demo",
+      version: "1.2.3",
+      format: "maven",
+      cloudsmithStatus: "ABSENT",
+    };
+
+    const prepared = await service.prepare({
+      workspace: "workspace",
+      repositoryHint: "repo",
+      dependencies: [
+        { ...dependency, qualifiers: { type: "jar", classifier: "javadoc" } },
+        { ...dependency, qualifiers: { type: "jar", classifier: "javadoc", scope: "test" } },
+        { ...dependency, qualifiers: { type: "javadoc" } },
+        { ...dependency, qualifiers: { type: "test-jar" } },
+        { ...dependency, qualifiers: { type: "test-jar", scope: "runtime" } },
+        { ...dependency, qualifiers: { type: "jar", classifier: "tests" } },
+      ],
+    });
+
+    assert.ok(prepared);
+    assert.deepStrictEqual(
+      prepared.plan.pullableDependencies.map(item => (
+        buildRegistryTriggerPlan("workspace", "repo", item).artifactRequest.url
+      )),
+      [
+        "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-javadoc.jar",
+        "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-tests.jar",
+      ]
+    );
+  });
+
   test("pulls Python dependencies via same-host redirects using manual auth-preserving requests", async () => {
     const calls = [];
+    let exactChecks = 0;
     const initialIndexUrl = "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/requests/";
     const redirectedIndexUrl = "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/requests/index.html";
     const artifactUrl = "https://dl.cloudsmith.io/basic/workspace/repo/python/packages/requests-2.31.0-py3-none-any.whl";
@@ -908,6 +1465,17 @@ suite("UpstreamPullService", () => {
         async getApiKey() {
           return "api-key";
         },
+      },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
       },
       fetchImpl: async (url, options) => {
         calls.push({ url, options });
@@ -945,6 +1513,7 @@ suite("UpstreamPullService", () => {
 
     assert.strictEqual(result.canceled, false);
     assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
     assert.strictEqual(calls.length, 3);
     assert.deepStrictEqual(
       calls.map((call) => call.url),
@@ -955,6 +1524,357 @@ suite("UpstreamPullService", () => {
       calls.every((call) => call.options.headers.Authorization === authorizationHeader),
       true
     );
+  });
+
+  test("pulls an exact scoped npm prerelease through its packument tarball", async () => {
+    const calls = [];
+    let exactChecks = 0;
+    const packumentUrl = "https://npm.cloudsmith.io/workspace/repo/%40scope%2Fwidget-name/1.2.3-beta.1";
+    const tarballUrl = "https://npm.cloudsmith.io/workspace/repo/@scope/widget-name/-/content-addressed.tgz";
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === packumentUrl) {
+          return createResponse(200, JSON.stringify({
+            name: "@scope/widget-name",
+            version: "1.2.3-beta.1",
+            dist: { tarball: tarballUrl },
+          }));
+        }
+        if (url === tarballUrl) return createResponse(200, "artifact");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "@scope/widget-name",
+          version: "1.2.3-beta.1",
+          format: "npm",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(calls, [packumentUrl, tarballUrl]);
+  });
+
+  test("maps npm packument 404 and 401/403 without attempting a tarball", async () => {
+    for (const [statusCode, expectedStatus] of [[404, "not_found"], [401, "auth_failed"], [403, "auth_failed"]]) {
+      let registryCalls = 0;
+      const service = new UpstreamPullService({}, {
+        credentialManager: { async getApiKey() { return "api-key"; } },
+        fetchImpl: async () => {
+          registryCalls += 1;
+          return createResponse(statusCode, "");
+        },
+        showErrorMessage: async () => {},
+      });
+
+      const result = await service.execute({
+        workspace: "workspace",
+        repository: { slug: "repo" },
+        plan: {
+          pullableDependencies: [{
+            name: "package-with-hyphens",
+            version: "1.2.3",
+            format: "npm",
+            cloudsmithStatus: "NOT_FOUND",
+          }],
+          skippedDependencies: [],
+        },
+      });
+
+      assert.strictEqual(result.pullResult.details[0].status, expectedStatus, String(statusCode));
+      assert.strictEqual(result.pullResult.cached, 0, String(statusCode));
+      assert.strictEqual(registryCalls, 1, String(statusCode));
+    }
+  });
+
+  test("pulls an exact NuGet package through its advertised v3 package base", async () => {
+    const calls = [];
+    let exactChecks = 0;
+    const indexUrl = "https://nuget.cloudsmith.io/workspace/repo/v3/index.json";
+    const packageBase = "https://nuget.cloudsmith.io/workspace/repo/v3/flat/";
+    const packageUrl = `${packageBase}serilog/3.1.1/serilog.3.1.1.nupkg`;
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === indexUrl) {
+          return createResponse(200, JSON.stringify({
+            resources: [{
+              "@id": packageBase,
+              "@type": "PackageBaseAddress/3.0.0",
+            }],
+          }));
+        }
+        if (url === packageUrl) return createResponse(200, "package");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "Serilog",
+          version: "3.1.1",
+          format: "nuget",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(calls, [indexUrl, packageUrl]);
+  });
+
+  test("pulls an exact Cargo crate through sparse index and config metadata", async () => {
+    const calls = [];
+    let exactChecks = 0;
+    const checksum = "a".repeat(64);
+    const indexUrl = "https://cargo.cloudsmith.io/workspace/repo/se/rd/serde";
+    const configUrl = "https://cargo.cloudsmith.io/workspace/repo/config.json";
+    const artifactUrl = `https://cargo.cloudsmith.io/workspace/repo/api/v1/crates/serde/1.0.200/${checksum}/download`;
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === indexUrl) {
+          return createResponse(200, JSON.stringify({
+            name: "serde",
+            vers: "1.0.200",
+            cksum: checksum,
+          }));
+        }
+        if (url === configUrl) {
+          return createResponse(200, JSON.stringify({
+            dl: "https://cargo.cloudsmith.io/workspace/repo/api/v1/crates/{crate}/{version}/{sha256-checksum}/download",
+          }));
+        }
+        if (url === artifactUrl) return createResponse(200, "artifact");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "serde",
+          version: "1.0.200",
+          format: "cargo",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(calls, [indexUrl, configUrl, artifactUrl]);
+  });
+
+  test("pulls the Maven POM before the qualifier-selected artifact", async () => {
+    const calls = [];
+    let exactChecks = 0;
+    const pomUrl = "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3.pom";
+    const jarUrl = "https://dl.cloudsmith.io/basic/workspace/repo/maven/com/example/demo/1.2.3/demo-1.2.3-tests.jar";
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === pomUrl) return createResponse(200, "<project />");
+        if (url === jarUrl) return createResponse(200, "artifact");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "com.example:demo",
+          version: "1.2.3",
+          format: "maven",
+          qualifiers: { type: "test-jar", classifier: "tests" },
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(calls, [pomUrl, jarUrl]);
+  });
+
+  test("pulls a Docker platform manifest and every referenced image blob", async () => {
+    const calls = [];
+    const requestTimeouts = [];
+    let exactChecks = 0;
+    const manifestDigest = `sha256:${"a".repeat(64)}`;
+    const configDigest = `sha256:${"b".repeat(64)}`;
+    const layerDigest = `sha256:${"c".repeat(64)}`;
+    const baseUrl = "https://docker.cloudsmith.io/v2/workspace/repo/library/redis";
+    const tagUrl = `${baseUrl}/manifests/7.2`;
+    const manifestUrl = `${baseUrl}/manifests/${encodeURIComponent(manifestDigest)}`;
+    const configUrl = `${baseUrl}/blobs/${encodeURIComponent(configDigest)}`;
+    const layerUrl = `${baseUrl}/blobs/${encodeURIComponent(layerDigest)}`;
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === tagUrl) {
+          return createResponse(200, JSON.stringify({
+            schemaVersion: 2,
+            manifests: [{
+              digest: manifestDigest,
+              platform: { os: "linux", architecture: "amd64" },
+            }],
+          }));
+        }
+        if (url === manifestUrl) {
+          return createResponse(200, JSON.stringify({
+            schemaVersion: 2,
+            config: { digest: configDigest },
+            layers: [{ digest: layerDigest }],
+          }));
+        }
+        if (url === configUrl || url === layerUrl) return createResponse(200, "blob");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+      setTimeout(_callback, delay) {
+        requestTimeouts.push(delay);
+        return {};
+      },
+      clearTimeout() {},
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "redis",
+          version: "7.2",
+          format: "docker",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.strictEqual(exactChecks, 2);
+    assert.deepStrictEqual(calls, [tagUrl, manifestUrl, configUrl, layerUrl]);
+    assert.deepStrictEqual(requestTimeouts, [30000, 30000, 120000, 120000]);
+  });
+
+  test("Docker blob redirects strip credentials before following safe storage URLs", async () => {
+    const calls = [];
+    const blobUrl = "https://docker.cloudsmith.io/v2/workspace/repo/library/demo/blobs/sha256%3Aabc";
+    const storageUrl = "https://distribution.cloudfront.net/object?signature=value";
+    const service = new UpstreamPullService({}, {
+      fetchImpl: async (url, options) => {
+        calls.push({ url, options });
+        return url === blobUrl
+          ? createResponse(307, "", { location: storageUrl })
+          : createResponse(200, "blob");
+      },
+    });
+
+    const result = await service._requestRegistry({
+      method: "GET",
+      url: blobUrl,
+      redirectPolicy: "docker-blob",
+      headers: {},
+    }, "api-key", null, { captureBody: false });
+
+    assert.strictEqual(result.statusCode, 200);
+    assert.strictEqual(calls.length, 2);
+    assert.match(calls[0].options.headers.Authorization, /^Basic /);
+    assert.strictEqual(calls[1].url, storageUrl);
+    assert.strictEqual(calls[1].options.headers.Authorization, undefined);
+
+    const ordinaryService = new UpstreamPullService({}, {
+      fetchImpl: async () => createResponse(307, "", { location: storageUrl }),
+    });
+    const rejected = await ordinaryService._requestRegistry({
+      method: "GET",
+      url: blobUrl,
+      headers: {},
+    }, "api-key", null, { captureBody: false });
+    assert.strictEqual(rejected.statusCode, 0);
+    assert.match(rejected.errorMessage, /redirect target was rejected/i);
   });
 
   test("rejects redirects to untrusted hosts before forwarding credentials", async () => {
@@ -1042,6 +1962,182 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(bodyReads, 2);
     assert.strictEqual(bodyCanceled, false);
     assert.strictEqual(textRead, false);
+  });
+
+  test("Dart registry metadata and archives use hosted Pub bearer authentication", async () => {
+    const calls = [];
+    let exactChecks = 0;
+    const metadataUrl = "https://dart.cloudsmith.io/workspace/repo/api/packages/collection";
+    const archiveUrl = "https://dart.cloudsmith.io/workspace/repo/packages/collection-1.19.0.tar.gz";
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => {
+        exactChecks += 1;
+        return {
+          workspace,
+          repository,
+          absent: exactChecks === 1,
+          present: exactChecks > 1,
+          complete: true,
+          stale: false,
+        };
+      },
+      fetchImpl: async (url, options) => {
+        calls.push({ url, authorization: options.headers.Authorization });
+        if (url === metadataUrl) {
+          return createResponse(200, JSON.stringify({
+            versions: [{ version: "1.19.0", archive_url: archiveUrl }],
+          }));
+        }
+        if (url === archiveUrl) return createResponse(200, "archive");
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+    });
+
+    const result = await service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "collection",
+          version: "1.19.0",
+          format: "dart",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    });
+
+    assert.strictEqual(result.pullResult.cached, 1);
+    assert.deepStrictEqual(calls, [
+      { url: metadataUrl, authorization: "Bearer api-key" },
+      { url: archiveUrl, authorization: "Bearer api-key" },
+    ]);
+  });
+
+  test("Go and platform-qualified Ruby pulls dispatch their exact native artifacts", async () => {
+    const cases = [
+      {
+        dependency: {
+          name: "github.com/MyOrg/MyModule",
+          version: "v1.2.3-RC1",
+          format: "go",
+          cloudsmithStatus: "NOT_FOUND",
+        },
+        expectedUrl: "https://golang.cloudsmith.io/workspace/repo/github.com/!my!org/!my!module/@v/v1.2.3-!r!c1.zip",
+      },
+      {
+        dependency: {
+          name: "nokogiri",
+          version: "1.16.5",
+          format: "ruby",
+          qualifiers: { platform: "x86_64-linux" },
+          cloudsmithStatus: "NOT_FOUND",
+        },
+        expectedUrl: "https://dl.cloudsmith.io/basic/workspace/repo/ruby/gems/nokogiri-1.16.5-x86_64-linux.gem",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const calls = [];
+      let exactChecks = 0;
+      const service = new UpstreamPullService({}, {
+        credentialManager: { async getApiKey() { return "api-key"; } },
+        checkPackageAbsence: async ({ workspace, repository }) => {
+          exactChecks += 1;
+          return {
+            workspace,
+            repository,
+            absent: exactChecks === 1,
+            present: exactChecks > 1,
+            complete: true,
+            stale: false,
+          };
+        },
+        fetchImpl: async (url, options) => {
+          calls.push({ url, authorization: options.headers.Authorization });
+          return createResponse(200, "artifact");
+        },
+      });
+      const result = await service.execute({
+        workspace: "workspace",
+        repository: { slug: "repo" },
+        plan: { pullableDependencies: [testCase.dependency], skippedDependencies: [] },
+      });
+
+      assert.strictEqual(result.pullResult.cached, 1);
+      assert.deepStrictEqual(calls, [{
+        url: testCase.expectedUrl,
+        authorization: `Basic ${Buffer.from("token:api-key").toString("base64")}`,
+      }]);
+    }
+  });
+
+  test("an external AbortSignal cancels in-flight registry metadata before artifact dispatch", async () => {
+    const controller = new AbortController();
+    let fetchCalls = 0;
+    let requestSignal = null;
+    let fetchStarted;
+    const started = new Promise(resolve => { fetchStarted = resolve; });
+    const service = new UpstreamPullService({}, {
+      credentialManager: { async getApiKey() { return "api-key"; } },
+      checkPackageAbsence: async ({ workspace, repository }) => ({
+        workspace,
+        repository,
+        absent: true,
+        present: false,
+        complete: true,
+        stale: false,
+      }),
+      fetchImpl: async (_url, options) => {
+        fetchCalls += 1;
+        requestSignal = options.signal;
+        fetchStarted();
+        return new Promise(() => {});
+      },
+    });
+
+    const pending = service.execute({
+      workspace: "workspace",
+      repository: { slug: "repo" },
+      plan: {
+        pullableDependencies: [{
+          name: "left-pad",
+          version: "1.3.0",
+          format: "npm",
+          cloudsmithStatus: "NOT_FOUND",
+        }],
+        skippedDependencies: [],
+      },
+    }, { signal: controller.signal });
+    await started;
+    controller.abort();
+    const result = await pending;
+
+    assert.strictEqual(result.canceled, true);
+    assert.strictEqual(fetchCalls, 1);
+    assert.strictEqual(requestSignal.aborted, true);
+  });
+
+  test("registry request timeouts are bounded and allow longer Docker blob transfers", async () => {
+    let scheduledDelay = null;
+    const service = new UpstreamPullService({}, {
+      fetchImpl: async () => createResponse(200, "blob"),
+      setTimeout(_callback, delay) {
+        scheduledDelay = delay;
+        return {};
+      },
+      clearTimeout() {},
+    });
+
+    const result = await service._requestRegistry({
+      method: "GET",
+      url: "https://docker.cloudsmith.io/v2/workspace/repo/library/example/blobs/sha256%3Aabc",
+      headers: {},
+    }, "api-key", null, { captureBody: false, timeoutMs: 10 * 60 * 1000 });
+
+    assert.strictEqual(result.statusCode, 200);
+    assert.strictEqual(scheduledDelay, 120000);
   });
 
   test("registry metadata bodies are bounded before retention", async () => {
@@ -1180,14 +2276,18 @@ suite("UpstreamPullService", () => {
     assert.strictEqual(readerCancelCalled, true);
   });
 
-  test("registry redirects cannot move credentials between allowed Cloudsmith hosts", async () => {
-    let calls = 0;
+  test("registry redirects preserve credentials only across trusted hosts in the same repository", async () => {
+    const calls = [];
+    const authorizationHeader = `Basic ${Buffer.from("token:api-key").toString("base64")}`;
     const service = new UpstreamPullService({}, {
-      fetchImpl: async () => {
-        calls += 1;
-        return createResponse(302, "", {
-          location: "https://npm.cloudsmith.io/workspace/repo/package.tgz",
-        });
+      fetchImpl: async (url, options) => {
+        calls.push({ url, options });
+        if (calls.length === 1) {
+          return createResponse(302, "", {
+            location: "https://npm.cloudsmith.io/workspace/repo/package.tgz?redirect=registry",
+          });
+        }
+        return createResponse(200, "metadata");
       },
     });
 
@@ -1197,9 +2297,33 @@ suite("UpstreamPullService", () => {
       headers: {},
     }, "api-key", null, { captureBody: true });
 
-    assert.strictEqual(result.statusCode, 0);
-    assert.match(result.errorMessage, /redirect target was rejected/i);
-    assert.strictEqual(calls, 1);
+    assert.strictEqual(result.statusCode, 200);
+    assert.strictEqual(result.body, "metadata");
+    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(calls[1].options.headers.Authorization, authorizationHeader);
+    assert.strictEqual(
+      calls[1].url,
+      "https://npm.cloudsmith.io/workspace/repo/package.tgz?redirect=registry"
+    );
+
+    let crossRepositoryCalls = 0;
+    const crossRepositoryService = new UpstreamPullService({}, {
+      fetchImpl: async () => {
+        crossRepositoryCalls += 1;
+        return createResponse(302, "", {
+          location: "https://npm.cloudsmith.io/workspace/other-repo/package.tgz",
+        });
+      },
+    });
+    const rejected = await crossRepositoryService._requestRegistry({
+      method: "GET",
+      url: "https://dl.cloudsmith.io/basic/workspace/repo/python/simple/artifact/",
+      headers: {},
+    }, "api-key", null, { captureBody: true });
+
+    assert.strictEqual(rejected.statusCode, 0);
+    assert.match(rejected.errorMessage, /redirect target was rejected/i);
+    assert.strictEqual(crossRepositoryCalls, 1);
   });
 
   test("stops after three authentication failures before expanding concurrency", async () => {

--- a/util/dependencyAdapterRegistry.js
+++ b/util/dependencyAdapterRegistry.js
@@ -76,6 +76,39 @@ const DEPENDENCY_FILE_ADAPTER_ERROR_CODES = Object.freeze({
 });
 const MAX_STRUCTURAL_GRAPH_ENTRIES = 50000;
 const MAX_STRUCTURAL_GRAPH_EDGES = 500000;
+const SAFE_DOCKER_ADAPTER_WARNINGS = new Map([
+  [
+    "a dockerfile target platform could not be resolved, so dependency results are partial.",
+    "A Dockerfile target platform could not be resolved; affected dependencies remain incomplete.",
+  ],
+  [
+    "a compose image reference could not be resolved, so dependency results are partial.",
+    "A Compose image reference could not be resolved; affected dependencies were omitted.",
+  ],
+  [
+    "a compose image platform could not be resolved, so dependency results are partial.",
+    "A Compose image platform could not be resolved; affected dependencies remain incomplete.",
+  ],
+  [
+    "a compose image platform was invalid and could not be checked.",
+    "A Compose image platform was invalid; affected dependencies remain incomplete.",
+  ],
+  [
+    "a compose pull policy could not be resolved, so dependency results are partial.",
+    "A Compose pull policy could not be resolved; affected services were omitted.",
+  ],
+  [
+    "a compose service requests a local build but has no usable build definition.",
+    "A Compose service requested a local build without a usable build definition.",
+  ],
+  [
+    "a compose image reference was invalid and could not be checked.",
+    "A Compose image reference was invalid; affected dependencies were omitted.",
+  ],
+]);
+for (const safeWarning of SAFE_DOCKER_ADAPTER_WARNINGS.values()) {
+  SAFE_DOCKER_ADAPTER_WARNINGS.set(safeWarning.toLowerCase(), safeWarning);
+}
 
 const RESOLUTION_AVAILABILITY = Object.freeze({
   AVAILABLE: "available",
@@ -1155,6 +1188,9 @@ function createAdapterResult(values) {
 
 function createSafeAdapterWarning(warning) {
   const normalized = boundedAdapterText(String(warning || ""), "warning").toLowerCase();
+  if (SAFE_DOCKER_ADAPTER_WARNINGS.has(normalized)) {
+    return SAFE_DOCKER_ADAPTER_WARNINGS.get(normalized);
+  }
   if (normalized.includes("display is capped") || normalized.includes("display reached")) {
     return "Dependency display reached its configured safety limit.";
   }

--- a/util/dependencyRecord.js
+++ b/util/dependencyRecord.js
@@ -363,12 +363,14 @@ function getDependencyArtifactKey(dependency) {
     artifactQualifiers.platform = qualifiers.platform;
   }
   if (format === "maven") {
-    if (qualifiers.type) artifactQualifiers.type = qualifiers.type;
-    if (qualifiers.classifier) artifactQualifiers.classifier = qualifiers.classifier;
+    const mavenArtifact = normalizeMavenArtifactIdentity(qualifiers);
+    artifactQualifiers.extension = mavenArtifact.extension;
+    if (mavenArtifact.classifier) artifactQualifiers.classifier = mavenArtifact.classifier;
   }
   if (format === "docker") {
     if (qualifiers.tag) artifactQualifiers.tag = qualifiers.tag;
     if (qualifiers.digest) artifactQualifiers.digest = qualifiers.digest;
+    if (qualifiers.platform) artifactQualifiers.platform = qualifiers.platform;
   }
   return JSON.stringify([
     format,
@@ -376,6 +378,31 @@ function getDependencyArtifactKey(dependency) {
     getDependencyConcreteVersion(dependency) || "",
     artifactQualifiers,
   ]);
+}
+
+function normalizeMavenArtifactIdentity(qualifiers) {
+  const type = String(qualifiers?.type || "jar").trim().toLowerCase();
+  const extension = [
+    "bundle",
+    "ejb",
+    "ejb-client",
+    "java-source",
+    "javadoc",
+    "maven-plugin",
+    "test-jar",
+  ].includes(type) ? "jar" : type;
+  const implicitClassifiers = {
+    "ejb-client": "client",
+    "java-source": "sources",
+    javadoc: "javadoc",
+    "test-jar": "tests",
+  };
+  return {
+    extension,
+    classifier: String(
+      qualifiers?.classifier || implicitClassifiers[type] || ""
+    ).trim(),
+  };
 }
 
 function getDependencyConcreteVersion(dependency) {

--- a/util/dependencyRecord.js
+++ b/util/dependencyRecord.js
@@ -3,6 +3,8 @@ const path = require("path");
 const { URL, pathToFileURL } = require("url");
 const {
   canonicalFormat,
+  normalizeDockerPlatformIdentity,
+  normalizeNuGetVersion,
   normalizePackageName,
   normalizeSwiftIdentity,
   sanitizePackageNameInput,
@@ -359,8 +361,8 @@ function getDependencyArtifactKey(dependency) {
     ? normalizeSwiftIdentity(dependency && dependency.name, qualifiers.scope)
     : String(dependency && (dependency.normalizedName || dependency.name) || "");
   const artifactQualifiers = {};
-  if (format === "ruby" && qualifiers.platform) {
-    artifactQualifiers.platform = qualifiers.platform;
+  if (format === "ruby") {
+    artifactQualifiers.platform = String(qualifiers.platform || "ruby").toLowerCase();
   }
   if (format === "maven") {
     const mavenArtifact = normalizeMavenArtifactIdentity(qualifiers);
@@ -369,13 +371,17 @@ function getDependencyArtifactKey(dependency) {
   }
   if (format === "docker") {
     if (qualifiers.tag) artifactQualifiers.tag = qualifiers.tag;
-    if (qualifiers.digest) artifactQualifiers.digest = qualifiers.digest;
-    if (qualifiers.platform) artifactQualifiers.platform = qualifiers.platform;
+    if (qualifiers.digest) artifactQualifiers.digest = String(qualifiers.digest).toLowerCase();
+    if (qualifiers.platform) {
+      artifactQualifiers.platform = normalizeDockerPlatformIdentity(qualifiers.platform)
+        || qualifiers.platform;
+    }
   }
+  const concreteVersion = getDependencyConcreteVersion(dependency) || "";
   return JSON.stringify([
     format,
     caseSensitive ? identityName : identityName.toLowerCase(),
-    getDependencyConcreteVersion(dependency) || "",
+    format === "nuget" ? normalizeNuGetVersion(concreteVersion) || concreteVersion : concreteVersion,
     artifactQualifiers,
   ]);
 }

--- a/util/exactPackageEvidence.js
+++ b/util/exactPackageEvidence.js
@@ -1,0 +1,130 @@
+// Copyright 2026 Cloudsmith Ltd. All rights reserved.
+
+function isPlainRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isBoundedEvidenceString(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= 4096
+    && value.trim() === value
+    && !/[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u.test(value);
+}
+
+function optionalEvidenceStringIsValid(value) {
+  return value == null || value === "" || isBoundedEvidenceString(value);
+}
+
+function packageCandidateEvidenceShapeIsValid(candidate) {
+  if (!isPlainRecord(candidate)) return false;
+  const identifiers = candidate.identifiers;
+  if (identifiers != null && !isPlainRecord(identifiers)) return false;
+  for (const value of [
+    candidate.packageIdentifier,
+    candidate.slug_perm,
+    candidate.slug_perm_raw,
+    candidate.scope,
+    candidate.architecture,
+    candidate.platform,
+    candidate.platform_os,
+    candidate.os,
+    candidate.variant,
+    identifiers && identifiers.group_id,
+    identifiers && identifiers.scope,
+    identifiers && identifiers.architecture,
+    identifiers && identifiers.platform,
+    identifiers && identifiers.docker_platform_os,
+    identifiers && identifiers.docker_platform_variant,
+  ]) {
+    if (!optionalEvidenceStringIsValid(value)) return false;
+  }
+  const tags = candidate.tags;
+  if (tags != null) {
+    if (!isPlainRecord(tags)) return false;
+    if (
+      tags.version != null
+      && (!Array.isArray(tags.version)
+        || tags.version.length > 256
+        || tags.version.some(tag => !isBoundedEvidenceString(tag)))
+    ) {
+      return false;
+    }
+  }
+  if (
+    candidate.architectures != null
+    && (!Array.isArray(candidate.architectures)
+      || candidate.architectures.length > 256
+      || candidate.architectures.some(architecture => {
+        if (typeof architecture === "string") return !isBoundedEvidenceString(architecture);
+        if (!isPlainRecord(architecture)) return true;
+        const values = [architecture.name, architecture.slug, architecture.identifier]
+          .filter(value => value != null);
+        return values.length === 0 || values.some(value => !isBoundedEvidenceString(value));
+      }))
+  ) {
+    return false;
+  }
+  if (
+    candidate.files != null
+    && (!Array.isArray(candidate.files)
+      || candidate.files.length > 1024
+      || candidate.files.some(file => {
+        if (!isPlainRecord(file)) return true;
+        const values = [file.filename, file.name, file.path].filter(value => value != null);
+        return values.length === 0 || values.some(value => !isBoundedEvidenceString(value));
+      }))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function qualifierEvidenceIsIncomplete(candidate, dependency, format) {
+  const qualifiers = dependency && dependency.qualifiers;
+  const safeQualifiers = qualifiers && typeof qualifiers === "object" && !Array.isArray(qualifiers)
+    ? qualifiers
+    : {};
+  if (format === "maven") {
+    return !Array.isArray(candidate && candidate.files);
+  }
+  if (format === "ruby" && String(safeQualifiers.platform || "").trim()) {
+    const identifiers = isPlainRecord(candidate && candidate.identifiers)
+      ? candidate.identifiers
+      : {};
+    return ![
+      candidate && candidate.architectures,
+      candidate && candidate.architecture,
+      candidate && candidate.platform,
+      identifiers.architecture,
+      identifiers.platform,
+    ].some(value => value != null);
+  }
+  if (format === "swift" && String(safeQualifiers.scope || "").trim()) {
+    const scope = String(safeQualifiers.scope).trim().toLowerCase();
+    const identifiers = isPlainRecord(candidate && candidate.identifiers)
+      ? candidate.identifiers
+      : {};
+    const observedScope = String(candidate && (candidate.scope || identifiers.scope) || "")
+      .trim()
+      .toLowerCase();
+    const observedName = String(candidate && candidate.name || "").trim().toLowerCase();
+    return !observedScope
+      && !observedName.startsWith(`${scope}.`)
+      && !observedName.startsWith(`${scope}/`);
+  }
+  if (format === "docker") {
+    const requestedDigest = String(
+      safeQualifiers.digest || dependency && dependency.digest || ""
+    ).trim();
+    return !requestedDigest && !isPlainRecord(candidate && candidate.tags);
+  }
+  return false;
+}
+
+module.exports = {
+  packageCandidateEvidenceShapeIsValid,
+  qualifierEvidenceIsIncomplete,
+};

--- a/util/licenseClassifier.js
+++ b/util/licenseClassifier.js
@@ -2,6 +2,21 @@
 // Supports compound SPDX expressions and user-configurable restrictive overrides.
 
 const vscode = require("vscode");
+const {
+  escapeCloudsmithQueryValue,
+  isValidAdvancedQuery,
+} = require("./searchQueryBuilder");
+
+const MAX_QUERY_LICENSE_IDENTIFIERS = 64;
+const MAX_QUERY_LICENSE_IDENTIFIER_LENGTH = 256;
+const QUERY_CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u;
+
+function isSafeQueryLicenseIdentifier(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= MAX_QUERY_LICENSE_IDENTIFIER_LENGTH
+    && !QUERY_CONTROL_OR_BIDI_PATTERN.test(value);
+}
 
 function isExpressionWhitespace(character) {
   return character.trim() === "";
@@ -232,8 +247,7 @@ class LicenseClassifier {
    * @returns {string}
    */
   static _escapeQueryValue(value) {
-    const escaped = value.replace(/(\\|&&|\|\||[+\-!(){}\[\]^"~*?:/|&])/g, (match) => `\\${match}`);
-    return /\s/.test(escaped) ? `"${escaped}"` : escaped;
+    return escapeCloudsmithQueryValue(value);
   }
 
   /**
@@ -246,9 +260,9 @@ class LicenseClassifier {
       const config = vscode.workspace.getConfiguration("cloudsmith-vsc");
       const userList = config.get("restrictiveLicenses");
       if (Array.isArray(userList)) {
-        for (const lic of userList) {
+        for (const lic of userList.slice(0, MAX_QUERY_LICENSE_IDENTIFIERS)) {
           const normalized = LicenseClassifier._normalizeIdentifier(lic);
-          if (normalized) {
+          if (isSafeQueryLicenseIdentifier(normalized)) {
             overrides.add(normalized);
           }
         }
@@ -284,7 +298,11 @@ class LicenseClassifier {
     const seen = new Set();
     for (const identifier of identifiers) {
       const normalized = LicenseClassifier._normalizeIdentifier(identifier);
-      if (normalized && !seen.has(normalized)) {
+      if (
+        isSafeQueryLicenseIdentifier(normalized)
+        && !seen.has(normalized)
+        && uniqueIdentifiers.length < MAX_QUERY_LICENSE_IDENTIFIERS
+      ) {
         seen.add(normalized);
         uniqueIdentifiers.push(normalized);
       }
@@ -294,11 +312,15 @@ class LicenseClassifier {
       return "";
     }
 
-    const clauses = uniqueIdentifiers.map((identifier) => `license:${LicenseClassifier._escapeQueryValue(identifier)}`);
-    if (clauses.length === 1) {
-      return clauses[0];
+    const clauses = [];
+    for (const identifier of uniqueIdentifiers) {
+      const clause = `license:${LicenseClassifier._escapeQueryValue(identifier)}`;
+      const next = clauses.length === 0 ? clause : `(${[...clauses, clause].join(" OR ")})`;
+      if (!isValidAdvancedQuery(next)) break;
+      clauses.push(clause);
     }
-    return `(${clauses.join(" OR ")})`;
+    if (clauses.length === 0) return "";
+    return clauses.length === 1 ? clauses[0] : `(${clauses.join(" OR ")})`;
   }
 
   /**

--- a/util/lockfileParsers/dockerParser.js
+++ b/util/lockfileParsers/dockerParser.js
@@ -1,6 +1,7 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const path = require("path");
 const { DEPENDENCY_VERSION_STATES } = require("../dependencyRecord");
+const { isDockerDigest } = require("../registryEndpoints");
 const {
   buildTree,
   countIndent,
@@ -86,6 +87,7 @@ const dockerParser = {
 function parseDockerfile(content, sourceFile, cancellationToken) {
   const dependencies = [];
   const warnings = [];
+  const addWarningOnce = createWarningCollector(warnings);
   const stageAliases = new Set();
   const argDefaults = new Map();
   let stageIndex = 0;
@@ -123,7 +125,7 @@ function parseDockerfile(content, sourceFile, cancellationToken) {
     }
 
     if (parsed.platformUnresolved) {
-      warnings.push(
+      addWarningOnce(
         "A Dockerfile target platform could not be resolved, so dependency results are partial."
       );
     }
@@ -153,6 +155,7 @@ function parseDockerfile(content, sourceFile, cancellationToken) {
 function parseCompose(content, sourceFile, projectEnvironment = new Map(), cancellationToken) {
   const dependencies = [];
   const warnings = [];
+  const addWarningOnce = createWarningCollector(warnings);
   let servicesIndent = null;
   let serviceIndent = null;
   let currentService = null;
@@ -163,13 +166,13 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
     }
     const pullPolicy = interpolateComposeValue(currentService.pullPolicy, projectEnvironment);
     if (pullPolicy.unresolved) {
-      warnings.push("A Compose pull policy could not be resolved, so dependency results are partial.");
+      addWarningOnce("A Compose pull policy could not be resolved, so dependency results are partial.");
       currentService = null;
       return;
     }
     const normalizedPullPolicy = pullPolicy.value.toLowerCase();
     if (normalizedPullPolicy === "build" && !currentService.hasBuild) {
-      warnings.push("A Compose service requests a local build but has no usable build definition.");
+      addWarningOnce("A Compose service requests a local build but has no usable build definition.");
     }
     const shouldIncludeImage = currentService.image && normalizedPullPolicy !== "build";
     if (shouldIncludeImage) {
@@ -178,19 +181,32 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
         currentService.platform,
         projectEnvironment
       );
-      if (interpolated.unresolved || interpolatedPlatform.unresolved) {
-        warnings.push("A Compose image reference could not be resolved, so dependency results are partial.");
-        currentService = null;
-        return;
-      }
-      const platform = normalizeDockerPlatform(interpolatedPlatform.value);
-      if (interpolatedPlatform.value && !platform) {
-        warnings.push("A Compose image platform was invalid and could not be checked.");
+      if (interpolated.unresolved) {
+        addWarningOnce("A Compose image reference could not be resolved, so dependency results are partial.");
         currentService = null;
         return;
       }
       const parsed = parseDockerImageReference(interpolated.value);
-      if (parsed && parsed.name.toLowerCase() !== "scratch") {
+      if (!parsed) {
+        if (interpolated.value) {
+          addWarningOnce("A Compose image reference was invalid and could not be checked.");
+        }
+        currentService = null;
+        return;
+      }
+      let platform = "";
+      let platformUnresolved = false;
+      if (interpolatedPlatform.unresolved) {
+        platformUnresolved = true;
+        addWarningOnce("A Compose image platform could not be resolved, so dependency results are partial.");
+      } else {
+        platform = normalizeDockerPlatform(interpolatedPlatform.value);
+      }
+      if (!platformUnresolved && interpolatedPlatform.value && !platform) {
+        platformUnresolved = true;
+        addWarningOnce("A Compose image platform was invalid and could not be checked.");
+      }
+      if (parsed.name.toLowerCase() !== "scratch") {
         dependencies.push(withDockerResolutionEvidence(createDependency({
           name: parsed.name,
           version: parsed.version,
@@ -207,9 +223,7 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
           digest: parsed.digest,
           platform: platform || null,
           packageSource: { kind: "registry" },
-        }), parsed));
-      } else if (interpolated.value) {
-        warnings.push("A Compose image reference was invalid and could not be checked.");
+        }), { ...parsed, platformUnresolved }));
       }
     }
     currentService = null;
@@ -276,7 +290,16 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
   flushCurrentService();
   return {
     dependencies,
-    warnings: [...new Set(warnings)],
+    warnings,
+  };
+}
+
+function createWarningCollector(warnings) {
+  const emitted = new Set();
+  return (warning) => {
+    if (emitted.has(warning)) return;
+    emitted.add(warning);
+    warnings.push(warning);
   };
 }
 
@@ -473,7 +496,7 @@ function parseDockerImageReference(reference) {
   const digestSeparator = raw.indexOf("@");
   const withoutDigest = digestSeparator >= 0 ? raw.slice(0, digestSeparator) : raw;
   const digest = digestSeparator >= 0 ? raw.slice(digestSeparator + 1) : "";
-  if (digestSeparator >= 0 && (!digest || !/^[A-Za-z0-9_+.-]+:[A-Fa-f0-9]+$/.test(digest))) {
+  if (digestSeparator >= 0 && !isDockerDigest(digest)) {
     return null;
   }
   const lastSlash = withoutDigest.lastIndexOf("/");

--- a/util/lockfileParsers/dockerParser.js
+++ b/util/lockfileParsers/dockerParser.js
@@ -1,5 +1,6 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const path = require("path");
+const { DEPENDENCY_VERSION_STATES } = require("../dependencyRecord");
 const {
   buildTree,
   countIndent,
@@ -77,12 +78,14 @@ const dockerParser = {
       const parsed = parseCompose(content, sourceFile, projectEnvironment, cancellationToken);
       return buildTree("docker", sourceFile, parsed.dependencies, parsed.warnings);
     }
-    return buildTree("docker", sourceFile, parseDockerfile(content, sourceFile, cancellationToken));
+    const parsed = parseDockerfile(content, sourceFile, cancellationToken);
+    return buildTree("docker", sourceFile, parsed.dependencies, parsed.warnings);
   },
 };
 
 function parseDockerfile(content, sourceFile, cancellationToken) {
   const dependencies = [];
+  const warnings = [];
   const stageAliases = new Set();
   const argDefaults = new Map();
   let stageIndex = 0;
@@ -119,6 +122,12 @@ function parseDockerfile(content, sourceFile, cancellationToken) {
       continue;
     }
 
+    if (parsed.platformUnresolved) {
+      warnings.push(
+        "A Dockerfile target platform could not be resolved, so dependency results are partial."
+      );
+    }
+
     dependencies.push(withDockerResolutionEvidence(createDependency({
       name: parsed.name,
       version: parsed.version,
@@ -132,12 +141,13 @@ function parseDockerfile(content, sourceFile, cancellationToken) {
       tag: parsed.tag,
       digest: parsed.digest,
       stage: parsed.alias || `stage-${stageIndex + 1}`,
+      platform: parsed.platform || null,
       packageSource: { kind: "registry" },
     }), parsed));
     stageIndex += 1;
   }
 
-  return dependencies;
+  return { dependencies, warnings };
 }
 
 function parseCompose(content, sourceFile, projectEnvironment = new Map(), cancellationToken) {
@@ -164,8 +174,18 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
     const shouldIncludeImage = currentService.image && normalizedPullPolicy !== "build";
     if (shouldIncludeImage) {
       const interpolated = interpolateComposeValue(currentService.image, projectEnvironment);
-      if (interpolated.unresolved) {
+      const interpolatedPlatform = interpolateComposeValue(
+        currentService.platform,
+        projectEnvironment
+      );
+      if (interpolated.unresolved || interpolatedPlatform.unresolved) {
         warnings.push("A Compose image reference could not be resolved, so dependency results are partial.");
+        currentService = null;
+        return;
+      }
+      const platform = normalizeDockerPlatform(interpolatedPlatform.value);
+      if (interpolatedPlatform.value && !platform) {
+        warnings.push("A Compose image platform was invalid and could not be checked.");
         currentService = null;
         return;
       }
@@ -185,6 +205,7 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
           pullPolicy: normalizedPullPolicy || "default",
           tag: parsed.tag,
           digest: parsed.digest,
+          platform: platform || null,
           packageSource: { kind: "registry" },
         }), parsed));
       } else if (interpolated.value) {
@@ -225,6 +246,7 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
         indent,
         hasBuild: false,
         image: "",
+        platform: "",
         pullPolicy: "",
       };
       continue;
@@ -240,6 +262,10 @@ function parseCompose(content, sourceFile, projectEnvironment = new Map(), cance
     }
     if (cleaned.startsWith("image:")) {
       currentService.image = unquote(cleaned.slice("image:".length).trim());
+      continue;
+    }
+    if (cleaned.startsWith("platform:")) {
+      currentService.platform = unquote(cleaned.slice("platform:".length).trim());
       continue;
     }
     if (cleaned.startsWith("pull_policy:")) {
@@ -393,7 +419,17 @@ function interpolateComposeValue(input, environment) {
 function parseFromInstruction(line, argDefaults, stageAliases) {
   const parts = line.split(/\s+/).filter(Boolean);
   let index = 1;
+  let platform = "";
+  let platformUnresolved = false;
   while (parts[index] && parts[index].startsWith("--")) {
+    if (parts[index].toLowerCase().startsWith("--platform=")) {
+      const resolvedPlatform = resolveDockerArgs(
+        unquote(parts[index].slice("--platform=".length)),
+        argDefaults
+      );
+      platform = normalizeDockerPlatform(resolvedPlatform);
+      platformUnresolved = !platform || resolvedPlatform.includes("$");
+    }
     index += 1;
   }
   const imageToken = parts[index];
@@ -413,8 +449,20 @@ function parseFromInstruction(line, argDefaults, stageAliases) {
   return {
     ...parsed,
     alias: alias ? unquote(alias) : "",
+    platform,
+    platformUnresolved,
     isDependency: !stageReference && parsed.name.toLowerCase() !== "scratch",
   };
+}
+
+function normalizeDockerPlatform(value) {
+  const platform = String(value || "").trim().toLowerCase();
+  if (!platform) return "";
+  const parts = platform.split("/");
+  return (
+    (parts.length === 2 || parts.length === 3)
+    && parts.every(part => part && /^[a-z0-9_.-]+$/.test(part))
+  ) ? parts.join("/") : "";
 }
 
 function parseDockerImageReference(reference) {
@@ -447,11 +495,17 @@ function parseDockerImageReference(reference) {
 }
 
 function withDockerResolutionEvidence(dependency, parsed) {
+  const hasResolutionEvidence = Boolean(
+    parsed && parsed.hasResolutionEvidence && !parsed.platformUnresolved
+  );
   return {
     ...dependency,
-    hasResolutionEvidence: Boolean(parsed && parsed.hasResolutionEvidence),
-    resolvedVersion: parsed && parsed.hasResolutionEvidence ? parsed.version : null,
+    hasResolutionEvidence,
+    resolvedVersion: hasResolutionEvidence ? parsed.version : null,
     declaredConstraint: parsed && (parsed.tag || parsed.digest) || null,
+    ...(parsed?.platformUnresolved
+      ? { versionState: DEPENDENCY_VERSION_STATES.INCOMPLETE }
+      : {}),
   };
 }
 

--- a/util/lockfileParsers/shared.js
+++ b/util/lockfileParsers/shared.js
@@ -784,6 +784,7 @@ function dependencyKey(dependency) {
   if (ecosystem === "docker") {
     if (qualifiers.tag) artifactQualifiers.tag = qualifiers.tag;
     if (qualifiers.digest) artifactQualifiers.digest = qualifiers.digest;
+    if (qualifiers.platform) artifactQualifiers.platform = qualifiers.platform;
     if (qualifiers.service) artifactQualifiers.service = qualifiers.service;
     if (qualifiers.stage) artifactQualifiers.stage = qualifiers.stage;
     if (qualifiers.pullPolicy) artifactQualifiers.pullPolicy = qualifiers.pullPolicy;

--- a/util/packageNameNormalizer.js
+++ b/util/packageNameNormalizer.js
@@ -60,6 +60,44 @@ function normalizePackageName(name, ecosystemOrFormat) {
   return rawName.toLowerCase();
 }
 
+function normalizeNuGetVersion(version) {
+  const raw = String(version || "").trim();
+  if (!raw || /[\u0000-\u001f\u007f\\/?#]/.test(raw)) return "";
+  const withoutMetadata = raw.split("+", 1)[0];
+  const separatorIndex = withoutMetadata.indexOf("-");
+  const release = separatorIndex >= 0
+    ? withoutMetadata.slice(0, separatorIndex)
+    : withoutMetadata;
+  const prerelease = separatorIndex >= 0
+    ? withoutMetadata.slice(separatorIndex + 1)
+    : "";
+  const releaseParts = release.split(".");
+  if (
+    releaseParts.length < 1
+    || releaseParts.length > 4
+    || releaseParts.some(part => !/^\d+$/.test(part))
+    || (separatorIndex >= 0 && !/^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(prerelease))
+  ) return "";
+  const normalizedRelease = releaseParts.map(part => part.replace(/^0+(?=\d)/, ""));
+  while (normalizedRelease.length < 3) normalizedRelease.push("0");
+  if (normalizedRelease.length === 4 && normalizedRelease[3] === "0") {
+    normalizedRelease.pop();
+  }
+  return `${normalizedRelease.join(".")}${prerelease ? `-${prerelease.toLowerCase()}` : ""}`;
+}
+
+function normalizeDockerPlatformIdentity(platform) {
+  const parts = String(platform || "").trim().toLowerCase().split("/");
+  if (parts.length < 2 || parts.length > 3 || parts.some(part => !part)) return "";
+  const architecture = {
+    "x86-64": "amd64",
+    x86_64: "amd64",
+    aarch64: "arm64",
+  }[parts[1]] || parts[1];
+  const variant = architecture === "arm64" && parts[2] === "v8" ? "" : parts[2] || "";
+  return `${parts[0]}/${architecture}${variant ? `/${variant}` : ""}`;
+}
+
 function getPackageLookupKeys(name, ecosystemOrFormat, identifiers) {
   const format = canonicalFormat(ecosystemOrFormat);
   const rawName = sanitizePackageNameInput(name);
@@ -85,7 +123,9 @@ function getPackageLookupKeys(name, ecosystemOrFormat, identifiers) {
 
   if (format === "swift") {
     const scope = sanitizePackageNameInput(identifiers && identifiers.scope);
-    return [normalizeSwiftIdentity(rawName, scope)].filter(Boolean);
+    const identity = normalizeSwiftIdentity(rawName, scope);
+    const unscoped = swiftUnscopedName(identity);
+    return [...new Set([identity, unscoped].filter(Boolean))];
   }
 
   return [normalizePackageName(rawName, format)];
@@ -122,7 +162,14 @@ function normalizeSwiftIdentity(name, scope) {
   const rawScope = sanitizePackageNameInput(scope);
   if (!rawName) return "";
   const normalizedName = rawName.toLowerCase().replace(/^\/+|\/+$/g, "");
-  if (!rawScope) return normalizedName;
+  if (!rawScope) {
+    const slashIndex = normalizedName.indexOf("/");
+    if (slashIndex > 0) return normalizedName;
+    const dotIndex = normalizedName.indexOf(".");
+    return dotIndex > 0
+      ? `${normalizedName.slice(0, dotIndex)}/${normalizedName.slice(dotIndex + 1)}`
+      : normalizedName;
+  }
   const normalizedScope = rawScope.toLowerCase().replace(/^\/+|\/+$/g, "");
   if (!normalizedScope) return normalizedName;
   if (
@@ -132,6 +179,14 @@ function normalizeSwiftIdentity(name, scope) {
     return `${normalizedScope}/${normalizedName.slice(normalizedScope.length + 1)}`;
   }
   return `${normalizedScope}/${normalizedName}`;
+}
+
+function swiftUnscopedName(identity) {
+  const normalized = sanitizePackageNameInput(identity).toLowerCase();
+  if (!normalized) return "";
+  const slashIndex = normalized.lastIndexOf("/");
+  const separatorIndex = slashIndex >= 0 ? slashIndex : normalized.indexOf(".");
+  return separatorIndex >= 0 ? normalized.slice(separatorIndex + 1) : normalized;
 }
 
 function buildDockerLookupKeys(name) {
@@ -178,6 +233,8 @@ module.exports = {
   getCloudsmithPackageLookupKeys,
   getPackageLookupKeys,
   normalizePackageName,
+  normalizeNuGetVersion,
+  normalizeDockerPlatformIdentity,
   normalizeSwiftIdentity,
   sanitizePackageNameInput,
 };

--- a/util/recentSearches.js
+++ b/util/recentSearches.js
@@ -2,6 +2,8 @@
 // Versioned, bounded recent-search persistence.
 // Searches are non-secret, but only the fields required to replay them are stored.
 
+const { isValidAdvancedQuery } = require("./searchQueryBuilder");
+
 const STORAGE_KEY_PREFIX = "cloudsmith-recentSearches:v2";
 const STORAGE_VERSION = 2;
 const DEFAULT_MAX = 10;
@@ -92,6 +94,7 @@ function normalizeEntry(entry, expectedWorkspace, now) {
     !isBoundedString(workspace, MAX_WORKSPACE_LENGTH)
     || workspace !== workspace.trim()
     || !isBoundedString(query, MAX_QUERY_LENGTH)
+    || !isValidAdvancedQuery(query)
     || !scope
     || (expectedWorkspace && workspace !== expectedWorkspace)
   ) {
@@ -118,6 +121,7 @@ function isStoredEntry(value, expectedWorkspace) {
     !isBoundedString(value.workspace, MAX_WORKSPACE_LENGTH)
     || value.workspace !== value.workspace.trim()
     || !isBoundedString(value.query, MAX_QUERY_LENGTH)
+    || !isValidAdvancedQuery(value.query)
     || (expectedWorkspace && value.workspace !== expectedWorkspace)
     || !Number.isFinite(value.timestamp)
     || value.timestamp <= 0

--- a/util/registryEndpoints.js
+++ b/util/registryEndpoints.js
@@ -32,6 +32,15 @@ const DOCKER_MANIFEST_ACCEPT =
   + "application/vnd.oci.image.manifest.v1+json, "
   + "application/vnd.oci.image.index.v1+json";
 
+const NPM_PACKUMENT_ACCEPT = "application/vnd.npm.install-v1+json, application/json";
+const DART_PACKAGE_ACCEPT = "application/vnd.pub.v2+json";
+const MAX_DOCKER_MANIFEST_DESCRIPTORS = 256;
+const DOCKER_DIGEST_PATTERN = /^[a-z0-9_+.-]+:[a-f0-9]{32,512}$/i;
+const DOCKER_BLOB_REDIRECT_HOST_SUFFIXES = Object.freeze([
+  ".amazonaws.com",
+  ".cloudfront.net",
+]);
+
 function formatForEcosystem(ecosystemOrFormat) {
   const normalized = canonicalFormat(ecosystemOrFormat);
   return normalized || null;
@@ -116,24 +125,43 @@ function encodeGoModulePath(modulePath) {
   )).join("/");
 }
 
+function encodeGoVersion(version) {
+  const raw = String(version || "");
+  if (!raw || raw !== raw.trim()) {
+    return "";
+  }
+  return encodePathSegment([...raw]
+    .map((character) => {
+      if (character === "!") return "!!";
+      if (character >= "A" && character <= "Z") return `!${character.toLowerCase()}`;
+      return character;
+    })
+    .join(""));
+}
+
 function cargoIndexPath(crateName) {
   const normalized = String(crateName || "").trim().toLowerCase();
-  if (!normalized) {
+  const encodedName = encodePathSegment(normalized);
+  if (!encodedName) {
     return null;
   }
 
-  if (normalized.length <= 2) {
-    return encodePathSegment(normalized);
+  if (normalized.length === 1) {
+    return `1/${encodedName}`;
+  }
+
+  if (normalized.length === 2) {
+    return `2/${encodedName}`;
   }
 
   if (normalized.length === 3) {
-    return `1/${encodePathSegment(normalized)}`;
+    return `3/${encodePathSegment(normalized.slice(0, 1))}/${encodedName}`;
   }
 
   return [
     encodePathSegment(normalized.slice(0, 2)),
     encodePathSegment(normalized.slice(2, 4)),
-    encodePathSegment(normalized),
+    encodedName,
   ].join("/");
 }
 
@@ -150,8 +178,8 @@ function buildNpmPackagePath(name) {
 
     const encodedName = encodePathSegment(rawName);
     return {
-      segments: [encodedName],
-      tarballBaseName: encodedName,
+      packumentPath: encodedName,
+      packageName: rawName,
     };
   }
 
@@ -168,9 +196,149 @@ function buildNpmPackagePath(name) {
   const packageName = rawName.slice(separatorIndex + 1);
 
   return {
-    segments: [encodePathSegment(scope), encodePathSegment(packageName)],
-    tarballBaseName: encodePathSegment(packageName),
+    // npm's registry route treats the complete scoped name as one encoded
+    // package identifier. The slash is identity here, not a path boundary.
+    packumentPath: encodeURIComponent(`${scope}/${packageName}`),
+    packageName: `${scope}/${packageName}`,
   };
+}
+
+function normalizeNuGetVersion(version) {
+  const raw = String(version || "").trim();
+  if (!raw || /[\u0000-\u001f\u007f\\/?#]/.test(raw)) {
+    return "";
+  }
+
+  const withoutMetadata = raw.split("+", 1)[0];
+  const separatorIndex = withoutMetadata.indexOf("-");
+  const release = separatorIndex >= 0
+    ? withoutMetadata.slice(0, separatorIndex)
+    : withoutMetadata;
+  const prerelease = separatorIndex >= 0
+    ? withoutMetadata.slice(separatorIndex + 1)
+    : "";
+  const releaseParts = release.split(".");
+  if (
+    releaseParts.length < 1
+    || releaseParts.length > 4
+    || releaseParts.some(part => !/^\d+$/.test(part))
+    || (separatorIndex >= 0 && !/^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(prerelease))
+  ) {
+    return "";
+  }
+
+  const normalizedRelease = releaseParts.map(part => part.replace(/^0+(?=\d)/, ""));
+  while (normalizedRelease.length < 3) {
+    normalizedRelease.push("0");
+  }
+  if (normalizedRelease.length === 4 && normalizedRelease[3] === "0") {
+    normalizedRelease.pop();
+  }
+
+  return `${normalizedRelease.join(".")}${prerelease ? `-${prerelease.toLowerCase()}` : ""}`;
+}
+
+function normalizeDockerImageName(name) {
+  const raw = sanitizePackageNameInput(name).replace(/^\/+|\/+$/g, "").toLowerCase();
+  if (!raw) {
+    return "";
+  }
+
+  const segments = raw.split("/");
+  if (segments.some(segment => !encodePathSegment(segment))) {
+    return "";
+  }
+
+  if (["docker.io", "index.docker.io", "registry-1.docker.io"].includes(segments[0])) {
+    segments.shift();
+  }
+  if (segments.length === 1) {
+    segments.unshift("library");
+  }
+
+  return segments.join("/");
+}
+
+function dockerCandidateMatchesPlatform(candidate, platform) {
+  const requested = parseDockerPlatform(platform);
+  if (!requested) return !String(platform || "").trim();
+  const identifiers = candidate?.identifiers && typeof candidate.identifiers === "object"
+    ? candidate.identifiers
+    : {};
+  const observedPlatforms = collectCandidateArchitectureValues(candidate)
+    .map(parseDockerPlatform)
+    .filter(Boolean);
+  const architecture = normalizeDockerArchitecture(
+    candidate?.architecture || identifiers.architecture
+  );
+  const os = String(
+    candidate?.os || candidate?.platform_os || identifiers.docker_platform_os || ""
+  ).trim().toLowerCase();
+  const variant = String(
+    candidate?.variant || identifiers.docker_platform_variant || ""
+  ).trim().toLowerCase();
+  if (architecture && os) {
+    observedPlatforms.push({ os, architecture, variant });
+  }
+  return observedPlatforms.some(observed => (
+    observed.os === requested.os
+    && observed.architecture === requested.architecture
+    && dockerVariantMatches(requested, observed)
+  ));
+}
+
+function parseDockerPlatform(value) {
+  const parts = String(value || "").trim().toLowerCase().split("/");
+  if (parts.length < 2 || parts.length > 3 || parts.some(part => !part)) return null;
+  return {
+    os: parts[0],
+    architecture: normalizeDockerArchitecture(parts[1]),
+    variant: parts[2] || "",
+  };
+}
+
+function normalizeDockerArchitecture(value) {
+  const architecture = String(value || "").trim().toLowerCase();
+  if (architecture === "x86_64" || architecture === "x86-64") return "amd64";
+  if (architecture === "aarch64") return "arm64";
+  return architecture;
+}
+
+function dockerVariantMatches(requested, observed) {
+  if (!requested.variant) return true;
+  if (observed.variant) return observed.variant === requested.variant;
+  return requested.architecture === "arm64" && requested.variant === "v8";
+}
+
+function rubyCandidateMatchesPlatform(candidate, platform) {
+  const requested = String(platform || "").trim().toLowerCase();
+  if (!requested) return true;
+  const observed = collectCandidateArchitectureValues(candidate)
+    .map(value => String(value || "").trim().toLowerCase())
+    .filter(Boolean);
+  return requested === "ruby"
+    ? observed.length === 0 || observed.includes("ruby")
+    : observed.includes(requested);
+}
+
+function collectCandidateArchitectureValues(candidate) {
+  const identifiers = candidate?.identifiers && typeof candidate.identifiers === "object"
+    ? candidate.identifiers
+    : {};
+  const values = [
+    candidate?.platform,
+    candidate?.architecture,
+    identifiers.platform,
+    identifiers.architecture,
+  ];
+  if (Array.isArray(candidate?.architectures)) {
+    for (const architecture of candidate.architectures) {
+      values.push(architecture && typeof architecture === "object"
+        ? architecture.name || architecture.slug || architecture.identifier
+        : architecture);
+    }
+  }
+  return values.filter(value => typeof value === "string" && value.trim());
 }
 
 function buildMavenCoordinates(dependency) {
@@ -193,7 +361,20 @@ function buildMavenCoordinates(dependency) {
   const groupSegments = groupId.split(".").map(segment => encodePathSegment(segment));
   const encodedArtifactId = encodePathSegment(artifactId);
   const encodedVersion = encodePathSegment(version);
-  if (!groupSegments.every(Boolean) || !encodedArtifactId || !encodedVersion) {
+  const qualifiers = dependency?.qualifiers || {};
+  const type = String(qualifiers.type || "jar").trim().toLowerCase();
+  const classifierValue = qualifiers.classifier || mavenDefaultClassifier(type);
+  const classifier = classifierValue
+    ? encodePathSegment(classifierValue)
+    : "";
+  const extension = mavenArtifactExtension(type);
+  if (
+    !groupSegments.every(Boolean)
+    || !encodedArtifactId
+    || !encodedVersion
+    || (classifierValue && !classifier)
+    || !extension
+  ) {
     return null;
   }
 
@@ -201,7 +382,48 @@ function buildMavenCoordinates(dependency) {
     groupPath: groupSegments.join("/"),
     artifactId: encodedArtifactId,
     version: encodedVersion,
+    classifier,
+    extension,
   };
+}
+
+function mavenDefaultClassifier(type) {
+  switch (type) {
+    case "test-jar": return "tests";
+    case "java-source": return "sources";
+    case "javadoc": return "javadoc";
+    case "ejb-client": return "client";
+    default: return "";
+  }
+}
+
+function mavenArtifactFileName(dependency, versionOverride = null) {
+  const coordinates = buildMavenCoordinates(versionOverride == null ? dependency : {
+    ...dependency,
+    version: versionOverride,
+  });
+  if (!coordinates) {
+    return "";
+  }
+  try {
+    return decodeURIComponent(
+      `${coordinates.artifactId}-${coordinates.version}`
+      + `${coordinates.classifier ? `-${coordinates.classifier}` : ""}`
+      + `.${coordinates.extension}`
+    );
+  } catch {
+    return "";
+  }
+}
+
+function mavenArtifactExtension(type) {
+  if (!type || /[\u0000-\u001f\u007f\\/?#]/.test(type)) {
+    return "";
+  }
+  if (["bundle", "ejb", "ejb-client", "java-source", "javadoc", "maven-plugin", "test-jar"].includes(type)) {
+    return "jar";
+  }
+  return encodePathSegment(type);
 }
 
 function buildComposerCoordinates(name) {
@@ -259,10 +481,15 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       }
       return {
         format,
-        strategy: "direct",
+        strategy: "maven-artifact",
         request: {
           method: "GET",
           url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/maven/${coordinates.groupPath}/${coordinates.artifactId}/${coordinates.version}/${coordinates.artifactId}-${coordinates.version}.pom`,
+          headers: {},
+        },
+        artifactRequest: {
+          method: "GET",
+          url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/maven/${coordinates.groupPath}/${coordinates.artifactId}/${coordinates.version}/${coordinates.artifactId}-${coordinates.version}${coordinates.classifier ? `-${coordinates.classifier}` : ""}.${coordinates.extension}`,
           headers: {},
         },
       };
@@ -274,11 +501,15 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       }
       return {
         format,
-        strategy: "direct",
+        strategy: "npm-packument",
+        packageName: packagePath.packageName,
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
-          url: `https://npm.cloudsmith.io/${safeWorkspace}/${safeRepo}/${packagePath.segments.join("/")}/-/${packagePath.tarballBaseName}-${version}.tgz`,
-          headers: {},
+          url: `https://npm.cloudsmith.io/${safeWorkspace}/${safeRepo}/${packagePath.packumentPath}/${version}`,
+          headers: {
+            Accept: NPM_PACKUMENT_ACCEPT,
+          },
         },
       };
     }
@@ -290,6 +521,8 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       return {
         format,
         strategy: "python-simple-index",
+        packageName: normalizedName,
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
           url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/python/simple/${encodePathSegment(normalizedName)}/`,
@@ -299,7 +532,8 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
     }
     case "go": {
       const modulePath = encodeGoModulePath(String(dependency && dependency.name || "").trim());
-      if (!modulePath || !version) {
+      const goVersion = encodeGoVersion(dependency && dependency.version);
+      if (!modulePath || !goVersion) {
         return null;
       }
       return {
@@ -307,7 +541,7 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
         strategy: "direct",
         request: {
           method: "GET",
-          url: `https://golang.cloudsmith.io/${safeWorkspace}/${safeRepo}/${modulePath}/@v/${version}.info`,
+          url: `https://golang.cloudsmith.io/${safeWorkspace}/${safeRepo}/${modulePath}/@v/${goVersion}.zip`,
           headers: {},
         },
       };
@@ -319,16 +553,31 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       }
       return {
         format,
-        strategy: "direct",
+        strategy: "cargo-sparse-index",
+        crateName: String(dependency && dependency.name || "").trim().toLowerCase(),
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
           url: `https://cargo.cloudsmith.io/${safeWorkspace}/${safeRepo}/${indexPath}`,
-          headers: {},
+          headers: {
+            Accept: "text/plain, application/octet-stream",
+          },
+        },
+        configRequest: {
+          method: "GET",
+          url: `https://cargo.cloudsmith.io/${safeWorkspace}/${safeRepo}/config.json`,
+          headers: {
+            Accept: "application/json",
+          },
         },
       };
     }
     case "ruby": {
       const name = encodePathSegment(dependency && dependency.name);
+      const platformValue = dependency?.qualifiers?.platform || dependency?.platform;
+      const platform = platformValue && String(platformValue).toLowerCase() !== "ruby"
+        ? encodePathSegment(platformValue)
+        : "";
       if (!name || !version) {
         return null;
       }
@@ -337,37 +586,48 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
         strategy: "direct",
         request: {
           method: "GET",
-          url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/ruby/gems/${name}-${version}.gem`,
+          url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/ruby/gems/${name}-${version}${platform ? `-${platform}` : ""}.gem`,
           headers: {},
         },
       };
     }
     case "nuget": {
-      const name = encodePathSegment(dependency && dependency.name);
-      if (!name || !version) {
+      const normalizedName = sanitizePackageNameInput(dependency && dependency.name).toLowerCase();
+      const normalizedVersion = normalizeNuGetVersion(dependency && dependency.version);
+      const name = encodePathSegment(normalizedName);
+      const packageVersion = encodePathSegment(normalizedVersion);
+      if (!name || !packageVersion) {
         return null;
       }
       return {
         format,
-        strategy: "direct",
+        strategy: "nuget-service-index",
+        packageName: name,
+        packageVersion,
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
-          url: `https://nuget.cloudsmith.io/${safeWorkspace}/${safeRepo}/v3/package/${name}/${version}/${name}.${version}.nupkg`,
-          headers: {},
+          url: `https://nuget.cloudsmith.io/${safeWorkspace}/${safeRepo}/v3/index.json`,
+          headers: { Accept: "application/json" },
         },
       };
     }
     case "docker": {
-      const image = encodePath(dependency && dependency.name);
-      if (!image || !version) {
+      const image = encodePath(normalizeDockerImageName(dependency && dependency.name));
+      const qualifiers = dependency?.qualifiers || dependency?.identifiers || {};
+      const reference = encodePathSegment(
+        qualifiers.digest || dependency?.digest || qualifiers.tag || dependency?.version
+      );
+      if (!image || !reference) {
         return null;
       }
       return {
         format,
-        strategy: "direct",
+        strategy: "docker-manifest",
+        imageBaseUrl: `https://docker.cloudsmith.io/v2/${safeWorkspace}/${safeRepo}/${image}`,
         request: {
           method: "GET",
-          url: `https://docker.cloudsmith.io/v2/${safeWorkspace}/${safeRepo}/${image}/manifests/${version}`,
+          url: `https://docker.cloudsmith.io/v2/${safeWorkspace}/${safeRepo}/${image}/manifests/${reference}`,
           headers: {
             Accept: DOCKER_MANIFEST_ACCEPT,
           },
@@ -397,10 +657,14 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       return {
         format,
         strategy: "dart-api",
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
           url: `https://dart.cloudsmith.io/${safeWorkspace}/${safeRepo}/api/packages/${name}`,
-          headers: {},
+          authScheme: "bearer",
+          headers: {
+            Accept: DART_PACKAGE_ACCEPT,
+          },
         },
       };
     }
@@ -413,6 +677,7 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
         format,
         strategy: "composer-p2",
         packageName: coordinates.packageName,
+        trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
           url: `https://composer.cloudsmith.io/${safeWorkspace}/${safeRepo}/p2/${coordinates.vendor}/${coordinates.package}.json`,
@@ -502,6 +767,205 @@ function buildRegistryTriggerPlan(workspace, repo, dependency) {
   return remainingSegments.length > 0 && remainingSegments.every(Boolean) ? plan : null;
 }
 
+function createRegistryTrustScope(workspace, repo) {
+  const normalizedWorkspace = String(workspace || "").trim();
+  const normalizedRepository = String(repo || "").trim();
+  if (!encodePathSegment(normalizedWorkspace) || !encodePathSegment(normalizedRepository)) {
+    return null;
+  }
+  return Object.freeze({
+    workspace: normalizedWorkspace,
+    repository: normalizedRepository,
+  });
+}
+
+function repeatedlyDecode(value) {
+  let decoded = String(value || "");
+  for (let depth = 0; depth < 3; depth += 1) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return null;
+    }
+    if (next === decoded) {
+      break;
+    }
+    decoded = next;
+  }
+  return decoded;
+}
+
+function hasUnsafeRegistryPath(pathname) {
+  const decoded = repeatedlyDecode(pathname);
+  if (decoded == null || /[\u0000-\u001f\u007f\\]/.test(decoded)) {
+    return true;
+  }
+  return decoded.split("/").some(segment => segment === "." || segment === "..");
+}
+
+function decodedPathSegments(parsedUrl) {
+  const segments = parsedUrl.pathname.split("/").filter(Boolean);
+  const decoded = segments.map(repeatedlyDecode);
+  return decoded.every(value => value != null) ? decoded : null;
+}
+
+function repositoryCoordinatesForUrl(parsedUrl) {
+  const segments = decodedPathSegments(parsedUrl);
+  if (!segments) {
+    return null;
+  }
+
+  if (parsedUrl.hostname === "dl.cloudsmith.io") {
+    if (segments.length < 3 || !["basic", "public", "signed"].includes(segments[0])) {
+      return null;
+    }
+    return { workspace: segments[1], repository: segments[2] };
+  }
+
+  if (parsedUrl.hostname === "docker.cloudsmith.io") {
+    if (segments.length < 3 || segments[0] !== "v2") {
+      return null;
+    }
+    return { workspace: segments[1], repository: segments[2] };
+  }
+
+  if (segments.length < 2) {
+    return null;
+  }
+  return { workspace: segments[0], repository: segments[1] };
+}
+
+function inferRegistryTrustScope(baseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return null;
+  }
+  if (!isTrustedRegistryUrl(parsed.toString()) || hasUnsafeRegistryPath(parsed.pathname)) {
+    return null;
+  }
+  const coordinates = repositoryCoordinatesForUrl(parsed);
+  return coordinates
+    ? createRegistryTrustScope(coordinates.workspace, coordinates.repository)
+    : null;
+}
+
+function isSupportedArtifactHash(hash) {
+  if (!hash) {
+    return true;
+  }
+  const match = /^#([a-z0-9_+-]{1,32})=([a-f0-9]{16,256})$/i.exec(hash);
+  return Boolean(match);
+}
+
+/**
+ * Resolve a metadata-provided registry URL and constrain it to the selected
+ * Cloudsmith workspace/repository. A valid Python index hash fragment may be
+ * accepted and is stripped because URL fragments must never be sent over HTTP.
+ */
+function resolveAndValidateScopedRegistryUrl(candidate, baseUrl, trustScope, options = {}) {
+  if (!candidate) {
+    return null;
+  }
+
+  let resolved;
+  try {
+    resolved = new URL(candidate, baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (
+    (resolved.search && !options.allowQuery)
+    || (resolved.hash && (!options.allowHashFragment || !isSupportedArtifactHash(resolved.hash)))
+    || hasUnsafeRegistryPath(resolved.pathname)
+  ) {
+    return null;
+  }
+
+  resolved.hash = "";
+  if (!isTrustedRegistryUrl(resolved.toString())) {
+    return null;
+  }
+
+  const expectedScope = trustScope || inferRegistryTrustScope(baseUrl);
+  const actualScope = repositoryCoordinatesForUrl(resolved);
+  if (
+    !expectedScope
+    || !actualScope
+    || actualScope.workspace !== expectedScope.workspace
+    || actualScope.repository !== expectedScope.repository
+  ) {
+    return null;
+  }
+
+  return resolved.toString();
+}
+
+function resolveAndValidateDockerBlobRedirectUrl(candidate, baseUrl) {
+  if (!candidate) return null;
+  const rawCandidate = String(candidate);
+  const rawPath = rawCandidate
+    .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]+/i, "")
+    .split(/[?#]/, 1)[0];
+  if (hasUnsafeRegistryPath(rawPath)) return null;
+  let resolved;
+  try {
+    resolved = new URL(candidate, baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (isTrustedRegistryUrl(resolved.toString())) {
+    return resolveAndValidateScopedRegistryUrl(
+      resolved.toString(),
+      baseUrl,
+      null,
+      { allowQuery: true }
+    );
+  }
+
+  const hostname = resolved.hostname.toLowerCase();
+  if (
+    resolved.protocol !== "https:"
+    || resolved.port
+    || resolved.username
+    || resolved.password
+    || resolved.hash
+    || hasUnsafeRegistryPath(resolved.pathname)
+    || !hostname.includes(".")
+    || hostname.endsWith(".")
+    || isLiteralIpHostname(hostname)
+    || !isSafeDnsHostname(hostname)
+    || hostname === "localhost"
+    || hostname.endsWith(".localhost")
+    || hostname.endsWith(".local")
+    || hostname.endsWith(".internal")
+    || hostname.endsWith(".home.arpa")
+    || !DOCKER_BLOB_REDIRECT_HOST_SUFFIXES.some(suffix => hostname.endsWith(suffix))
+  ) {
+    return null;
+  }
+  return resolved.toString();
+}
+
+function isSafeDnsHostname(hostname) {
+  return hostname.length <= 253 && hostname.split(".").every(label => (
+    label.length > 0
+    && label.length <= 63
+    && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  ));
+}
+
+function isLiteralIpHostname(hostname) {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) return true;
+  const parts = hostname.split(".");
+  return parts.length === 4
+    && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
 function isTrustedCloudsmithHost(host) {
   const normalizedHost = String(host || "").trim().toLowerCase();
   return TRUSTED_REGISTRY_HOSTS.has(normalizedHost);
@@ -589,38 +1053,104 @@ function collectHrefValues(html) {
   return hrefs;
 }
 
-function scorePythonArtifact(url, version) {
-  const normalizedVersion = String(version || "").trim().toLowerCase();
-  const fileName = decodeURIComponent(String(url || "").split("/").pop() || "").toLowerCase();
+function normalizePythonFileNameIdentity(value) {
+  return String(value || "").trim().toLowerCase().replace(/[-_.]+/g, "-");
+}
 
+function pythonArtifactIdentity(url) {
+  let fileName;
+  try {
+    const parsed = new URL(url);
+    fileName = decodeURIComponent(parsed.pathname.split("/").pop() || "");
+  } catch {
+    return null;
+  }
   if (!fileName) {
+    return null;
+  }
+
+  const lowerFileName = fileName.toLowerCase();
+  if (lowerFileName.endsWith(".whl")) {
+    const fields = fileName.slice(0, -4).split("-");
+    if (fields.length < 5) {
+      return null;
+    }
+    return {
+      name: normalizePythonFileNameIdentity(fields[0]),
+      version: normalizePythonFileNameIdentity(fields[1]),
+      score: 2,
+    };
+  }
+
+  const extension = lowerFileName.endsWith(".tar.gz")
+    ? ".tar.gz"
+    : lowerFileName.endsWith(".zip")
+      ? ".zip"
+      : "";
+  if (!extension) {
+    return null;
+  }
+
+  return {
+    stem: fileName.slice(0, -extension.length),
+    score: 1,
+  };
+}
+
+function scorePythonArtifact(url, packageName, version) {
+  const identity = pythonArtifactIdentity(url);
+  const normalizedName = normalizePythonFileNameIdentity(packageName);
+  const normalizedVersion = normalizePythonFileNameIdentity(version);
+  if (!identity || !normalizedVersion) {
     return -1;
   }
 
-  let score = 0;
-  if (normalizedVersion) {
-    if (!fileName.includes(normalizedVersion)) {
+  if (identity.stem != null) {
+    const versionSuffix = `-${String(version || "").trim()}`.toLowerCase();
+    if (!identity.stem.toLowerCase().endsWith(versionSuffix)) {
       return -1;
     }
-    score += 10;
+    const distribution = identity.stem.slice(0, -versionSuffix.length);
+    if (normalizedName && normalizePythonFileNameIdentity(distribution) !== normalizedName) {
+      return -1;
+    }
+    return identity.score + 10;
   }
 
-  if (fileName.endsWith(".whl")) {
-    score += 2;
-  } else if (fileName.endsWith(".tar.gz") || fileName.endsWith(".zip")) {
-    score += 1;
+  if (
+    identity.version !== normalizedVersion
+    || (normalizedName && identity.name !== normalizedName)
+  ) {
+    return -1;
   }
-
-  return score;
+  return identity.score + 10;
 }
 
-function findPythonDistributionUrl(html, version, baseUrl) {
+function findPythonDistributionUrl(html, packageName, version, baseUrl, trustScope) {
+  // Backward-compatible shape: (html, version, baseUrl). Exact distribution
+  // identity requires the new four-argument form used by pull-through.
+  let wantedName = packageName;
+  let wantedVersion = version;
+  let registryBaseUrl = baseUrl;
+  let expectedScope = trustScope;
+  if (baseUrl === undefined) {
+    wantedName = "";
+    wantedVersion = packageName;
+    registryBaseUrl = version;
+    expectedScope = undefined;
+  }
+
   const candidates = collectHrefValues(html)
-    .map((href) => resolveAndValidateRegistryUrl(href, baseUrl))
+    .map((href) => resolveAndValidateScopedRegistryUrl(
+      href,
+      registryBaseUrl,
+      expectedScope,
+      { allowHashFragment: true }
+    ))
     .filter(Boolean)
     .map((url) => ({
       url,
-      score: scorePythonArtifact(url, version),
+      score: scorePythonArtifact(url, wantedName, wantedVersion),
     }))
     .filter((candidate) => candidate.score >= 0)
     .sort((left, right) => right.score - left.score || left.url.localeCompare(right.url));
@@ -628,7 +1158,266 @@ function findPythonDistributionUrl(html, version, baseUrl) {
   return candidates.length > 0 ? candidates[0].url : null;
 }
 
-function parseDartArchiveUrl(body, version, baseUrl) {
+function parseNpmTarballUrl(body, packageName, version, baseUrl, trustScope) {
+  let payload;
+  try {
+    payload = JSON.parse(String(body || ""));
+  } catch {
+    return null;
+  }
+
+  const wantedName = sanitizePackageNameInput(packageName).toLowerCase();
+  const wantedVersion = String(version || "").trim();
+  if (
+    !wantedName
+    || !wantedVersion
+    || !payload
+    || typeof payload !== "object"
+    || Array.isArray(payload)
+    || typeof payload.name !== "string"
+    || payload.name.toLowerCase() !== wantedName
+  ) {
+    return null;
+  }
+
+  const entry = payload.version === wantedVersion
+    ? payload
+    : payload.versions
+      && typeof payload.versions === "object"
+      && !Array.isArray(payload.versions)
+      && Object.prototype.hasOwnProperty.call(payload.versions, wantedVersion)
+      ? payload.versions[wantedVersion]
+      : null;
+  if (
+    !entry
+    || typeof entry !== "object"
+    || Array.isArray(entry)
+    || entry.version !== wantedVersion
+    || !entry.dist
+    || typeof entry.dist !== "object"
+  ) {
+    return null;
+  }
+
+  return resolveAndValidateScopedRegistryUrl(
+    entry.dist.tarball,
+    baseUrl,
+    trustScope
+  );
+}
+
+function parseCargoIndexEntry(body, crateName, version) {
+  const wantedName = String(crateName || "").trim().toLowerCase();
+  const wantedVersion = String(version || "").trim();
+  if (!wantedName || !wantedVersion) {
+    return null;
+  }
+
+  const lines = String(body || "").split(/\r?\n/, 10001);
+  if (lines.length > 10000) {
+    return null;
+  }
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (
+      entry
+      && typeof entry === "object"
+      && String(entry.name || "").toLowerCase() === wantedName
+      && entry.vers === wantedVersion
+      && /^[a-f0-9]{64}$/i.test(String(entry.cksum || ""))
+    ) {
+      return Object.freeze({
+        name: String(entry.name),
+        version: entry.vers,
+        checksum: String(entry.cksum).toLowerCase(),
+        yanked: Boolean(entry.yanked),
+      });
+    }
+  }
+  return null;
+}
+
+function parseCargoDownloadUrl(body, crateName, version, checksum, baseUrl, trustScope) {
+  let payload;
+  try {
+    payload = JSON.parse(String(body || ""));
+  } catch {
+    return null;
+  }
+
+  const normalizedName = String(crateName || "").trim().toLowerCase();
+  const encodedName = encodePathSegment(normalizedName);
+  const encodedVersion = encodePathSegment(version);
+  const normalizedChecksum = String(checksum || "").trim().toLowerCase();
+  if (
+    !payload
+    || typeof payload.dl !== "string"
+    || !encodedName
+    || !encodedVersion
+    || !/^[a-f0-9]{64}$/.test(normalizedChecksum)
+  ) {
+    return null;
+  }
+
+  const prefix = cargoIndexPath(normalizedName);
+  const hadTemplateMarker = /\{(?:crate|version|prefix|lowerprefix|sha256-checksum)\}/.test(payload.dl);
+  let candidate = payload.dl
+    .replaceAll("{crate}", encodedName)
+    .replaceAll("{version}", encodedVersion)
+    .replaceAll("{prefix}", prefix)
+    .replaceAll("{lowerprefix}", prefix.toLowerCase())
+    .replaceAll("{sha256-checksum}", normalizedChecksum);
+  if (/\{[^{}]+\}/.test(candidate)) {
+    return null;
+  }
+  if (!hadTemplateMarker) {
+    candidate = `${candidate.replace(/\/$/, "")}/${encodedName}/${encodedVersion}/download`;
+  }
+
+  return resolveAndValidateScopedRegistryUrl(candidate, baseUrl, trustScope);
+}
+
+function parseDockerManifest(body, preferredPlatform = {}) {
+  let payload;
+  try {
+    payload = JSON.parse(String(body || ""));
+  } catch {
+    return null;
+  }
+
+  if (!payload || payload.schemaVersion !== 2) {
+    return null;
+  }
+
+  if (Array.isArray(payload.manifests)) {
+    if (
+      payload.manifests.length === 0
+      || payload.manifests.length > MAX_DOCKER_MANIFEST_DESCRIPTORS
+    ) {
+      return null;
+    }
+    const requested = preferredDockerPlatform(preferredPlatform);
+    if (!requested) {
+      return null;
+    }
+    const { os: requestedOs, architecture: requestedArchitecture, variant: requestedVariant } = requested;
+    const candidates = payload.manifests.filter(entry => (
+      entry
+      && isDockerDigest(entry.digest)
+      && entry.platform
+      && typeof entry.platform === "object"
+    ));
+    const exact = candidates.find(entry => (
+      String(entry.platform.os || "").toLowerCase() === requestedOs
+      && String(entry.platform.architecture || "").toLowerCase() === requestedArchitecture
+      && (!requestedVariant || String(entry.platform.variant || "").toLowerCase() === requestedVariant)
+    ));
+    const selected = exact || (requested.explicit ? null : candidates.find(entry => (
+      String(entry.platform.os || "").toLowerCase() === "linux"
+      && String(entry.platform.architecture || "").toLowerCase() === "amd64"
+    ))) || (requested.explicit ? null : candidates[0]);
+    return selected ? { manifestDigest: selected.digest, blobDigests: [] } : null;
+  }
+
+  const descriptors = [payload.config, ...(Array.isArray(payload.layers) ? payload.layers : [])];
+  if (
+    descriptors.length === 0
+    || descriptors.length > MAX_DOCKER_MANIFEST_DESCRIPTORS
+    || descriptors.some(entry => !entry || !isDockerDigest(entry.digest))
+  ) {
+    return null;
+  }
+
+  return {
+    manifestDigest: null,
+    blobDigests: [...new Set(descriptors.map(entry => entry.digest))],
+  };
+}
+
+function preferredDockerPlatform(value) {
+  const preferred = value && typeof value === "object" ? value : {};
+  const platform = String(preferred.platform || "").trim().toLowerCase();
+  if (platform) {
+    const parts = platform.split("/");
+    if (
+      (parts.length !== 2 && parts.length !== 3)
+      || parts.some(part => !part || !/^[a-z0-9_.-]+$/.test(part))
+    ) {
+      return null;
+    }
+    return {
+      os: parts[0],
+      architecture: parts[1],
+      variant: parts[2] || "",
+      explicit: true,
+    };
+  }
+
+  const explicit = Boolean(preferred.os || preferred.architecture || preferred.arch || preferred.variant);
+  const os = String(preferred.os || "linux").trim().toLowerCase();
+  const architecture = String(
+    preferred.architecture || preferred.arch || "amd64"
+  ).trim().toLowerCase();
+  const variant = String(preferred.variant || "").trim().toLowerCase();
+  if (
+    !os
+    || !architecture
+    || !/^[a-z0-9_.-]+$/.test(os)
+    || !/^[a-z0-9_.-]+$/.test(architecture)
+    || (variant && !/^[a-z0-9_.-]+$/.test(variant))
+  ) {
+    return null;
+  }
+  return { os, architecture, variant, explicit };
+}
+
+function parseNuGetPackageUrl(body, packageName, packageVersion, baseUrl, trustScope) {
+  let payload;
+  try {
+    payload = JSON.parse(String(body || ""));
+  } catch {
+    return null;
+  }
+  const normalizedName = encodePathSegment(String(packageName || "").toLowerCase());
+  const normalizedVersion = encodePathSegment(normalizeNuGetVersion(packageVersion));
+  if (!normalizedName || !normalizedVersion || !Array.isArray(payload?.resources)) {
+    return null;
+  }
+
+  for (const resource of payload.resources.slice(0, 256)) {
+    if (!resource || typeof resource !== "object") continue;
+    const types = Array.isArray(resource["@type"])
+      ? resource["@type"]
+      : [resource["@type"]];
+    if (!types.some(type => String(type || "").startsWith("PackageBaseAddress/"))) {
+      continue;
+    }
+    const packageBase = resolveAndValidateScopedRegistryUrl(
+      resource["@id"],
+      baseUrl,
+      trustScope
+    );
+    if (!packageBase) continue;
+    return `${packageBase.replace(/\/$/, "")}/${normalizedName}/${normalizedVersion}/${normalizedName}.${normalizedVersion}.nupkg`;
+  }
+  return null;
+}
+
+function isDockerDigest(value) {
+  return typeof value === "string"
+    && value.length <= 1024
+    && DOCKER_DIGEST_PATTERN.test(value);
+}
+
+function parseDartArchiveUrl(body, version, baseUrl, trustScope) {
   let payload;
   try {
     payload = JSON.parse(String(body || ""));
@@ -661,7 +1450,7 @@ function parseDartArchiveUrl(body, version, baseUrl) {
   }
 
   for (const candidate of candidates) {
-    const resolved = resolveAndValidateRegistryUrl(candidate, baseUrl);
+    const resolved = resolveAndValidateScopedRegistryUrl(candidate, baseUrl, trustScope);
     if (resolved) {
       return resolved;
     }
@@ -670,7 +1459,7 @@ function parseDartArchiveUrl(body, version, baseUrl) {
   return null;
 }
 
-function parseComposerDistUrl(body, packageName, version, baseUrl) {
+function parseComposerDistUrl(body, packageName, version, baseUrl, trustScope) {
   let payload;
   try {
     payload = JSON.parse(String(body || ""));
@@ -697,24 +1486,36 @@ function parseComposerDistUrl(body, packageName, version, baseUrl) {
     entries.push(...payload);
   }
 
-  const matchedEntry = entries.find((entry) => entry && entry.version === version)
-    || entries.find(Boolean);
+  const matchedEntry = entries.find((entry) => entry && entry.version === version);
   const distUrl = matchedEntry
     && matchedEntry.dist
     && typeof matchedEntry.dist === "object"
     ? matchedEntry.dist.url
     : null;
 
-  return resolveAndValidateRegistryUrl(distUrl, baseUrl);
+  return resolveAndValidateScopedRegistryUrl(distUrl, baseUrl, trustScope);
 }
 
 module.exports = {
   buildRegistryTriggerPlan,
+  cargoIndexPath,
+  createRegistryTrustScope,
+  dockerCandidateMatchesPlatform,
   findPythonDistributionUrl,
   formatForDependency,
   isPullUnsupportedFormat,
   isTrustedRegistryUrl,
+  mavenArtifactFileName,
+  normalizeNuGetVersion,
+  parseDockerManifest,
+  parseNuGetPackageUrl,
+  parseCargoDownloadUrl,
+  parseCargoIndexEntry,
   parseComposerDistUrl,
   parseDartArchiveUrl,
+  parseNpmTarballUrl,
+  resolveAndValidateDockerBlobRedirectUrl,
   resolveAndValidateRegistryUrl,
+  resolveAndValidateScopedRegistryUrl,
+  rubyCandidateMatchesPlatform,
 };

--- a/util/registryEndpoints.js
+++ b/util/registryEndpoints.js
@@ -1,10 +1,14 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const {
   canonicalFormat,
+  normalizeNuGetVersion,
   sanitizePackageNameInput,
 } = require("./packageNameNormalizer");
 
 const MAX_REGISTRY_VALUE_LENGTH = 4096;
+const MAX_REGISTRY_URL_LENGTH = 16384;
+const MAX_REGISTRY_DECODE_DEPTH = 8;
+const REGISTRY_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u;
 const TRUSTED_REGISTRY_HOSTS = new Set([
   "cargo.cloudsmith.io",
   "composer.cloudsmith.io",
@@ -35,7 +39,7 @@ const DOCKER_MANIFEST_ACCEPT =
 const NPM_PACKUMENT_ACCEPT = "application/vnd.npm.install-v1+json, application/json";
 const DART_PACKAGE_ACCEPT = "application/vnd.pub.v2+json";
 const MAX_DOCKER_MANIFEST_DESCRIPTORS = 256;
-const DOCKER_DIGEST_PATTERN = /^[a-z0-9_+.-]+:[a-f0-9]{32,512}$/i;
+const DOCKER_DIGEST_PATTERN = /^([a-z0-9_+.-]+):([a-f0-9]{32,512})$/i;
 const DOCKER_BLOB_REDIRECT_HOST_SUFFIXES = Object.freeze([
   ".amazonaws.com",
   ".cloudfront.net",
@@ -63,25 +67,20 @@ function encodePathSegment(value) {
     !normalized
     || normalized !== raw
     || normalized.length > MAX_REGISTRY_VALUE_LENGTH
-    || /[\u0000-\u001f\u007f\\/?#]/.test(normalized)
+    || REGISTRY_CONTROL_OR_BIDI.test(normalized)
+    || /[\\/?#]/.test(normalized)
   ) {
     return "";
   }
 
-  let decoded = normalized;
-  for (let depth = 0; depth < 3; depth += 1) {
-    let next;
-    try {
-      next = decodeURIComponent(decoded);
-    } catch {
-      return "";
-    }
-    if (next === decoded) {
-      break;
-    }
-    decoded = next;
-  }
-  if (decoded === "." || decoded === ".." || /[\u0000-\u001f\u007f\\/?#]/.test(decoded)) {
+  const decoded = repeatedlyDecode(normalized);
+  if (
+    decoded == null
+    || decoded === "."
+    || decoded === ".."
+    || REGISTRY_CONTROL_OR_BIDI.test(decoded)
+    || /[\\/?#]/.test(decoded)
+  ) {
     return "";
   }
 
@@ -90,7 +89,7 @@ function encodePathSegment(value) {
 
 function encodePath(value) {
   const raw = String(value == null ? "" : value);
-  if (!raw || raw !== raw.trim() || /[\\?#\u0000-\u001f\u007f]/.test(raw)) {
+  if (!raw || raw !== raw.trim() || REGISTRY_CONTROL_OR_BIDI.test(raw) || /[\\?#]/.test(raw)) {
     return "";
   }
   const segments = raw.split("/");
@@ -145,24 +144,18 @@ function cargoIndexPath(crateName) {
   if (!encodedName) {
     return null;
   }
+  const prefix = cargoPrefix(normalized);
+  return prefix ? `${prefix}/${encodedName}` : null;
+}
 
-  if (normalized.length === 1) {
-    return `1/${encodedName}`;
-  }
-
-  if (normalized.length === 2) {
-    return `2/${encodedName}`;
-  }
-
-  if (normalized.length === 3) {
-    return `3/${encodePathSegment(normalized.slice(0, 1))}/${encodedName}`;
-  }
-
-  return [
-    encodePathSegment(normalized.slice(0, 2)),
-    encodePathSegment(normalized.slice(2, 4)),
-    encodedName,
-  ].join("/");
+function cargoPrefix(crateName, lowercase = false) {
+  const raw = String(crateName || "").trim();
+  const name = lowercase ? raw.toLowerCase() : raw;
+  if (!encodePathSegment(name)) return null;
+  if (name.length === 1) return "1";
+  if (name.length === 2) return "2";
+  if (name.length === 3) return `3/${encodePathSegment(name.slice(0, 1))}`;
+  return `${encodePathSegment(name.slice(0, 2))}/${encodePathSegment(name.slice(2, 4))}`;
 }
 
 function buildNpmPackagePath(name) {
@@ -201,41 +194,6 @@ function buildNpmPackagePath(name) {
     packumentPath: encodeURIComponent(`${scope}/${packageName}`),
     packageName: `${scope}/${packageName}`,
   };
-}
-
-function normalizeNuGetVersion(version) {
-  const raw = String(version || "").trim();
-  if (!raw || /[\u0000-\u001f\u007f\\/?#]/.test(raw)) {
-    return "";
-  }
-
-  const withoutMetadata = raw.split("+", 1)[0];
-  const separatorIndex = withoutMetadata.indexOf("-");
-  const release = separatorIndex >= 0
-    ? withoutMetadata.slice(0, separatorIndex)
-    : withoutMetadata;
-  const prerelease = separatorIndex >= 0
-    ? withoutMetadata.slice(separatorIndex + 1)
-    : "";
-  const releaseParts = release.split(".");
-  if (
-    releaseParts.length < 1
-    || releaseParts.length > 4
-    || releaseParts.some(part => !/^\d+$/.test(part))
-    || (separatorIndex >= 0 && !/^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(prerelease))
-  ) {
-    return "";
-  }
-
-  const normalizedRelease = releaseParts.map(part => part.replace(/^0+(?=\d)/, ""));
-  while (normalizedRelease.length < 3) {
-    normalizedRelease.push("0");
-  }
-  if (normalizedRelease.length === 4 && normalizedRelease[3] === "0") {
-    normalizedRelease.pop();
-  }
-
-  return `${normalizedRelease.join(".")}${prerelease ? `-${prerelease.toLowerCase()}` : ""}`;
 }
 
 function normalizeDockerImageName(name) {
@@ -310,9 +268,33 @@ function dockerVariantMatches(requested, observed) {
   return requested.architecture === "arm64" && requested.variant === "v8";
 }
 
+function dockerDigestMatches(observedValue, requestedValue) {
+  const observed = String(observedValue || "").trim().toLowerCase();
+  const requested = String(requestedValue || "").trim().toLowerCase();
+  if (!observed || !requested) return false;
+  const split = value => {
+    const match = value.match(DOCKER_DIGEST_PATTERN);
+    if (match && isDockerDigest(value)) return { algorithm: match[1], digest: match[2] };
+    if (!/^[a-f0-9]{32,512}$/.test(value)) return null;
+    return {
+      algorithm: value.length === 64 ? "sha256" : value.length === 128 ? "sha512" : "",
+      digest: value,
+    };
+  };
+  const observedDigest = split(observed);
+  const requestedDigest = split(requested);
+  if (!observedDigest || !requestedDigest) return false;
+  if (
+    observedDigest.algorithm !== requestedDigest.algorithm
+    && (observedDigest.algorithm || requestedDigest.algorithm)
+  ) {
+    return false;
+  }
+  return observedDigest.digest === requestedDigest.digest;
+}
+
 function rubyCandidateMatchesPlatform(candidate, platform) {
-  const requested = String(platform || "").trim().toLowerCase();
-  if (!requested) return true;
+  const requested = String(platform || "ruby").trim().toLowerCase() || "ruby";
   const observed = collectCandidateArchitectureValues(candidate)
     .map(value => String(value || "").trim().toLowerCase())
     .filter(Boolean);
@@ -447,16 +429,32 @@ function buildComposerCoordinates(name) {
   };
 }
 
-function buildSwiftCoordinates(name) {
+function buildSwiftCoordinates(name, qualifiers = {}) {
   const rawName = sanitizePackageNameInput(name);
-  const parts = rawName.split("/");
-  if (parts.length < 2 || parts.some(part => !encodePathSegment(part))) {
+  const rawScope = sanitizePackageNameInput(qualifiers && qualifiers.scope);
+  let scope = rawScope;
+  let packageName = rawName;
+  if (scope && (packageName.toLowerCase().startsWith(`${scope.toLowerCase()}.`)
+    || packageName.toLowerCase().startsWith(`${scope.toLowerCase()}/`))) {
+    packageName = packageName.slice(scope.length + 1);
+  } else if (!scope) {
+    const slashIndex = packageName.indexOf("/");
+    const dotIndex = packageName.indexOf(".");
+    const separatorIndex = slashIndex > 0 ? slashIndex : dotIndex;
+    if (separatorIndex > 0) {
+      scope = packageName.slice(0, separatorIndex);
+      packageName = packageName.slice(separatorIndex + 1);
+    }
+  }
+  const encodedScope = scope ? encodePathSegment(scope.toLowerCase()) : "";
+  const encodedName = encodePathSegment(packageName.toLowerCase());
+  if (!encodedScope || !encodedName) {
     return null;
   }
 
   return {
-    scope: parts.slice(0, -1).map((part) => encodePathSegment(part)).join("/"),
-    name: encodePathSegment(parts[parts.length - 1]),
+    scope: encodedScope,
+    name: encodedName,
   };
 }
 
@@ -481,13 +479,8 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       }
       return {
         format,
-        strategy: "maven-artifact",
+        strategy: "direct",
         request: {
-          method: "GET",
-          url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/maven/${coordinates.groupPath}/${coordinates.artifactId}/${coordinates.version}/${coordinates.artifactId}-${coordinates.version}.pom`,
-          headers: {},
-        },
-        artifactRequest: {
           method: "GET",
           url: `https://dl.cloudsmith.io/basic/${safeWorkspace}/${safeRepo}/maven/${coordinates.groupPath}/${coordinates.artifactId}/${coordinates.version}/${coordinates.artifactId}-${coordinates.version}${coordinates.classifier ? `-${coordinates.classifier}` : ""}.${coordinates.extension}`,
           headers: {},
@@ -615,8 +608,12 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
     case "docker": {
       const image = encodePath(normalizeDockerImageName(dependency && dependency.name));
       const qualifiers = dependency?.qualifiers || dependency?.identifiers || {};
+      const requestedDigest = String(qualifiers.digest || dependency?.digest || "").trim();
+      if (requestedDigest && !isDockerDigest(requestedDigest)) {
+        return null;
+      }
       const reference = encodePathSegment(
-        qualifiers.digest || dependency?.digest || qualifiers.tag || dependency?.version
+        requestedDigest || qualifiers.tag || dependency?.version
       );
       if (!image || !reference) {
         return null;
@@ -657,6 +654,7 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       return {
         format,
         strategy: "dart-api",
+        packageName: String(dependency && dependency.name || "").trim(),
         trustScope: createRegistryTrustScope(workspace, repo),
         request: {
           method: "GET",
@@ -701,7 +699,10 @@ function buildRegistryTriggerPlanUnchecked(workspace, repo, dependency) {
       };
     }
     case "swift": {
-      const coordinates = buildSwiftCoordinates(dependency && dependency.name);
+      const coordinates = buildSwiftCoordinates(
+        dependency && dependency.name,
+        dependency && (dependency.qualifiers || dependency.identifiers)
+      );
       if (!coordinates || !coordinates.scope || !coordinates.name || !version) {
         return null;
       }
@@ -781,7 +782,8 @@ function createRegistryTrustScope(workspace, repo) {
 
 function repeatedlyDecode(value) {
   let decoded = String(value || "");
-  for (let depth = 0; depth < 3; depth += 1) {
+  if (decoded.length > MAX_REGISTRY_URL_LENGTH) return null;
+  for (let depth = 0; depth < MAX_REGISTRY_DECODE_DEPTH; depth += 1) {
     let next;
     try {
       next = decodeURIComponent(decoded);
@@ -789,16 +791,16 @@ function repeatedlyDecode(value) {
       return null;
     }
     if (next === decoded) {
-      break;
+      return decoded;
     }
     decoded = next;
   }
-  return decoded;
+  return null;
 }
 
 function hasUnsafeRegistryPath(pathname) {
   const decoded = repeatedlyDecode(pathname);
-  if (decoded == null || /[\u0000-\u001f\u007f\\]/.test(decoded)) {
+  if (decoded == null || REGISTRY_CONTROL_OR_BIDI.test(decoded) || /\\/.test(decoded)) {
     return true;
   }
   return decoded.split("/").some(segment => segment === "." || segment === "..");
@@ -866,7 +868,11 @@ function isSupportedArtifactHash(hash) {
  * accepted and is stripped because URL fragments must never be sent over HTTP.
  */
 function resolveAndValidateScopedRegistryUrl(candidate, baseUrl, trustScope, options = {}) {
-  if (!candidate) {
+  if (
+    !candidate
+    || String(candidate).length > MAX_REGISTRY_URL_LENGTH
+    || String(baseUrl || "").length > MAX_REGISTRY_URL_LENGTH
+  ) {
     return null;
   }
 
@@ -905,7 +911,11 @@ function resolveAndValidateScopedRegistryUrl(candidate, baseUrl, trustScope, opt
 }
 
 function resolveAndValidateDockerBlobRedirectUrl(candidate, baseUrl) {
-  if (!candidate) return null;
+  if (
+    !candidate
+    || String(candidate).length > MAX_REGISTRY_URL_LENGTH
+    || String(baseUrl || "").length > MAX_REGISTRY_URL_LENGTH
+  ) return null;
   const rawCandidate = String(candidate);
   const rawPath = rawCandidate
     .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]+/i, "")
@@ -972,6 +982,7 @@ function isTrustedCloudsmithHost(host) {
 }
 
 function isTrustedRegistryUrl(candidateUrl) {
+  if (String(candidateUrl || "").length > MAX_REGISTRY_URL_LENGTH) return false;
   try {
     const parsed = new URL(candidateUrl);
     return parsed.protocol === "https:"
@@ -984,25 +995,6 @@ function isTrustedRegistryUrl(candidateUrl) {
   } catch {
     return false;
   }
-}
-
-function resolveAndValidateRegistryUrl(candidate, baseUrl) {
-  if (!candidate) {
-    return null;
-  }
-
-  let resolved;
-  try {
-    resolved = new URL(candidate, baseUrl);
-  } catch {
-    return null;
-  }
-
-  if (!isTrustedRegistryUrl(resolved.toString())) {
-    return null;
-  }
-
-  return resolved.toString();
 }
 
 function collectHrefValues(html) {
@@ -1127,24 +1119,15 @@ function scorePythonArtifact(url, packageName, version) {
 }
 
 function findPythonDistributionUrl(html, packageName, version, baseUrl, trustScope) {
-  // Backward-compatible shape: (html, version, baseUrl). Exact distribution
-  // identity requires the new four-argument form used by pull-through.
-  let wantedName = packageName;
-  let wantedVersion = version;
-  let registryBaseUrl = baseUrl;
-  let expectedScope = trustScope;
-  if (baseUrl === undefined) {
-    wantedName = "";
-    wantedVersion = packageName;
-    registryBaseUrl = version;
-    expectedScope = undefined;
-  }
+  const wantedName = sanitizePackageNameInput(packageName);
+  const wantedVersion = String(version || "").trim();
+  if (!wantedName || !wantedVersion || !baseUrl) return null;
 
   const candidates = collectHrefValues(html)
     .map((href) => resolveAndValidateScopedRegistryUrl(
       href,
-      registryBaseUrl,
-      expectedScope,
+      baseUrl,
+      trustScope,
       { allowHashFragment: true }
     ))
     .filter(Boolean)
@@ -1253,8 +1236,8 @@ function parseCargoDownloadUrl(body, crateName, version, checksum, baseUrl, trus
     return null;
   }
 
-  const normalizedName = String(crateName || "").trim().toLowerCase();
-  const encodedName = encodePathSegment(normalizedName);
+  const rawName = String(crateName || "").trim();
+  const encodedName = encodePathSegment(rawName);
   const encodedVersion = encodePathSegment(version);
   const normalizedChecksum = String(checksum || "").trim().toLowerCase();
   if (
@@ -1267,13 +1250,15 @@ function parseCargoDownloadUrl(body, crateName, version, checksum, baseUrl, trus
     return null;
   }
 
-  const prefix = cargoIndexPath(normalizedName);
+  const prefix = cargoPrefix(rawName);
+  const lowerPrefix = cargoPrefix(rawName, true);
+  if (!prefix || !lowerPrefix) return null;
   const hadTemplateMarker = /\{(?:crate|version|prefix|lowerprefix|sha256-checksum)\}/.test(payload.dl);
   let candidate = payload.dl
     .replaceAll("{crate}", encodedName)
     .replaceAll("{version}", encodedVersion)
     .replaceAll("{prefix}", prefix)
-    .replaceAll("{lowerprefix}", prefix.toLowerCase())
+    .replaceAll("{lowerprefix}", lowerPrefix)
     .replaceAll("{sha256-checksum}", normalizedChecksum);
   if (/\{[^{}]+\}/.test(candidate)) {
     return null;
@@ -1308,18 +1293,13 @@ function parseDockerManifest(body, preferredPlatform = {}) {
     if (!requested) {
       return null;
     }
-    const { os: requestedOs, architecture: requestedArchitecture, variant: requestedVariant } = requested;
     const candidates = payload.manifests.filter(entry => (
       entry
       && isDockerDigest(entry.digest)
       && entry.platform
       && typeof entry.platform === "object"
     ));
-    const exact = candidates.find(entry => (
-      String(entry.platform.os || "").toLowerCase() === requestedOs
-      && String(entry.platform.architecture || "").toLowerCase() === requestedArchitecture
-      && (!requestedVariant || String(entry.platform.variant || "").toLowerCase() === requestedVariant)
-    ));
+    const exact = candidates.find(entry => dockerPlatformValuesMatch(requested, entry.platform));
     const selected = exact || (requested.explicit ? null : candidates.find(entry => (
       String(entry.platform.os || "").toLowerCase() === "linux"
       && String(entry.platform.architecture || "").toLowerCase() === "amd64"
@@ -1346,26 +1326,19 @@ function preferredDockerPlatform(value) {
   const preferred = value && typeof value === "object" ? value : {};
   const platform = String(preferred.platform || "").trim().toLowerCase();
   if (platform) {
-    const parts = platform.split("/");
-    if (
-      (parts.length !== 2 && parts.length !== 3)
-      || parts.some(part => !part || !/^[a-z0-9_.-]+$/.test(part))
-    ) {
-      return null;
-    }
+    const parsed = parseDockerPlatform(platform);
+    if (!parsed) return null;
     return {
-      os: parts[0],
-      architecture: parts[1],
-      variant: parts[2] || "",
+      ...parsed,
       explicit: true,
     };
   }
 
   const explicit = Boolean(preferred.os || preferred.architecture || preferred.arch || preferred.variant);
   const os = String(preferred.os || "linux").trim().toLowerCase();
-  const architecture = String(
+  const architecture = normalizeDockerArchitecture(
     preferred.architecture || preferred.arch || "amd64"
-  ).trim().toLowerCase();
+  );
   const variant = String(preferred.variant || "").trim().toLowerCase();
   if (
     !os
@@ -1377,6 +1350,22 @@ function preferredDockerPlatform(value) {
     return null;
   }
   return { os, architecture, variant, explicit };
+}
+
+function dockerPlatformValuesMatch(requested, observedValue) {
+  if (!requested || !observedValue || typeof observedValue !== "object") return false;
+  const observed = {
+    os: String(observedValue.os || "").trim().toLowerCase(),
+    architecture: normalizeDockerArchitecture(observedValue.architecture),
+    variant: String(observedValue.variant || "").trim().toLowerCase(),
+  };
+  return Boolean(
+    observed.os
+    && observed.architecture
+    && observed.os === requested.os
+    && observed.architecture === requested.architecture
+    && dockerVariantMatches(requested, observed)
+  );
 }
 
 function parseNuGetPackageUrl(body, packageName, packageVersion, baseUrl, trustScope) {
@@ -1412,12 +1401,17 @@ function parseNuGetPackageUrl(body, packageName, packageVersion, baseUrl, trustS
 }
 
 function isDockerDigest(value) {
-  return typeof value === "string"
-    && value.length <= 1024
-    && DOCKER_DIGEST_PATTERN.test(value);
+  if (typeof value !== "string" || value.length > 1024) return false;
+  const match = value.match(DOCKER_DIGEST_PATTERN);
+  if (!match) return false;
+  const algorithm = match[1].toLowerCase();
+  const length = match[2].length;
+  if (algorithm === "sha256") return length === 64;
+  if (algorithm === "sha512") return length === 128;
+  return length >= 32 && length <= 512;
 }
 
-function parseDartArchiveUrl(body, version, baseUrl, trustScope) {
+function parseDartArchiveUrl(body, packageName, version, baseUrl, trustScope) {
   let payload;
   try {
     payload = JSON.parse(String(body || ""));
@@ -1425,7 +1419,12 @@ function parseDartArchiveUrl(body, version, baseUrl, trustScope) {
     return null;
   }
 
+  const wantedName = sanitizePackageNameInput(packageName).toLowerCase();
+  const observedName = sanitizePackageNameInput(payload && payload.name).toLowerCase();
   const wantedVersion = String(version || "").trim();
+  if (!wantedName || observedName !== wantedName) {
+    return null;
+  }
   const candidates = [];
 
   if (payload && payload.latest && payload.latest.version === wantedVersion && payload.latest.archive_url) {
@@ -1468,25 +1467,32 @@ function parseComposerDistUrl(body, packageName, version, baseUrl, trustScope) {
   }
 
   const entries = [];
-  const normalizedPackageName = sanitizePackageNameInput(packageName);
+  const normalizedPackageName = sanitizePackageNameInput(packageName).toLowerCase();
 
   if (payload && payload.packages && typeof payload.packages === "object") {
-    if (Array.isArray(payload.packages[normalizedPackageName])) {
-      entries.push(...payload.packages[normalizedPackageName]);
-    } else {
-      for (const value of Object.values(payload.packages)) {
-        if (Array.isArray(value)) {
-          entries.push(...value);
-        }
+    const exactKey = Object.keys(payload.packages).find(key => (
+      sanitizePackageNameInput(key).toLowerCase() === normalizedPackageName
+    ));
+    if (exactKey && Array.isArray(payload.packages[exactKey])) {
+      entries.push(...payload.packages[exactKey]);
+    }
+  } else if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      if (
+        entry
+        && sanitizePackageNameInput(entry.name).toLowerCase() === normalizedPackageName
+      ) {
+        entries.push(entry);
       }
     }
   }
 
-  if (Array.isArray(payload)) {
-    entries.push(...payload);
-  }
-
-  const matchedEntry = entries.find((entry) => entry && entry.version === version);
+  const matchedEntry = entries.find((entry) => (
+    entry
+    && entry.version === version
+    && (!entry.name
+      || sanitizePackageNameInput(entry.name).toLowerCase() === normalizedPackageName)
+  ));
   const distUrl = matchedEntry
     && matchedEntry.dist
     && typeof matchedEntry.dist === "object"
@@ -1498,12 +1504,12 @@ function parseComposerDistUrl(body, packageName, version, baseUrl, trustScope) {
 
 module.exports = {
   buildRegistryTriggerPlan,
-  cargoIndexPath,
-  createRegistryTrustScope,
   dockerCandidateMatchesPlatform,
+  dockerDigestMatches,
   findPythonDistributionUrl,
   formatForDependency,
   isPullUnsupportedFormat,
+  isDockerDigest,
   isTrustedRegistryUrl,
   mavenArtifactFileName,
   normalizeNuGetVersion,
@@ -1515,7 +1521,6 @@ module.exports = {
   parseDartArchiveUrl,
   parseNpmTarballUrl,
   resolveAndValidateDockerBlobRedirectUrl,
-  resolveAndValidateRegistryUrl,
   resolveAndValidateScopedRegistryUrl,
   rubyCandidateMatchesPlatform,
 };

--- a/util/searchQueryBuilder.js
+++ b/util/searchQueryBuilder.js
@@ -14,7 +14,7 @@ class SearchQueryBuilder {
             value = String(value);
         }
 
-        const escaped = value.replace(/(\\|&&|\|\||[+\-!(){}\[\]^"~*?:/|&])/g, (match) => `\\${match}`);
+        const escaped = value.replace(/(\\|&&|\|\||[!(){}\[\]^"~*?:|&])/g, (match) => `\\${match}`);
         return /\s/.test(escaped) ? `"${escaped}"` : escaped;
     }
 

--- a/util/searchQueryBuilder.js
+++ b/util/searchQueryBuilder.js
@@ -1,6 +1,29 @@
 // Builds query strings for the Cloudsmith packages API.
 // Handles escaping, boolean operators, and field-specific syntax.
 
+const MAX_ADVANCED_QUERY_LENGTH = 2048;
+const QUERY_CONTROL_OR_BIDI_PATTERN = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/;
+
+function isValidAdvancedQuery(value) {
+    return typeof value === 'string'
+        && value.trim().length > 0
+        && value.length <= MAX_ADVANCED_QUERY_LENGTH
+        && !QUERY_CONTROL_OR_BIDI_PATTERN.test(value);
+}
+
+function escapeCloudsmithQueryValue(value) {
+    const normalized = typeof value === 'string' ? value : String(value);
+    const escaped = normalized.replace(
+        /(?:^[+-]+|\\|&&|\|\||[!(){}\[\]^$'"~*?:<>|&])/g,
+        (match, offset) => (
+            offset === 0 && /^[+-]+$/.test(match)
+                ? [...match].map((character) => `\\${character}`).join('')
+                : `\\${match}`
+        )
+    );
+    return /\s/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
 class SearchQueryBuilder {
     constructor() {
         this.terms = [];
@@ -10,12 +33,7 @@ class SearchQueryBuilder {
      * Escape a value for use in a Cloudsmith query.
      */
     _escapeValue(value) {
-        if (typeof value !== 'string') {
-            value = String(value);
-        }
-
-        const escaped = value.replace(/(\\|&&|\|\||[!(){}\[\]^"~*?:|&])/g, (match) => `\\${match}`);
-        return /\s/.test(escaped) ? `"${escaped}"` : escaped;
+        return escapeCloudsmithQueryValue(value);
     }
 
     /** Add a name search term. */
@@ -49,8 +67,24 @@ class SearchQueryBuilder {
     }
 
     /**
+     * Add a user-authored Cloudsmith query-language expression after validating
+     * its transport boundary. Operators remain intentional DSL, not field data.
+     */
+    advanced(queryString) {
+        if (typeof queryString !== 'string') {
+            throw new TypeError('Advanced Cloudsmith query must be a string.');
+        }
+        const query = queryString.trim();
+        if (!isValidAdvancedQuery(query)) {
+            throw new TypeError('Advanced Cloudsmith query is invalid.');
+        }
+        this.terms.push(query);
+        return this;
+    }
+
+    /**
      * Add a raw query term (pass-through for advanced users).
-     * @warning Raw input is not escaped; only use trusted, advanced query fragments here.
+     * @warning Raw input is not escaped or validated; only use trusted internal fragments here.
      */
     raw(queryString) {
         if (queryString) {
@@ -61,7 +95,11 @@ class SearchQueryBuilder {
 
     /** Build the final query string. */
     build() {
-        return this.terms.join(' AND ');
+        const query = this.terms.join(' AND ');
+        if (query && !isValidAdvancedQuery(query)) {
+            throw new RangeError('Cloudsmith query exceeds the safe transport boundary.');
+        }
+        return query;
     }
 
     /** Reset the builder for reuse. */
@@ -75,8 +113,11 @@ class SearchQueryBuilder {
      * Returns packages that are not quarantined and have no deny policy violations.
      */
     static permissible(name) {
-        const builder = new SearchQueryBuilder();
-        return `name:${builder._escapeValue(name)} AND NOT status:quarantined AND deny_policy_violated:false`;
+        return new SearchQueryBuilder()
+            .name(name)
+            .raw('NOT status:quarantined')
+            .raw('deny_policy_violated:false')
+            .build();
     }
 
     /**
@@ -87,4 +128,8 @@ class SearchQueryBuilder {
     }
 }
 
-module.exports = { SearchQueryBuilder };
+module.exports = {
+    SearchQueryBuilder,
+    escapeCloudsmithQueryValue,
+    isValidAdvancedQuery,
+};

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -8,14 +8,25 @@ const { PaginatedFetch } = require("./paginatedFetch");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
 const {
   buildRegistryTriggerPlan,
+  dockerCandidateMatchesPlatform,
   findPythonDistributionUrl,
   formatForDependency,
   isPullUnsupportedFormat,
   isTrustedRegistryUrl,
+  mavenArtifactFileName,
+  normalizeNuGetVersion,
+  parseCargoDownloadUrl,
+  parseCargoIndexEntry,
   parseComposerDistUrl,
   parseDartArchiveUrl,
-  resolveAndValidateRegistryUrl,
+  parseDockerManifest,
+  parseNpmTarballUrl,
+  parseNuGetPackageUrl,
+  resolveAndValidateDockerBlobRedirectUrl,
+  resolveAndValidateScopedRegistryUrl,
+  rubyCandidateMatchesPlatform,
 } = require("./registryEndpoints");
+const { getDependencyArtifactKey } = require("./dependencyRecord");
 const {
   canonicalFormat,
   getCloudsmithPackageLookupKeys,
@@ -36,11 +47,26 @@ const MAX_CONCURRENT_PULLS = 5;
 const INITIAL_AUTH_PROBE_CONCURRENCY = 3;
 const MAX_REGISTRY_REDIRECTS = 5;
 const REQUEST_TIMEOUT_MS = 30 * 1000;
+const DOCKER_BLOB_REQUEST_TIMEOUT_MS = 120 * 1000;
+const MAX_REGISTRY_REQUEST_TIMEOUT_MS = 120 * 1000;
 const MAX_REGISTRY_METADATA_BYTES = 1024 * 1024;
 const ABSENCE_LOOKUP_PAGE_SIZE = 100;
 const ABSENCE_LOOKUP_MAX_PAGES = 100;
 const ABSENCE_LOOKUP_MAX_ITEMS = ABSENCE_LOOKUP_PAGE_SIZE * ABSENCE_LOOKUP_MAX_PAGES;
 const ABSENCE_LOOKUP_MAX_FIELD_LENGTH = 2048;
+const DEFAULT_POST_TRIGGER_POLL_DELAYS_MS = Object.freeze([
+  0,
+  1000,
+  2000,
+  4000,
+  8000,
+  15000,
+  30000,
+  60000,
+]);
+const MAX_POST_TRIGGER_POLL_ATTEMPTS = 10;
+const MAX_POST_TRIGGER_POLL_DELAY_MS = 60 * 1000;
+const MAX_POST_TRIGGER_POLL_TOTAL_DELAY_MS = 120 * 1000;
 const REPOSITORY_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u;
 const REPOSITORY_DISPLAY_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/gu;
 const SAFE_REGISTRY_ERROR_MESSAGES = new Set([
@@ -93,6 +119,12 @@ class UpstreamPullService {
     this._checkPackageAbsence = typeof options.checkPackageAbsence === "function"
       ? options.checkPackageAbsence
       : this._checkExactPackageAbsence.bind(this);
+    this._postTriggerPollDelaysMs = normalizePostTriggerPollDelays(
+      options.postTriggerPollDelaysMs
+    );
+    this._postTriggerDelay = typeof options.postTriggerDelay === "function"
+      ? options.postTriggerDelay
+      : this._delayPostTriggerPoll.bind(this);
   }
 
   async run(options) {
@@ -400,16 +432,40 @@ class UpstreamPullService {
       options.signal || null,
       prepared?.account || null
     );
+    const isExecutionCurrent = () => this._isPreparationCurrent(executionOperation);
     const absence = await this._verifyTargetAbsence(
       prepared?.workspace,
       prepared?.repository?.slug,
       prepared?.plan?.pullableDependencies,
       executionOperation
     );
-    if (!absence || !this._isPreparedAccountCurrent(prepared)) {
-      return { canceled: true, stale: true };
+    if (!absence || !isExecutionCurrent()) {
+      return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
     }
     if (!absence.ok) {
+      if (
+        absence.reason === "present"
+        && prepared?.plan?.pullableDependencies?.length === 1
+        && this._isPreparationCurrent(executionOperation)
+      ) {
+        const detail = toPublicPullDetail({
+          dependency: absence.dependency,
+          status: PULL_STATUS.ALREADY_EXISTS,
+          errorMessage: null,
+          networkError: false,
+        });
+        await publishStatus(
+          typeof options.onStatus === "function" ? options.onStatus : null,
+          detail
+        );
+        if (!this._isPreparationCurrent(executionOperation)) {
+          return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
+        }
+        return {
+          canceled: false,
+          pullResult: buildPullResult([detail]),
+        };
+      }
       await this._showWarningMessage(buildAbsenceVerificationFailureMessage(
         absence,
         prepared.workspace,
@@ -417,21 +473,21 @@ class UpstreamPullService {
       ));
       return { canceled: true, absenceUnverified: true };
     }
-    if (!this._isPreparedAccountCurrent(prepared)) {
-      return { canceled: true, stale: true };
+    if (!isExecutionCurrent()) {
+      return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
     }
     let apiKey;
     try {
       apiKey = await this._credentialManager.getApiKey();
     } catch {
-      if (!this._isPreparedAccountCurrent(prepared)) {
-        return { canceled: true, stale: true };
+      if (!isExecutionCurrent()) {
+        return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
       }
       await this._showErrorMessage("Authentication failed. Check your API key in Cloudsmith settings.");
       return null;
     }
-    if (!this._isPreparedAccountCurrent(prepared)) {
-      return { canceled: true, stale: true };
+    if (!isExecutionCurrent()) {
+      return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
     }
     if (!apiKey) {
       const message = this._credentialManager.getCredentialKind?.() === "sso"
@@ -476,9 +532,9 @@ class UpstreamPullService {
     };
 
     const processNext = async () => {
-      if (!this._isPreparedAccountCurrent(prepared)) {
+      if (!isExecutionCurrent()) {
         state.canceled = true;
-        state.stale = true;
+        state.stale = !this._isPreparedAccountCurrent(prepared);
         return;
       }
       if (token && token.isCancellationRequested) {
@@ -504,9 +560,9 @@ class UpstreamPullService {
           errorMessage: null,
         };
         await publishStatus(onStatus, pullingDetail);
-        if (!this._isPreparedAccountCurrent(prepared)) {
+        if (!isExecutionCurrent()) {
           state.canceled = true;
-          state.stale = true;
+          state.stale = !this._isPreparedAccountCurrent(prepared);
           return;
         }
 
@@ -518,7 +574,8 @@ class UpstreamPullService {
             dependency,
             apiKey,
             token,
-            () => this._isPreparedAccountCurrent(prepared)
+            executionOperation.signal,
+            isExecutionCurrent
           );
         } catch {
           result = createPullFailure(
@@ -527,15 +584,34 @@ class UpstreamPullService {
           );
         }
 
-        if (!this._isPreparedAccountCurrent(prepared)) {
+        if (!isExecutionCurrent()) {
           state.canceled = true;
-          state.stale = true;
+          state.stale = !this._isPreparedAccountCurrent(prepared);
           return;
         }
 
         if (result.canceled) {
           state.canceled = true;
           state.stale = result.stale === true;
+          return;
+        }
+
+        if (result.triggerSucceeded === true) {
+          result = await this._verifyPostTriggerPresence(
+            prepared.workspace,
+            prepared.repository.slug,
+            dependency,
+            executionOperation
+          );
+          if (result.canceled) {
+            state.canceled = true;
+            state.stale = result.stale === true;
+            return;
+          }
+        }
+        if (!this._isPreparationCurrent(executionOperation)) {
+          state.canceled = true;
+          state.stale = !this._isPreparedAccountCurrent(prepared);
           return;
         }
 
@@ -591,7 +667,7 @@ class UpstreamPullService {
         && (state.expandedConcurrency || launchedCount < INITIAL_AUTH_PROBE_CONCURRENCY)
         && nextDependencyIndex < queue.length
         && !(token && token.isCancellationRequested)
-        && this._isPreparedAccountCurrent(prepared)
+        && isExecutionCurrent()
         && !state.stopForAuthFailure
       ) {
         launchedCount += 1;
@@ -603,9 +679,9 @@ class UpstreamPullService {
           () => pending.delete(promise)
         );
       }
-      if (!this._isPreparedAccountCurrent(prepared)) {
+      if (!isExecutionCurrent()) {
         state.canceled = true;
-        state.stale = true;
+        state.stale = !this._isPreparedAccountCurrent(prepared);
       }
     };
 
@@ -861,7 +937,10 @@ class UpstreamPullService {
     account,
   }) {
     const format = canonicalFormat(dependency?.format || dependency?.ecosystem);
-    const version = String(dependency?.version || "").trim();
+    const requestedVersion = String(dependency?.version || "").trim();
+    const version = format === "nuget"
+      ? normalizeNuGetVersion(requestedVersion)
+      : requestedVersion;
     const lookupNames = getPackageLookupKeys(
       dependency?.name,
       format,
@@ -887,13 +966,16 @@ class UpstreamPullService {
     const paginatedFetch = new PaginatedFetch(this._api);
 
     for (const lookupName of lookupNames) {
-      const query = new SearchQueryBuilder()
+      const queryBuilder = new SearchQueryBuilder()
         .name(lookupName)
-        .format(format)
-        .version(version)
-        .build();
+        .format(format);
+      if (format !== "docker") {
+        queryBuilder.version(version);
+      }
+      const query = queryBuilder.build();
       let resume = null;
       const knownIdentities = new Set();
+      const accumulatedCandidates = [];
       while (true) {
         if (
           isCancellationRequested(cancellationToken)
@@ -925,7 +1007,8 @@ class UpstreamPullService {
         ) {
           return incompleteAbsenceResult(workspace, repository, true);
         }
-        const present = result.items.some(candidate => (
+        accumulatedCandidates.push(...result.items);
+        const present = accumulatedCandidates.some(candidate => (
           exactPackageCandidateMatches(candidate, dependency, format, version)
         ));
         if (present) {
@@ -957,6 +1040,108 @@ class UpstreamPullService {
       complete: true,
       stale: false,
     };
+  }
+
+  async _verifyPostTriggerPresence(workspace, repository, dependency, operation) {
+    for (const delayMs of this._postTriggerPollDelaysMs) {
+      if (!this._isPreparationCurrent(operation)) {
+        return {
+          canceled: true,
+          stale: !this._isAbsenceAccountCurrent(operation?.account),
+        };
+      }
+      if (delayMs > 0) {
+        try {
+          await this._postTriggerDelay(delayMs, operation);
+        } catch {
+          // Delay failures are treated as an inconclusive verification attempt.
+        }
+      }
+      if (!this._isPreparationCurrent(operation)) {
+        return {
+          canceled: true,
+          stale: !this._isAbsenceAccountCurrent(operation?.account),
+        };
+      }
+
+      let result;
+      try {
+        result = await this._checkPackageAbsence({
+          workspace,
+          repository,
+          dependency,
+          cancellationToken: operation.cancellationToken,
+          signal: operation.signal,
+          account: operation.account,
+        });
+      } catch {
+        result = null;
+      }
+      if (!this._isPreparationCurrent(operation)) {
+        return {
+          canceled: true,
+          stale: !this._isAbsenceAccountCurrent(operation?.account),
+        };
+      }
+
+      const scoped = result
+        && result.workspace === workspace
+        && result.repository === repository
+        && result.stale !== true;
+      if (
+        scoped
+        && result.present === true
+        && result.absent === false
+      ) {
+        return {
+          dependency,
+          status: PULL_STATUS.CACHED,
+          errorMessage: null,
+          networkError: false,
+        };
+      }
+    }
+
+    return createPullFailure(
+      dependency,
+      "Cloudsmith did not confirm the package in the target repository after the upstream request completed."
+    );
+  }
+
+  _delayPostTriggerPoll(delayMs, operation) {
+    if (delayMs <= 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      let settled = false;
+      let timeoutHandle = null;
+      const disposables = [];
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        if (timeoutHandle !== null) this._clearTimeout(timeoutHandle);
+        for (const disposable of disposables.reverse()) disposable?.dispose?.();
+        if (operation?.signal) {
+          operation.signal.removeEventListener("abort", finish);
+        }
+        resolve();
+      };
+
+      if (typeof operation?.cancellationToken?.onCancellationRequested === "function") {
+        disposables.push(operation.cancellationToken.onCancellationRequested(finish));
+      }
+      if (typeof this._connectionManager?.onDidChange === "function") {
+        disposables.push(this._connectionManager.onDidChange(() => {
+          if (!this._isPreparationCurrent(operation)) finish();
+        }));
+      }
+      if (operation?.signal) {
+        operation.signal.addEventListener("abort", finish, { once: true });
+      }
+      if (!this._isPreparationCurrent(operation)) {
+        finish();
+        return;
+      }
+      timeoutHandle = this._setTimeout(finish, delayMs);
+    });
   }
 
   _isAbsenceAccountCurrent(account) {
@@ -996,7 +1181,7 @@ class UpstreamPullService {
       || Boolean(prepared?.account && isAccountCurrent(this._connectionManager, prepared.account));
   }
 
-  async _pullDependency(workspace, repo, dependency, apiKey, token, isCurrent = null) {
+  async _pullDependency(workspace, repo, dependency, apiKey, token, signal = null, isCurrent = null) {
     const plan = buildRegistryTriggerPlan(workspace, repo, dependency);
     const format = formatForDependency(dependency);
 
@@ -1017,7 +1202,7 @@ class UpstreamPullService {
       plan.request,
       apiKey,
       token,
-      { captureBody: plan.strategy !== "direct", isCurrent }
+      { captureBody: plan.strategy !== "direct", isCurrent, signal }
     );
     if (metadataAttempt.canceled) {
       return metadataAttempt;
@@ -1039,17 +1224,106 @@ class UpstreamPullService {
       return mapRegistryAttempt(dependency, metadataAttempt, format);
     }
 
+    if (plan.strategy === "docker-manifest") {
+      return this._pullDockerManifest(
+        plan,
+        dependency,
+        metadataAttempt,
+        apiKey,
+        token,
+        signal,
+        isCurrent
+      );
+    }
+
+    if (plan.strategy === "maven-artifact") {
+      if (plan.artifactRequest.url === plan.request.url) {
+        return mapRegistryAttempt(dependency, metadataAttempt, format);
+      }
+      const artifactAttempt = await this._requestRegistry(
+        plan.artifactRequest,
+        apiKey,
+        token,
+        { captureBody: false, isCurrent, signal }
+      );
+      if (artifactAttempt.canceled) return artifactAttempt;
+      return mapRegistryAttempt(dependency, artifactAttempt, format);
+    }
+
     let artifactUrl = null;
     if (plan.strategy === "python-simple-index") {
-      artifactUrl = findPythonDistributionUrl(metadataAttempt.body, dependency.version, plan.request.url);
+      artifactUrl = findPythonDistributionUrl(
+        metadataAttempt.body,
+        plan.packageName || dependency.name,
+        dependency.version,
+        plan.request.url,
+        plan.trustScope
+      );
+    } else if (plan.strategy === "npm-packument") {
+      artifactUrl = parseNpmTarballUrl(
+        metadataAttempt.body,
+        plan.packageName || dependency.name,
+        dependency.version,
+        plan.request.url,
+        plan.trustScope
+      );
+    } else if (plan.strategy === "cargo-sparse-index") {
+      const indexEntry = parseCargoIndexEntry(
+        metadataAttempt.body,
+        plan.crateName || dependency.name,
+        dependency.version
+      );
+      if (!indexEntry) {
+        return {
+          dependency,
+          status: PULL_STATUS.NOT_FOUND,
+          errorMessage: missingArtifactMessage(plan.strategy, dependency.version),
+          networkError: false,
+        };
+      }
+
+      const configAttempt = await this._requestRegistry(
+        plan.configRequest,
+        apiKey,
+        token,
+        { captureBody: true, isCurrent, signal }
+      );
+      if (configAttempt.canceled) {
+        return configAttempt;
+      }
+      if (configAttempt.statusCode < 200 || configAttempt.statusCode >= 300) {
+        return mapRegistryAttempt(dependency, configAttempt, format);
+      }
+      artifactUrl = parseCargoDownloadUrl(
+        configAttempt.body,
+        indexEntry.name,
+        indexEntry.version,
+        indexEntry.checksum,
+        plan.configRequest.url,
+        plan.trustScope
+      );
     } else if (plan.strategy === "dart-api") {
-      artifactUrl = parseDartArchiveUrl(metadataAttempt.body, dependency.version, plan.request.url);
+      artifactUrl = parseDartArchiveUrl(
+        metadataAttempt.body,
+        dependency.version,
+        plan.request.url,
+        plan.trustScope
+      );
     } else if (plan.strategy === "composer-p2") {
       artifactUrl = parseComposerDistUrl(
         metadataAttempt.body,
         plan.packageName || dependency.name,
         dependency.version,
-        plan.request.url
+        plan.request.url,
+        plan.trustScope
+      );
+    } else if (plan.strategy === "nuget-service-index") {
+      artifactUrl = parseNuGetPackageUrl(
+        metadataAttempt.body,
+        plan.packageName,
+        plan.packageVersion,
+        plan.request.url,
+        plan.trustScope
       );
     }
 
@@ -1070,11 +1344,12 @@ class UpstreamPullService {
       {
         method: "GET",
         url: artifactUrl,
+        authScheme: plan.request.authScheme,
         headers: {},
       },
       apiKey,
       token,
-      { captureBody: false, isCurrent }
+      { captureBody: false, isCurrent, signal }
     );
 
     if (artifactAttempt.canceled) {
@@ -1084,8 +1359,79 @@ class UpstreamPullService {
     return mapRegistryAttempt(dependency, artifactAttempt, format);
   }
 
+  async _pullDockerManifest(plan, dependency, initialAttempt, apiKey, token, signal, isCurrent) {
+    let parsed = parseDockerManifest(initialAttempt.body, dependency?.qualifiers || {});
+    if (!parsed) {
+      return {
+        dependency,
+        status: PULL_STATUS.NOT_FOUND,
+        errorMessage: "No usable Docker image manifest was found upstream.",
+        networkError: false,
+      };
+    }
+
+    if (parsed.manifestDigest) {
+      const manifestAttempt = await this._requestRegistry(
+        {
+          method: "GET",
+          url: `${plan.imageBaseUrl}/manifests/${encodeURIComponent(parsed.manifestDigest)}`,
+          headers: { Accept: plan.request.headers.Accept },
+        },
+        apiKey,
+        token,
+        { captureBody: true, isCurrent, signal }
+      );
+      if (manifestAttempt.canceled) return manifestAttempt;
+      if (manifestAttempt.statusCode < 200 || manifestAttempt.statusCode >= 300) {
+        return mapRegistryAttempt(dependency, manifestAttempt, "docker");
+      }
+      parsed = parseDockerManifest(manifestAttempt.body, dependency?.qualifiers || {});
+      if (!parsed || parsed.manifestDigest || parsed.blobDigests.length === 0) {
+        return {
+          dependency,
+          status: PULL_STATUS.NOT_FOUND,
+          errorMessage: "No usable Docker image manifest was found upstream.",
+          networkError: false,
+        };
+      }
+    }
+
+    let lastAttempt = initialAttempt;
+    for (const digest of parsed.blobDigests) {
+      if (isCurrent && !isCurrent()) {
+        return { canceled: true, stale: true };
+      }
+      lastAttempt = await this._requestRegistry(
+        {
+          method: "GET",
+          url: `${plan.imageBaseUrl}/blobs/${encodeURIComponent(digest)}`,
+          redirectPolicy: "docker-blob",
+          headers: {},
+        },
+        apiKey,
+        token,
+        {
+          captureBody: false,
+          isCurrent,
+          signal,
+          timeoutMs: DOCKER_BLOB_REQUEST_TIMEOUT_MS,
+        }
+      );
+      if (lastAttempt.canceled) return lastAttempt;
+      if (lastAttempt.statusCode < 200 || lastAttempt.statusCode >= 300) {
+        return mapRegistryAttempt(dependency, lastAttempt, "docker");
+      }
+    }
+
+    return mapRegistryAttempt(dependency, lastAttempt, "docker");
+  }
+
   async _requestRegistry(request, apiKey, token, options = {}) {
     const isCurrent = typeof options.isCurrent === "function" ? options.isCurrent : null;
+    const externalSignal = options.signal || null;
+    if (externalSignal?.aborted) {
+      return { canceled: true };
+    }
     if (isCurrent && !isCurrent()) {
       return { canceled: true, stale: true };
     }
@@ -1100,13 +1446,18 @@ class UpstreamPullService {
     };
     const timeoutHandle = this._setTimeout(() => {
       abort("timeout");
-    }, REQUEST_TIMEOUT_MS);
+    }, normalizeRegistryRequestTimeout(options.timeoutMs));
 
     const cancellationDisposable = token && typeof token.onCancellationRequested === "function"
       ? token.onCancellationRequested(() => abort("cancelled"))
       : null;
     if (token && token.isCancellationRequested) {
       abort("cancelled");
+    }
+    const abortFromSignal = () => abort("cancelled");
+    if (externalSignal) {
+      externalSignal.addEventListener("abort", abortFromSignal, { once: true });
+      if (externalSignal.aborted) abortFromSignal();
     }
 
     try {
@@ -1125,7 +1476,11 @@ class UpstreamPullService {
         ? await discardRegistryBody(response, controller.signal)
         : await readRegistryBody(response, MAX_REGISTRY_METADATA_BYTES, controller.signal);
 
-      if (abortCause === "cancelled" || (token && token.isCancellationRequested)) {
+      if (
+        abortCause === "cancelled"
+        || (token && token.isCancellationRequested)
+        || externalSignal?.aborted
+      ) {
         return { canceled: true };
       }
       if (abortCause === "timeout" || controller.signal.aborted) {
@@ -1140,7 +1495,11 @@ class UpstreamPullService {
       if (isCurrent && !isCurrent()) {
         return { canceled: true, stale: true };
       }
-      if (abortCause === "cancelled" || (token && token.isCancellationRequested)) {
+      if (
+        abortCause === "cancelled"
+        || (token && token.isCancellationRequested)
+        || externalSignal?.aborted
+      ) {
         return { canceled: true };
       }
 
@@ -1157,11 +1516,18 @@ class UpstreamPullService {
       if (cancellationDisposable && typeof cancellationDisposable.dispose === "function") {
         cancellationDisposable.dispose();
       }
+      if (externalSignal) {
+        externalSignal.removeEventListener("abort", abortFromSignal);
+      }
     }
   }
 
   async _fetchRegistryResponse(request, apiKey, signal, redirectCount, isCurrent = null) {
-    if (!request || !isTrustedRegistryUrl(request.url)) {
+    const sendCredentials = request?.sendCredentials !== false;
+    const isCredentiallessDockerBlobRequest = request?.redirectPolicy === "docker-blob"
+      && !sendCredentials
+      && resolveAndValidateDockerBlobRedirectUrl(request.url, request.url) === request.url;
+    if (!request || (!isTrustedRegistryUrl(request.url) && !isCredentiallessDockerBlobRequest)) {
       throw new Error("Refused to send Cloudsmith credentials to an untrusted registry host.");
     }
     if (isCurrent && !isCurrent()) {
@@ -1171,7 +1537,9 @@ class UpstreamPullService {
     const fetchResult = await this._awaitRegistryAbortable(this._fetchImpl(request.url, {
       method: request.method || "GET",
       headers: {
-        Authorization: buildBasicAuthHeader(apiKey),
+        ...(sendCredentials
+          ? { Authorization: buildRegistryAuthHeader(apiKey, request.authScheme) }
+          : {}),
         ...buildRegistryRequestHeaders(request.headers),
       },
       redirect: "manual",
@@ -1197,10 +1565,18 @@ class UpstreamPullService {
     const location = response.headers && typeof response.headers.get === "function"
       ? response.headers.get("location")
       : "";
-    const redirectUrl = resolveAndValidateRegistryUrl(location, request.url);
-    const currentUrl = new URL(request.url);
-    const nextUrl = redirectUrl ? new URL(redirectUrl) : null;
-    if (!nextUrl || nextUrl.hostname !== currentUrl.hostname) {
+    let redirectUrl = resolveAndValidateScopedRegistryUrl(
+      location,
+      request.url,
+      null,
+      { allowQuery: true }
+    );
+    let redirectSendsCredentials = sendCredentials;
+    if (!redirectUrl && request.redirectPolicy === "docker-blob") {
+      redirectUrl = resolveAndValidateDockerBlobRedirectUrl(location, request.url);
+      redirectSendsCredentials = false;
+    }
+    if (!redirectUrl) {
       await cancelRegistryBody(response);
       throw new Error("Registry redirect target was rejected.");
     }
@@ -1215,6 +1591,7 @@ class UpstreamPullService {
       {
         ...request,
         url: redirectUrl,
+        sendCredentials: redirectSendsCredentials,
       },
       apiKey,
       signal,
@@ -1309,16 +1686,39 @@ function exactPackageCandidateIdentity(candidate) {
 
 function exactPackageCandidateMatches(candidate, dependency, format, version) {
   if (
-    candidate.version !== version
-    || canonicalFormat(candidate.format) !== format
+    canonicalFormat(candidate.format) !== format
   ) return false;
+  if (format === "docker") {
+    const versionTags = Array.isArray(candidate?.tags?.version)
+      ? candidate.tags.version
+      : [];
+    const requestedDigest = String(
+      dependency?.qualifiers?.digest || dependency?.digest || ""
+    ).trim().toLowerCase();
+    const observedDigest = String(candidate.version || "").trim().toLowerCase();
+    const digestMatches = requestedDigest
+      && observedDigest.replace(/^[a-z0-9_+.-]+:/, "")
+        === requestedDigest.replace(/^[a-z0-9_+.-]+:/, "");
+    const tagMatches = versionTags.some(tag => String(tag) === version);
+    if (requestedDigest ? !digestMatches : !tagMatches) return false;
+    if (!dockerCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)) {
+      return false;
+    }
+  } else if (
+    format === "nuget"
+      ? normalizeNuGetVersion(candidate.version) !== normalizeNuGetVersion(version)
+      : candidate.version !== version
+  ) {
+    return false;
+  }
   const dependencyName = String(dependency?.name || "").trim();
   if (!dependencyName) return false;
 
   if (format === "maven" && dependencyName.includes(":")) {
     const expectedName = normalizePackageName(dependencyName, format);
     return getCloudsmithPackageLookupKeys(candidate, format)
-      .some(key => key.includes(":") && key === expectedName);
+      .some(key => key.includes(":") && key === expectedName)
+      && mavenCandidateContainsRequestedArtifact(candidate, dependency);
   }
   if (format === "swift") {
     const candidateIdentifiers = candidate.identifiers
@@ -1335,22 +1735,11 @@ function exactPackageCandidateMatches(candidate, dependency, format, version) {
     );
     return Boolean(expected && observed && expected === observed);
   }
-  if (format === "ruby" && dependency?.qualifiers?.platform) {
-    const candidateIdentifiers = candidate.identifiers
-      && typeof candidate.identifiers === "object"
-      ? candidate.identifiers
-      : {};
-    const observedPlatform = String(
-      candidate.platform
-      || candidate.architecture
-      || candidateIdentifiers.platform
-      || candidateIdentifiers.architecture
-      || ""
-    ).trim();
-    if (
-      observedPlatform
-      && observedPlatform.toLowerCase() !== String(dependency.qualifiers.platform).toLowerCase()
-    ) return false;
+  if (
+    format === "ruby"
+    && !rubyCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)
+  ) {
+    return false;
   }
 
   const expectedKeys = getPackageLookupKeys(
@@ -1360,6 +1749,22 @@ function exactPackageCandidateMatches(candidate, dependency, format, version) {
   );
   const observedKeys = new Set(getCloudsmithPackageLookupKeys(candidate, format));
   return expectedKeys.some(key => observedKeys.has(key));
+}
+
+function mavenCandidateContainsRequestedArtifact(candidate, dependency) {
+  const qualifiers = dependency?.qualifiers;
+  const hasArtifactQualifier = qualifiers
+    && typeof qualifiers === "object"
+    && (Object.prototype.hasOwnProperty.call(qualifiers, "classifier")
+      || Object.prototype.hasOwnProperty.call(qualifiers, "type"));
+  if (!hasArtifactQualifier) return true;
+  const expectedFileName = mavenArtifactFileName(dependency);
+  if (!expectedFileName || !Array.isArray(candidate?.files)) return false;
+  return candidate.files.some(file => (
+    file
+    && typeof file === "object"
+    && String(file.filename || file.name || file.path || "").split("/").pop() === expectedFileName
+  ));
 }
 
 function incompleteAbsenceResult(workspace, repository, stale = false) {
@@ -1855,6 +2260,24 @@ function createResultCounts(total) {
   };
 }
 
+function buildPullResult(details) {
+  const safeDetails = Array.isArray(details) ? details : [];
+  const counts = createResultCounts(safeDetails.length);
+  for (const detail of safeDetails) updateResultCounts(counts, detail);
+  return {
+    total: counts.total,
+    cached: counts.cached,
+    alreadyExisted: counts.alreadyExisted,
+    notFound: counts.notFound,
+    formatMismatched: counts.formatMismatched,
+    errors: counts.errors,
+    networkErrors: counts.networkErrors,
+    authFailed: counts.authFailed,
+    skipped: counts.skipped,
+    details: safeDetails,
+  };
+}
+
 function updateResultCounts(counts, result) {
   counts.completed += 1;
   switch (result.status) {
@@ -1898,21 +2321,17 @@ function recomputeResultCounts(counts, results) {
 }
 
 function mapRegistryAttempt(dependency, attempt, format) {
-  if (attempt.statusCode >= 200 && attempt.statusCode < 300) {
+  if (
+    (attempt.statusCode >= 200 && attempt.statusCode < 300)
+    || attempt.statusCode === 304
+    || attempt.statusCode === 409
+  ) {
     return {
       dependency,
-      status: PULL_STATUS.CACHED,
+      status: PULL_STATUS.PENDING,
       errorMessage: null,
       networkError: false,
-    };
-  }
-
-  if (attempt.statusCode === 304 || attempt.statusCode === 409) {
-    return {
-      dependency,
-      status: PULL_STATUS.ALREADY_EXISTS,
-      errorMessage: null,
-      networkError: false,
+      triggerSucceeded: true,
     };
   }
 
@@ -1970,6 +2389,10 @@ function missingArtifactMessage(strategy, version) {
   switch (strategy) {
     case "python-simple-index":
       return `No distribution file was found for version ${version}.`;
+    case "npm-packument":
+      return `No npm tarball URL was found for version ${version}.`;
+    case "cargo-sparse-index":
+      return `No downloadable Cargo crate was found for version ${version}.`;
     case "dart-api":
       return `No Dart archive URL was found for version ${version}.`;
     case "composer-p2":
@@ -2014,8 +2437,35 @@ function buildBasicAuthHeader(apiKey) {
   return `Basic ${Buffer.from(`token:${apiKey}`).toString("base64")}`;
 }
 
+function buildRegistryAuthHeader(apiKey, scheme) {
+  return String(scheme || "").toLowerCase() === "bearer"
+    ? `Bearer ${apiKey}`
+    : buildBasicAuthHeader(apiKey);
+}
+
+function normalizeRegistryRequestTimeout(value) {
+  const timeout = Number(value);
+  return Number.isInteger(timeout) && timeout > 0
+    ? Math.min(timeout, MAX_REGISTRY_REQUEST_TIMEOUT_MS)
+    : REQUEST_TIMEOUT_MS;
+}
+
 function isRedirectStatus(statusCode) {
-  return Number.isInteger(statusCode) && statusCode >= 300 && statusCode < 400;
+  return [301, 302, 303, 307, 308].includes(statusCode);
+}
+
+function normalizePostTriggerPollDelays(value) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_POST_TRIGGER_POLL_ATTEMPTS) {
+    return DEFAULT_POST_TRIGGER_POLL_DELAYS_MS;
+  }
+  const delays = value.map(delay => Number(delay));
+  if (
+    delays.some(delay => !Number.isInteger(delay) || delay < 0 || delay > MAX_POST_TRIGGER_POLL_DELAY_MS)
+    || delays.reduce((total, delay) => total + delay, 0) > MAX_POST_TRIGGER_POLL_TOTAL_DELAY_MS
+  ) {
+    return DEFAULT_POST_TRIGGER_POLL_DELAYS_MS;
+  }
+  return Object.freeze(delays);
 }
 
 function safeHost(url) {
@@ -2047,11 +2497,15 @@ function pullDependencyKey(dependency) {
   const format = String(
     canonicalFormat(dependency && (dependency.format || dependency.ecosystem)) || ""
   ).toLowerCase();
-  return [
+  return getDependencyArtifactKey({
+    ...dependency,
+    ecosystem: format,
     format,
-    normalizePackageName(dependency && dependency.name, format),
-    String(dependency && dependency.version || "").trim(),
-  ].join(":");
+    normalizedName: normalizePackageName(dependency && dependency.name, format),
+    resolvedVersion: String(
+      dependency && (dependency.resolvedVersion || dependency.version) || ""
+    ).trim(),
+  });
 }
 
 function singleFormatPullHeader(dependencies, repositoryLabel) {

--- a/util/upstreamPullService.js
+++ b/util/upstreamPullService.js
@@ -1,5 +1,6 @@
 // Copyright 2026 Cloudsmith Ltd. All rights reserved.
 const vscode = require("vscode");
+const { fromApiPackageRecord } = require("../domain/packageAdapters");
 const { CloudsmithAPI } = require("./cloudsmithAPI");
 const { CredentialManager } = require("./credentialManager");
 const { apiEndpoint } = require("./apiEndpoint");
@@ -7,8 +8,13 @@ const { fetchWorkspaceRepositories } = require("./workspaceRepositoryFetcher");
 const { PaginatedFetch } = require("./paginatedFetch");
 const { SearchQueryBuilder } = require("./searchQueryBuilder");
 const {
+  packageCandidateEvidenceShapeIsValid,
+  qualifierEvidenceIsIncomplete,
+} = require("./exactPackageEvidence");
+const {
   buildRegistryTriggerPlan,
   dockerCandidateMatchesPlatform,
+  dockerDigestMatches,
   findPythonDistributionUrl,
   formatForDependency,
   isPullUnsupportedFormat,
@@ -473,6 +479,7 @@ class UpstreamPullService {
       ));
       return { canceled: true, absenceUnverified: true };
     }
+    executionOperation.absenceProofs = absence.proofs;
     if (!isExecutionCurrent()) {
       return { canceled: true, stale: !this._isPreparedAccountCurrent(prepared) };
     }
@@ -503,6 +510,7 @@ class UpstreamPullService {
     const queue = prepared.plan.pullableDependencies.slice();
     let nextDependencyIndex = 0;
     const details = [];
+    const verificationReceipts = new Map();
     const counts = createResultCounts(prepared.plan.pullableDependencies.length);
     const state = {
       authFailureCount: 0,
@@ -601,7 +609,8 @@ class UpstreamPullService {
             prepared.workspace,
             prepared.repository.slug,
             dependency,
-            executionOperation
+            executionOperation,
+            { dockerPlatformVerified: result.dockerPlatformVerified === true }
           );
           if (result.canceled) {
             state.canceled = true;
@@ -613,6 +622,13 @@ class UpstreamPullService {
           state.canceled = true;
           state.stale = !this._isPreparedAccountCurrent(prepared);
           return;
+        }
+
+        if (result.coverageReceipt) {
+          verificationReceipts.set(
+            getDependencyArtifactKey(dependency),
+            Object.freeze({ ...result.coverageReceipt })
+          );
         }
 
         result = toPublicPullDetail(result);
@@ -723,6 +739,7 @@ class UpstreamPullService {
 
     return {
       canceled: false,
+      ...(verificationReceipts.size > 0 ? { verificationReceipts } : {}),
       pullResult: {
         total: counts.total,
         cached: counts.cached,
@@ -892,6 +909,7 @@ class UpstreamPullService {
       || dependencies.length === 0
     ) return null;
 
+    const proofs = new Map();
     for (const dependency of dependencies) {
       if (!this._isPreparationCurrent(operation)) return null;
       let result;
@@ -924,8 +942,12 @@ class UpstreamPullService {
           dependency,
         };
       }
+      proofs.set(
+        getDependencyArtifactKey(dependency),
+        new Set(Array.isArray(result.observedIdentities) ? result.observedIdentities : [])
+      );
     }
-    return { ok: true };
+    return { ok: true, proofs };
   }
 
   async _checkExactPackageAbsence({
@@ -935,6 +957,8 @@ class UpstreamPullService {
     cancellationToken,
     signal,
     account,
+    baselineIdentities,
+    dockerPlatformVerified = false,
   }) {
     const format = canonicalFormat(dependency?.format || dependency?.ecosystem);
     const requestedVersion = String(dependency?.version || "").trim();
@@ -965,6 +989,8 @@ class UpstreamPullService {
     }
     const paginatedFetch = new PaginatedFetch(this._api);
 
+    let incompleteQualifierEvidence = false;
+    const observedIdentities = new Set();
     for (const lookupName of lookupNames) {
       const queryBuilder = new SearchQueryBuilder()
         .name(lookupName)
@@ -972,7 +998,12 @@ class UpstreamPullService {
       if (format !== "docker") {
         queryBuilder.version(version);
       }
-      const query = queryBuilder.build();
+      let query;
+      try {
+        query = queryBuilder.build();
+      } catch {
+        return incompleteAbsenceResult(workspace, repository);
+      }
       let resume = null;
       const knownIdentities = new Set();
       const accumulatedCandidates = [];
@@ -1008,9 +1039,22 @@ class UpstreamPullService {
           return incompleteAbsenceResult(workspace, repository, true);
         }
         accumulatedCandidates.push(...result.items);
-        const present = accumulatedCandidates.some(candidate => (
-          exactPackageCandidateMatches(candidate, dependency, format, version)
-        ));
+        for (const candidate of result.items) {
+          observedIdentities.add(exactPackageCandidateIdentity(candidate));
+        }
+        if (accumulatedCandidates.some(candidate => (
+          exactPackageCandidateEvidenceIsIncomplete(candidate, dependency, format, version)
+        ))) {
+          incompleteQualifierEvidence = true;
+        }
+        const present = exactPackageCandidateCollectionMatches(
+          accumulatedCandidates,
+          dependency,
+          format,
+          version,
+          baselineIdentities,
+          dockerPlatformVerified
+        );
         if (present) {
           return {
             workspace,
@@ -1032,6 +1076,10 @@ class UpstreamPullService {
       }
     }
 
+    if (incompleteQualifierEvidence) {
+      return incompleteAbsenceResult(workspace, repository);
+    }
+
     return {
       workspace,
       repository,
@@ -1039,10 +1087,17 @@ class UpstreamPullService {
       present: false,
       complete: true,
       stale: false,
+      observedIdentities: [...observedIdentities],
     };
   }
 
-  async _verifyPostTriggerPresence(workspace, repository, dependency, operation) {
+  async _verifyPostTriggerPresence(
+    workspace,
+    repository,
+    dependency,
+    operation,
+    verificationReceipt = {}
+  ) {
     for (const delayMs of this._postTriggerPollDelaysMs) {
       if (!this._isPreparationCurrent(operation)) {
         return {
@@ -1073,6 +1128,10 @@ class UpstreamPullService {
           cancellationToken: operation.cancellationToken,
           signal: operation.signal,
           account: operation.account,
+          baselineIdentities: operation.absenceProofs?.get(
+            getDependencyArtifactKey(dependency)
+          ),
+          dockerPlatformVerified: verificationReceipt.dockerPlatformVerified === true,
         });
       } catch {
         result = null;
@@ -1093,11 +1152,21 @@ class UpstreamPullService {
         && result.present === true
         && result.absent === false
       ) {
+        const format = canonicalFormat(dependency?.format || dependency?.ecosystem);
+        const coverageReceipt = {
+          ...(format === "docker" && verificationReceipt.dockerPlatformVerified === true
+            ? { dockerPlatformVerified: true }
+            : {}),
+          ...(format === "swift" && String(dependency?.qualifiers?.scope || "").trim()
+            ? { swiftScopeVerified: true }
+            : {}),
+        };
         return {
           dependency,
           status: PULL_STATUS.CACHED,
           errorMessage: null,
           networkError: false,
+          ...(Object.keys(coverageReceipt).length > 0 ? { coverageReceipt } : {}),
         };
       }
     }
@@ -1236,20 +1305,6 @@ class UpstreamPullService {
       );
     }
 
-    if (plan.strategy === "maven-artifact") {
-      if (plan.artifactRequest.url === plan.request.url) {
-        return mapRegistryAttempt(dependency, metadataAttempt, format);
-      }
-      const artifactAttempt = await this._requestRegistry(
-        plan.artifactRequest,
-        apiKey,
-        token,
-        { captureBody: false, isCurrent, signal }
-      );
-      if (artifactAttempt.canceled) return artifactAttempt;
-      return mapRegistryAttempt(dependency, artifactAttempt, format);
-    }
-
     let artifactUrl = null;
     if (plan.strategy === "python-simple-index") {
       artifactUrl = findPythonDistributionUrl(
@@ -1305,6 +1360,7 @@ class UpstreamPullService {
     } else if (plan.strategy === "dart-api") {
       artifactUrl = parseDartArchiveUrl(
         metadataAttempt.body,
+        plan.packageName || dependency.name,
         dependency.version,
         plan.request.url,
         plan.trustScope
@@ -1370,6 +1426,7 @@ class UpstreamPullService {
       };
     }
 
+    let dockerPlatformVerified = false;
     if (parsed.manifestDigest) {
       const manifestAttempt = await this._requestRegistry(
         {
@@ -1394,6 +1451,7 @@ class UpstreamPullService {
           networkError: false,
         };
       }
+      dockerPlatformVerified = Boolean(dependency?.qualifiers?.platform);
     }
 
     let lastAttempt = initialAttempt;
@@ -1423,7 +1481,10 @@ class UpstreamPullService {
       }
     }
 
-    return mapRegistryAttempt(dependency, lastAttempt, "docker");
+    const result = mapRegistryAttempt(dependency, lastAttempt, "docker");
+    return result.triggerSucceeded && dockerPlatformVerified
+      ? { ...result, dockerPlatformVerified: true }
+      : result;
   }
 
   async _requestRegistry(request, apiKey, token, options = {}) {
@@ -1650,7 +1711,7 @@ function isBoundedLookupField(value) {
     && value.length > 0
     && value.length <= ABSENCE_LOOKUP_MAX_FIELD_LENGTH
     && value.trim() === value
-    && !/[\u0000-\u001f\u007f]/u.test(value);
+    && !REPOSITORY_CONTROL_OR_BIDI.test(value);
 }
 
 function isExactPackageCandidateArray(value, workspace, repository) {
@@ -1665,23 +1726,35 @@ function isExactPackageCandidateArray(value, workspace, repository) {
       && isBoundedLookupField(candidate.name)
       && isBoundedLookupField(candidate.version)
       && isBoundedLookupField(candidate.format)
+      && isBoundedLookupField(exactPackageCandidateIdentifier(candidate))
+      && packageCandidateEvidenceShapeIsValid(candidate)
       && Boolean(exactPackageCandidateIdentity(candidate))
     ));
 }
 
 function exactPackageCandidateIdentity(candidate) {
   if (!candidate || typeof candidate !== "object") return null;
+  const packageIdentifier = exactPackageCandidateIdentifier(candidate);
+  if (!packageIdentifier) return null;
   const stableIdentifier = [
     candidate.namespace,
     candidate.repository,
     candidate.format,
     candidate.name,
     candidate.version,
-    candidate.slug_perm || candidate.identifier || "",
+    packageIdentifier,
   ];
   return stableIdentifier.every(value => typeof value === "string")
     ? JSON.stringify(stableIdentifier)
     : null;
+}
+
+function exactPackageCandidateIdentifier(candidate) {
+  try {
+    return fromApiPackageRecord(candidate).packageIdentifier;
+  } catch {
+    return null;
+  }
 }
 
 function exactPackageCandidateMatches(candidate, dependency, format, version) {
@@ -1697,13 +1770,9 @@ function exactPackageCandidateMatches(candidate, dependency, format, version) {
     ).trim().toLowerCase();
     const observedDigest = String(candidate.version || "").trim().toLowerCase();
     const digestMatches = requestedDigest
-      && observedDigest.replace(/^[a-z0-9_+.-]+:/, "")
-        === requestedDigest.replace(/^[a-z0-9_+.-]+:/, "");
+      && dockerDigestMatches(observedDigest, requestedDigest);
     const tagMatches = versionTags.some(tag => String(tag) === version);
     if (requestedDigest ? !digestMatches : !tagMatches) return false;
-    if (!dockerCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)) {
-      return false;
-    }
   } else if (
     format === "nuget"
       ? normalizeNuGetVersion(candidate.version) !== normalizeNuGetVersion(version)
@@ -1751,13 +1820,76 @@ function exactPackageCandidateMatches(candidate, dependency, format, version) {
   return expectedKeys.some(key => observedKeys.has(key));
 }
 
+function exactPackageCandidateCollectionMatches(
+  candidates,
+  dependency,
+  format,
+  version,
+  baselineIdentities,
+  dockerPlatformVerified
+) {
+  const requestedPlatform = format === "docker"
+    ? String(dependency && dependency.qualifiers && dependency.qualifiers.platform || "").trim()
+    : "";
+  const identityCandidate = candidates.find(candidate => (
+    exactPackageCandidateMatches(candidate, dependency, format, version)
+    && (
+      !requestedPlatform
+      || dockerPlatformVerified === true
+      || dockerCandidateMatchesPlatform(candidate, requestedPlatform)
+    )
+  ));
+  if (identityCandidate) return true;
+  if (format === "swift" && baselineIdentities instanceof Set) {
+    return candidates.some(candidate => (
+      !baselineIdentities.has(exactPackageCandidateIdentity(candidate))
+      && exactPackageCandidateBaseNameMatches(candidate, dependency, format)
+      && candidate.version === version
+      && qualifierEvidenceIsIncomplete(candidate, dependency, format)
+    ));
+  }
+  return false;
+}
+
+function exactPackageCandidateEvidenceIsIncomplete(candidate, dependency, format, version) {
+  if (!exactPackageCandidateBaseNameMatches(candidate, dependency, format)) return false;
+  if (format === "docker") {
+    if (qualifierEvidenceIsIncomplete(candidate, dependency, format)) return true;
+    const requestedPlatform = String(
+      dependency && dependency.qualifiers && dependency.qualifiers.platform || ""
+    ).trim();
+    return Boolean(
+      requestedPlatform
+      && exactPackageCandidateMatches(candidate, dependency, format, version)
+      && !dockerCandidateMatchesPlatform(candidate, requestedPlatform)
+    );
+  }
+  const candidateVersionMatches = format === "nuget"
+    ? normalizeNuGetVersion(candidate.version) === normalizeNuGetVersion(version)
+    : candidate.version === version;
+  return candidateVersionMatches
+    && qualifierEvidenceIsIncomplete(candidate, dependency, format);
+}
+
+function exactPackageCandidateBaseNameMatches(candidate, dependency, format) {
+  if (canonicalFormat(candidate && candidate.format) !== format) return false;
+  const dependencyName = String(dependency && dependency.name || "").trim();
+  if (!dependencyName) return false;
+  if (format === "maven" && dependencyName.includes(":")) {
+    const expectedName = normalizePackageName(dependencyName, format);
+    return getCloudsmithPackageLookupKeys(candidate, format)
+      .some(key => key.includes(":") && key === expectedName);
+  }
+  const expectedKeys = new Set(getPackageLookupKeys(
+    dependencyName,
+    format,
+    dependency && (dependency.identifiers || dependency.qualifiers)
+  ));
+  return getCloudsmithPackageLookupKeys(candidate, format)
+    .some(key => expectedKeys.has(key));
+}
+
 function mavenCandidateContainsRequestedArtifact(candidate, dependency) {
-  const qualifiers = dependency?.qualifiers;
-  const hasArtifactQualifier = qualifiers
-    && typeof qualifiers === "object"
-    && (Object.prototype.hasOwnProperty.call(qualifiers, "classifier")
-      || Object.prototype.hasOwnProperty.call(qualifiers, "type"));
-  if (!hasArtifactQualifier) return true;
   const expectedFileName = mavenArtifactFileName(dependency);
   if (!expectedFileName || !Array.isArray(candidate?.files)) return false;
   return candidate.files.some(file => (

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -11,6 +11,7 @@ const {
   createSafeAdapterWarning,
 } = require("../util/dependencyAdapterRegistry");
 const {
+  DEPENDENCY_QUALIFIER_KEYS,
   DEPENDENCY_VERSION_STATES,
   getDependencyArtifactKey,
   getDependencyConcreteVersion: getCanonicalDependencyConcreteVersion,
@@ -24,6 +25,12 @@ const {
 } = require("../util/diagnosticsPublisher");
 const { fetchWorkspaceRepositories } = require("../util/workspaceRepositoryFetcher");
 const { SearchQueryBuilder } = require("../util/searchQueryBuilder");
+const {
+  dockerCandidateMatchesPlatform,
+  mavenArtifactFileName,
+  normalizeNuGetVersion,
+  rubyCandidateMatchesPlatform,
+} = require("../util/registryEndpoints");
 const { LicenseClassifier } = require("../util/licenseClassifier");
 const {
   canonicalFormat,
@@ -2558,10 +2565,13 @@ async function lookupExactDependency({
   const endpoint = buildPackageLookupEndpoint(cloudsmithWorkspace, cloudsmithRepo);
   const lookupNames = getDependencyLookupNames(dependency);
   const format = canonicalFormat(dependency && (dependency.format || dependency.ecosystem));
+  const lookupVersion = format === "nuget"
+    ? normalizeNuGetVersion(concreteVersion)
+    : concreteVersion;
   if (
     !endpoint
     || !boundedExactLookupString(format, LOOKUP_MAX_PACKAGE_FORMAT_LENGTH)
-    || !boundedExactLookupString(concreteVersion, LOOKUP_MAX_PACKAGE_VERSION_LENGTH)
+    || !boundedExactLookupString(lookupVersion, LOOKUP_MAX_PACKAGE_VERSION_LENGTH)
     || lookupNames.length === 0
     || !api
     || typeof api.get !== "function"
@@ -2575,14 +2585,17 @@ async function lookupExactDependency({
 
   let pagesFetched = 0;
   for (const lookupName of lookupNames) {
-    const query = new SearchQueryBuilder()
+    const queryBuilder = new SearchQueryBuilder()
       .format(format)
-      .name(lookupName)
-      .version(concreteVersion)
-      .build();
+      .name(lookupName);
+    if (format !== "docker") {
+      queryBuilder.version(lookupVersion);
+    }
+    const query = queryBuilder.build();
     let page = 1;
     let paginationAnchor = null;
     const seenPackageIdentities = new Set();
+    const accumulatedCandidates = [];
 
     while (true) {
       if (token && token.isCancellationRequested) {
@@ -2684,7 +2697,12 @@ async function lookupExactDependency({
       }
       for (const identity of pageIdentities) seenPackageIdentities.add(identity);
       pagesFetched += 1;
-      const match = matchCoverageCandidates(response.data, dependency, concreteVersion);
+      accumulatedCandidates.push(...response.data);
+      const match = matchCoverageCandidates(
+        accumulatedCandidates,
+        dependency,
+        lookupVersion
+      );
       if (match) {
         let canonicalMatch;
         try {
@@ -3192,17 +3210,31 @@ function countCoverageDependencies(trees) {
 
 function buildPackageIndex(packages, format) {
   const index = new Map();
+  const normalizedFormat = canonicalFormat(format);
   for (const pkg of packages) {
-    const versionKey = String(pkg.version || "").trim();
+    const versionKeys = new Set([String(pkg.version || "").trim()]);
+    if (normalizedFormat === "nuget") {
+      const normalizedVersion = normalizeNuGetVersion(pkg.version);
+      if (normalizedVersion) versionKeys.add(normalizedVersion);
+    }
+    if (normalizedFormat === "docker" && Array.isArray(pkg?.tags?.version)) {
+      for (const tag of pkg.tags.version) {
+        const normalizedTag = String(tag || "").trim();
+        if (normalizedTag) versionKeys.add(normalizedTag);
+      }
+    }
     for (const nameKey of getCaseAwareCloudsmithPackageLookupKeys(pkg, format)) {
       if (!index.has(nameKey)) {
         index.set(nameKey, new Map());
       }
       const versionMap = index.get(nameKey);
-      if (!versionMap.has(versionKey)) {
-        versionMap.set(versionKey, []);
+      for (const versionKey of versionKeys) {
+        if (!versionKey) continue;
+        if (!versionMap.has(versionKey)) {
+          versionMap.set(versionKey, []);
+        }
+        versionMap.get(versionKey).push(pkg);
       }
-      versionMap.get(versionKey).push(pkg);
     }
   }
   return index;
@@ -3219,7 +3251,9 @@ function findCoverageMatch(packageIndex, dependency) {
     if (!versions) {
       continue;
     }
-    const versionKey = concreteVersion;
+    const versionKey = canonicalFormat(dependency.format || dependency.ecosystem) === "nuget"
+      ? normalizeNuGetVersion(concreteVersion)
+      : concreteVersion;
     if (versions.has(versionKey)) {
       const match = matchCoverageCandidates(versions.get(versionKey), dependency, concreteVersion);
       if (match) {
@@ -3238,8 +3272,12 @@ function matchCoverageCandidates(candidates, dependency, expectedVersion = getCo
   const dependencyFormat = canonicalFormat(
     dependency && (dependency.format || dependency.ecosystem)
   );
+  const normalizedExpectedVersion = dependencyFormat === "nuget"
+    ? normalizeNuGetVersion(expectedVersion)
+    : String(expectedVersion).trim();
+  const candidateList = Array.isArray(candidates) ? candidates : [];
 
-  for (const candidate of Array.isArray(candidates) ? candidates : []) {
+  for (const candidate of candidateList) {
     const candidateFormat = canonicalFormat(candidate && (candidate.format || candidate.ecosystem));
     if (!dependencyFormat || candidateFormat !== dependencyFormat) {
       continue;
@@ -3247,7 +3285,21 @@ function matchCoverageCandidates(candidates, dependency, expectedVersion = getCo
     if (!packageNameMatchesDependency(candidate, dependency)) {
       continue;
     }
-    if (String(candidate.version || "").trim() === expectedVersion) {
+    const dockerTags = dependencyFormat === "docker" && Array.isArray(candidate?.tags?.version)
+      ? candidate.tags.version
+      : [];
+    const requestedDigest = dependencyFormat === "docker"
+      ? String(dependency?.qualifiers?.digest || dependency?.digest || "").trim().toLowerCase()
+      : "";
+    const observedVersion = String(candidate.version || "").trim();
+    const versionMatches = dependencyFormat === "nuget"
+      ? normalizeNuGetVersion(observedVersion) === normalizedExpectedVersion
+      : observedVersion === normalizedExpectedVersion;
+    const digestMatches = requestedDigest
+      && observedVersion.toLowerCase().replace(/^[a-z0-9_+.-]+:/, "")
+        === requestedDigest.replace(/^[a-z0-9_+.-]+:/, "");
+    const tagMatches = dockerTags.some(tag => String(tag) === normalizedExpectedVersion);
+    if (dependencyFormat === "docker" ? (requestedDigest ? digestMatches : tagMatches) : versionMatches) {
       return candidate;
     }
   }
@@ -3263,7 +3315,8 @@ function packageNameMatchesDependency(candidate, dependency) {
 
   if (format === "maven" && dependencyName.includes(":")) {
     const candidateKeys = getCaseAwareCloudsmithPackageLookupKeys(candidate, format);
-    return candidateKeys.some((key) => key.includes(":") && key === dependencyName);
+    return candidateKeys.some((key) => key.includes(":") && key === dependencyName)
+      && mavenCandidateContainsRequestedArtifact(candidate, dependency);
   }
 
   if (format === "swift") {
@@ -3282,28 +3335,42 @@ function packageNameMatchesDependency(candidate, dependency) {
     return Boolean(dependencyIdentity && candidateIdentity && dependencyIdentity === candidateIdentity);
   }
 
-  if (format === "ruby" && dependency && dependency.qualifiers && dependency.qualifiers.platform) {
-    const candidateIdentifiers = candidate && candidate.identifiers
-      && typeof candidate.identifiers === "object"
-      ? candidate.identifiers
-      : {};
-    const candidatePlatform = String(
-      candidate && (candidate.platform || candidate.architecture)
-      || candidateIdentifiers.platform
-      || candidateIdentifiers.architecture
-      || ""
-    ).trim();
-    if (
-      candidatePlatform
-      && candidatePlatform.toLowerCase() !== String(dependency.qualifiers.platform).toLowerCase()
-    ) {
-      return false;
-    }
+  if (
+    format === "docker"
+    && !dockerCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)
+  ) {
+    return false;
+  }
+
+  if (
+    format === "ruby"
+    && !rubyCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)
+  ) {
+    return false;
   }
 
   const dependencyKeys = getCaseAwarePackageLookupKeys(dependency && dependency.name, format);
   const candidateKeys = new Set(getCaseAwareCloudsmithPackageLookupKeys(candidate, format));
   return dependencyKeys.some((key) => candidateKeys.has(key));
+}
+
+function mavenCandidateContainsRequestedArtifact(candidate, dependency) {
+  const qualifiers = dependency?.qualifiers;
+  const hasArtifactQualifier = qualifiers
+    && typeof qualifiers === "object"
+    && (Object.prototype.hasOwnProperty.call(qualifiers, "classifier")
+      || Object.prototype.hasOwnProperty.call(qualifiers, "type"));
+  if (!hasArtifactQualifier) return true;
+  const expectedFileName = mavenArtifactFileName(
+    dependency,
+    getConcreteDependencyVersion(dependency)
+  );
+  if (!expectedFileName || !Array.isArray(candidate?.files)) return false;
+  return candidate.files.some(file => (
+    file
+    && typeof file === "object"
+    && String(file.filename || file.name || file.path || "").split("/").pop() === expectedFileName
+  ));
 }
 
 function applyCoverageMatchBatchToTrees(trees, matchMap) {
@@ -4343,6 +4410,7 @@ function normalizeUserInteraction(userInteraction) {
 }
 
 function resolveSingleDependencyPullTarget(coordinate, trees) {
+  const expectedQualifierIdentity = dependencyPullQualifierIdentity(coordinate);
   const matches = (Array.isArray(trees) ? trees : [])
     .flatMap(tree => Array.isArray(tree?.dependencies) ? tree.dependencies : [])
     .filter(dependency => (
@@ -4350,6 +4418,7 @@ function resolveSingleDependencyPullTarget(coordinate, trees) {
       && dependency.name === coordinate.name
       && getConcreteDependencyVersion(dependency) === coordinate.version
       && canonicalFormat(dependency.format || dependency.ecosystem) === coordinate.format
+      && dependencyPullQualifierIdentity(dependency) === expectedQualifierIdentity
       && isAbsentCoverageStatus(dependency.cloudsmithStatus)
     ));
   if (matches.length === 0) return null;
@@ -4363,6 +4432,16 @@ function resolveSingleDependencyPullTarget(coordinate, trees) {
     format: coordinate.format,
     ecosystem: dependency.ecosystem || coordinate.format,
   };
+}
+
+function dependencyPullQualifierIdentity(dependency) {
+  const qualifiers = dependency && dependency.qualifiers;
+  if (!qualifiers || typeof qualifiers !== "object" || Array.isArray(qualifiers)) {
+    return JSON.stringify([]);
+  }
+  return JSON.stringify(DEPENDENCY_QUALIFIER_KEYS
+    .filter(key => Object.prototype.hasOwnProperty.call(qualifiers, key))
+    .map(key => [key, qualifiers[key]]));
 }
 
 function formatSingleDependencyLabel(dependency) {

--- a/views/dependencyHealthProvider.js
+++ b/views/dependencyHealthProvider.js
@@ -26,7 +26,12 @@ const {
 const { fetchWorkspaceRepositories } = require("../util/workspaceRepositoryFetcher");
 const { SearchQueryBuilder } = require("../util/searchQueryBuilder");
 const {
+  packageCandidateEvidenceShapeIsValid,
+  qualifierEvidenceIsIncomplete,
+} = require("../util/exactPackageEvidence");
+const {
   dockerCandidateMatchesPlatform,
+  dockerDigestMatches,
   mavenArtifactFileName,
   normalizeNuGetVersion,
   rubyCandidateMatchesPlatform,
@@ -83,6 +88,7 @@ const LOOKUP_MAX_PACKAGE_FORMAT_LENGTH = 100;
 const LOOKUP_MAX_PACKAGE_VERSION_LENGTH = 2048;
 const COVERAGE_MATCH_BATCH_SIZE = 50;
 const ENRICHMENT_PROGRESS_DEBOUNCE_MS = 500;
+const LOOKUP_CONTROL_OR_BIDI = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff]/u;
 
 const CLOUDSMITH_COVERAGE_STATUS = Object.freeze({
   CHECKING: "CHECKING",
@@ -901,9 +907,9 @@ class DependencyHealthProvider {
       cancellationToken: token,
     });
     if (typeof this._dependencyAdapters.getDiscoveryWarnings === "function") {
-      warnings.push(...this._dependencyAdapters.getDiscoveryWarnings().map(
-        safeDiscoveryWarning
-      ));
+      for (const warning of this._dependencyAdapters.getDiscoveryWarnings()) {
+        appendUniqueWarning(warnings, safeDiscoveryWarning(warning));
+      }
     }
     if (token.isCancellationRequested) {
       return { canceled: true };
@@ -963,7 +969,9 @@ class DependencyHealthProvider {
             coveredManifestPaths.add(path.resolve(sourceManifestPath));
           }
           if (result.warnings.length > 0) {
-            warnings.push(...result.warnings.map(createSafeAdapterWarning));
+            for (const warning of result.warnings) {
+              warnings.push(createSafeAdapterWarning(warning));
+            }
           }
         }
       }
@@ -993,6 +1001,7 @@ class DependencyHealthProvider {
       this._fullTrees = [];
       this._summary = emptySummary();
       this._statusMessage = null;
+      this._warnings = warnings.slice();
       if (this._lastManifests.length === 0) {
         this._noManifestsFolder = path.basename(folderPath);
       }
@@ -1014,6 +1023,7 @@ class DependencyHealthProvider {
       this._fullTrees = [];
       this._summary = emptySummary();
       this._statusMessage = null;
+      this._warnings = warnings.slice();
       await this._storeReportData(this._reportDateFactory());
       return { canceled: false };
     }
@@ -1027,7 +1037,7 @@ class DependencyHealthProvider {
     if (limited.truncated) {
       const warning = "Dependency display reached its configured safety limit; "
         + "the complete resolved inventory remains available to the scan pipeline.";
-      this._warnings.push(warning);
+      appendUniqueWarning(this._warnings, warning);
     }
     this._statusMessage = null;
     this._rebuildSummary();
@@ -1077,19 +1087,13 @@ class DependencyHealthProvider {
         || result.status === ADAPTER_RESULT_STATUSES.UNSUPPORTED
       ) {
         const message = createSafeAdapterError(result.error).message;
-        if (!warnings.includes(message)) {
-          warnings.push(message);
-        }
-        if (!parserErrors.includes(message)) {
-          parserErrors.push(message);
-        }
+        warnings.push(message);
+        parserErrors.push(message);
         continue;
       }
       for (const warning of result.warnings || []) {
         const safeWarning = createSafeAdapterWarning(warning);
-        if (!warnings.includes(safeWarning)) {
-          warnings.push(safeWarning);
-        }
+        warnings.push(safeWarning);
       }
       if (
         ![
@@ -1161,7 +1165,9 @@ class DependencyHealthProvider {
         progress,
         token,
         progressLabel,
-        requestBudget
+        requestBudget,
+        options.verificationReceipt || null,
+        options.verificationReceipts || null
       );
     }
 
@@ -1274,7 +1280,9 @@ class DependencyHealthProvider {
     progress,
     token,
     progressLabel = "Matching coverage",
-    requestBudget = null
+    requestBudget = null,
+    verificationReceipt = null,
+    verificationReceipts = null
   ) {
     const uniqueDependencies = dependencies.slice();
     const api = uniqueDependencies.some((dependency) => getConcreteDependencyVersion(dependency))
@@ -1297,6 +1305,9 @@ class DependencyHealthProvider {
 
         let result;
         try {
+          const dependencyVerificationReceipt = verificationReceipts instanceof Map
+            ? verificationReceipts.get(getDependencyArtifactKey(dependency)) || null
+            : verificationReceipt;
           result = await lookupExactDependency({
             api,
             cloudsmithWorkspace,
@@ -1304,6 +1315,7 @@ class DependencyHealthProvider {
             dependency,
             token,
             requestBudget,
+            verificationReceipt: dependencyVerificationReceipt,
           });
         } catch {
           result = createCoverageLookupResult(
@@ -1678,7 +1690,8 @@ class DependencyHealthProvider {
               execution.workspace,
               execution.repository.slug,
               progress,
-              cancellationSource.token
+              cancellationSource.token,
+              { verificationReceipts: execution.verificationReceipts }
             );
 
             if (cancellationSource.token.isCancellationRequested) {
@@ -1852,12 +1865,16 @@ class DependencyHealthProvider {
             const pullDetail = getSingleDependencyPullDetail(execution.pullResult);
             if (isSuccessfulSingleDependencyPull(pullDetail)) {
               progress.report({ message: "Refreshing Cloudsmith coverage..." });
+              const verificationReceipt = execution.verificationReceipts instanceof Map
+                ? execution.verificationReceipts.get(getDependencyArtifactKey(prepared.dependency))
+                : null;
               await this._refreshSingleDependencyAfterPull(
                 prepared.workspace,
                 prepared.repository.slug,
                 prepared.dependency,
                 progress,
-                cancellationSource.token
+                cancellationSource.token,
+                { verificationReceipt }
               );
             }
 
@@ -1909,24 +1926,41 @@ class DependencyHealthProvider {
     }
   }
 
-  async _refreshCoverageAfterPull(cloudsmithWorkspace, cloudsmithRepo, progress, token) {
+  async _refreshCoverageAfterPull(
+    cloudsmithWorkspace,
+    cloudsmithRepo,
+    progress,
+    token,
+    options = {}
+  ) {
     await this._refreshCoverageForDependencies(
       cloudsmithWorkspace,
       cloudsmithRepo,
       null,
       progress,
       token,
-      { refreshRemainingUpstream: true }
+      {
+        refreshRemainingUpstream: true,
+        verificationReceipts: options.verificationReceipts || null,
+      }
     );
   }
 
-  async _refreshSingleDependencyAfterPull(cloudsmithWorkspace, cloudsmithRepo, dependency, progress, token) {
+  async _refreshSingleDependencyAfterPull(
+    cloudsmithWorkspace,
+    cloudsmithRepo,
+    dependency,
+    progress,
+    token,
+    options = {}
+  ) {
     await this._refreshCoverageForDependencies(
       cloudsmithWorkspace,
       cloudsmithRepo,
       [dependency],
       progress,
-      token
+      token,
+      { verificationReceipt: options.verificationReceipt || null }
     );
   }
 
@@ -1982,6 +2016,8 @@ class DependencyHealthProvider {
       {
         packageIndexFailureVerb: "refresh",
         progressLabel: "Refreshing Cloudsmith coverage",
+        verificationReceipt: options.verificationReceipt || null,
+        verificationReceipts: options.verificationReceipts || null,
       }
     );
 
@@ -2139,7 +2175,11 @@ class DependencyHealthProvider {
       return nodes;
     }
 
-    if (!this._hasSuccessfulScan && this._scanOperation.status === SCAN_STATES.IDLE) {
+    if (
+      !this._hasSuccessfulScan
+      && this._scanOperation.status === SCAN_STATES.IDLE
+      && this._warnings.length === 0
+    ) {
       return [
         new InfoNode(
           "Scan dependencies",
@@ -2151,6 +2191,15 @@ class DependencyHealthProvider {
       ];
     }
 
+    if (this._warnings.length > 0) {
+      nodes.push(new InfoNode(
+        this._warnings[0],
+        "",
+        this._warnings.join("\n"),
+        "warning",
+        "statusMessage"
+      ));
+    }
     nodes.push(new InfoNode(
       "No dependencies found",
       "",
@@ -2537,6 +2586,7 @@ async function lookupExactDependency({
   dependency,
   token,
   requestBudget = null,
+  verificationReceipt = null,
 }) {
   if (dependency && dependency.lookupEligibility
     && dependency.lookupEligibility.state === "unresolved") {
@@ -2584,6 +2634,7 @@ async function lookupExactDependency({
   }
 
   let pagesFetched = 0;
+  let incompleteQualifierEvidence = false;
   for (const lookupName of lookupNames) {
     const queryBuilder = new SearchQueryBuilder()
       .format(format)
@@ -2591,7 +2642,17 @@ async function lookupExactDependency({
     if (format !== "docker") {
       queryBuilder.version(lookupVersion);
     }
-    const query = queryBuilder.build();
+    let query;
+    try {
+      query = queryBuilder.build();
+    } catch {
+      return createCoverageLookupResult(
+        CLOUDSMITH_COVERAGE_STATUS.LOOKUP_FAILED,
+        null,
+        "The Cloudsmith package identity exceeded the safe query boundary.",
+        pagesFetched
+      );
+    }
     let page = 1;
     let paginationAnchor = null;
     const seenPackageIdentities = new Set();
@@ -2698,10 +2759,16 @@ async function lookupExactDependency({
       for (const identity of pageIdentities) seenPackageIdentities.add(identity);
       pagesFetched += 1;
       accumulatedCandidates.push(...response.data);
+      if (accumulatedCandidates.some(candidate => (
+        coverageCandidateEvidenceIsIncomplete(candidate, dependency, format, lookupVersion)
+      ))) {
+        incompleteQualifierEvidence = true;
+      }
       const match = matchCoverageCandidates(
         accumulatedCandidates,
         dependency,
-        lookupVersion
+        lookupVersion,
+        verificationReceipt
       );
       if (match) {
         let canonicalMatch;
@@ -2748,6 +2815,15 @@ async function lookupExactDependency({
       }
       page += 1;
     }
+  }
+
+  if (incompleteQualifierEvidence) {
+    return createCoverageLookupResult(
+      CLOUDSMITH_COVERAGE_STATUS.LOOKUP_INCOMPLETE,
+      null,
+      "Cloudsmith did not return enough artifact evidence to prove package absence.",
+      pagesFetched
+    );
   }
 
   return createCoverageLookupResult(
@@ -3000,6 +3076,7 @@ function isPackageCandidateArray(value, expectedWorkspace, expectedRepository) {
       && boundedExactLookupString(candidate.version, LOOKUP_MAX_PACKAGE_VERSION_LENGTH)
       && candidate.namespace === expectedWorkspace
       && (!expectedRepository || candidate.repository === expectedRepository)
+      && packageCandidateEvidenceShapeIsValid(candidate)
       && Boolean(getPackagePolicyFlags(candidate))
       && Boolean(packageCandidateIdentity(candidate))
     ));
@@ -3018,7 +3095,7 @@ function boundedExactLookupString(value, maxLength) {
     && value.length > 0
     && value.length <= maxLength
     && value.trim() === value
-    && !/[\u0000-\u001f\u007f]/.test(value);
+    && !LOOKUP_CONTROL_OR_BIDI.test(value);
 }
 
 function isLookupEligibleForConsumer(dependency) {
@@ -3264,7 +3341,12 @@ function findCoverageMatch(packageIndex, dependency) {
   return null;
 }
 
-function matchCoverageCandidates(candidates, dependency, expectedVersion = getConcreteDependencyVersion(dependency)) {
+function matchCoverageCandidates(
+  candidates,
+  dependency,
+  expectedVersion = getConcreteDependencyVersion(dependency),
+  verificationReceipt = null
+) {
   if (!expectedVersion) {
     return null;
   }
@@ -3276,13 +3358,29 @@ function matchCoverageCandidates(candidates, dependency, expectedVersion = getCo
     ? normalizeNuGetVersion(expectedVersion)
     : String(expectedVersion).trim();
   const candidateList = Array.isArray(candidates) ? candidates : [];
+  const requestedDockerPlatform = dependencyFormat === "docker"
+    ? String(dependency && dependency.qualifiers && dependency.qualifiers.platform || "").trim()
+    : "";
 
   for (const candidate of candidateList) {
     const candidateFormat = canonicalFormat(candidate && (candidate.format || candidate.ecosystem));
     if (!dependencyFormat || candidateFormat !== dependencyFormat) {
       continue;
     }
-    if (!packageNameMatchesDependency(candidate, dependency)) {
+    const nameMatches = packageNameMatchesDependency(candidate, dependency)
+      || (
+        dependencyFormat === "swift"
+        && verificationReceipt?.swiftScopeVerified === true
+        && coverageCandidateBaseNameMatches(candidate, dependency, dependencyFormat)
+      );
+    if (!nameMatches) {
+      continue;
+    }
+    if (
+      requestedDockerPlatform
+      && verificationReceipt?.dockerPlatformVerified !== true
+      && !dockerCandidateMatchesPlatform(candidate, requestedDockerPlatform)
+    ) {
       continue;
     }
     const dockerTags = dependencyFormat === "docker" && Array.isArray(candidate?.tags?.version)
@@ -3296,14 +3394,59 @@ function matchCoverageCandidates(candidates, dependency, expectedVersion = getCo
       ? normalizeNuGetVersion(observedVersion) === normalizedExpectedVersion
       : observedVersion === normalizedExpectedVersion;
     const digestMatches = requestedDigest
-      && observedVersion.toLowerCase().replace(/^[a-z0-9_+.-]+:/, "")
-        === requestedDigest.replace(/^[a-z0-9_+.-]+:/, "");
+      && dockerDigestMatches(observedVersion, requestedDigest);
     const tagMatches = dockerTags.some(tag => String(tag) === normalizedExpectedVersion);
     if (dependencyFormat === "docker" ? (requestedDigest ? digestMatches : tagMatches) : versionMatches) {
       return candidate;
     }
   }
   return null;
+}
+
+function coverageCandidateEvidenceIsIncomplete(candidate, dependency, format, expectedVersion) {
+  if (!coverageCandidateBaseNameMatches(candidate, dependency, format)) return false;
+  if (format === "docker") {
+    if (qualifierEvidenceIsIncomplete(candidate, dependency, format)) return true;
+    const requestedPlatform = String(
+      dependency && dependency.qualifiers && dependency.qualifiers.platform || ""
+    ).trim();
+    if (!requestedPlatform) return false;
+    const dockerTags = Array.isArray(candidate && candidate.tags && candidate.tags.version)
+      ? candidate.tags.version
+      : [];
+    const requestedDigest = String(
+      dependency && dependency.qualifiers && dependency.qualifiers.digest
+      || dependency && dependency.digest
+      || ""
+    ).trim();
+    const identityMatches = requestedDigest
+      ? dockerDigestMatches(candidate && candidate.version, requestedDigest)
+      : dockerTags.some(tag => String(tag) === String(expectedVersion));
+    return identityMatches && !dockerCandidateMatchesPlatform(candidate, requestedPlatform);
+  }
+  const versionMatches = format === "nuget"
+    ? normalizeNuGetVersion(candidate.version) === normalizeNuGetVersion(expectedVersion)
+    : String(candidate.version || "").trim() === String(expectedVersion || "").trim();
+  return versionMatches && qualifierEvidenceIsIncomplete(candidate, dependency, format);
+}
+
+function coverageCandidateBaseNameMatches(candidate, dependency, format) {
+  if (canonicalFormat(candidate && (candidate.format || candidate.ecosystem)) !== format) {
+    return false;
+  }
+  const dependencyName = packageIdentityName(dependency && dependency.name, format);
+  if (!dependencyName) return false;
+  if (format === "maven" && dependencyName.includes(":")) {
+    return getCaseAwareCloudsmithPackageLookupKeys(candidate, format)
+      .some(key => key.includes(":") && key === dependencyName);
+  }
+  const expectedKeys = new Set(getCaseAwarePackageLookupKeys(
+    dependency && dependency.name,
+    format,
+    dependency && dependency.qualifiers
+  ));
+  return getCaseAwareCloudsmithPackageLookupKeys(candidate, format)
+    .some(key => expectedKeys.has(key));
 }
 
 function packageNameMatchesDependency(candidate, dependency) {
@@ -3336,13 +3479,6 @@ function packageNameMatchesDependency(candidate, dependency) {
   }
 
   if (
-    format === "docker"
-    && !dockerCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)
-  ) {
-    return false;
-  }
-
-  if (
     format === "ruby"
     && !rubyCandidateMatchesPlatform(candidate, dependency?.qualifiers?.platform)
   ) {
@@ -3355,12 +3491,6 @@ function packageNameMatchesDependency(candidate, dependency) {
 }
 
 function mavenCandidateContainsRequestedArtifact(candidate, dependency) {
-  const qualifiers = dependency?.qualifiers;
-  const hasArtifactQualifier = qualifiers
-    && typeof qualifiers === "object"
-    && (Object.prototype.hasOwnProperty.call(qualifiers, "classifier")
-      || Object.prototype.hasOwnProperty.call(qualifiers, "type"));
-  if (!hasArtifactQualifier) return true;
   const expectedFileName = mavenArtifactFileName(
     dependency,
     getConcreteDependencyVersion(dependency)

--- a/views/searchProvider.js
+++ b/views/searchProvider.js
@@ -20,6 +20,7 @@ const {
 } = require("../util/collectionIdentity");
 const { fromApiPackageRecord } = require("../domain/packageAdapters");
 const { ContextKeyProjector } = require("../util/contextKeyProjector");
+const { isValidAdvancedQuery } = require("../util/searchQueryBuilder");
 
 const MAX_RESULTS = 5000;
 const MAX_REPOSITORIES = 1000;
@@ -1216,7 +1217,11 @@ function normalizeDescriptor(value) {
         "workspace",
         MAX_WORKSPACE_LENGTH
     );
-    if (typeof value.query !== "string" || value.query.length > MAX_QUERY_LENGTH) {
+    if (
+        typeof value.query !== "string"
+        || value.query.length > MAX_QUERY_LENGTH
+        || !isValidAdvancedQuery(value.query)
+    ) {
         throw new Error("Could not search packages. The search query was invalid.");
     }
     const query = value.query;


### PR DESCRIPTION
## Summary

- Fixed Dependency Health pull-through request construction across Cargo, Dart, Docker, Go, Maven, npm, NuGet, Python, Ruby, and scoped Swift identities.
- Added exact, bounded target-repository verification so registry success is reported as cached only after authoritative artifact evidence is present.
- Hardened Cloudsmith query literals, package/URL evidence, qualifier matching, redirect handling, and post-pull evidence transport while preserving registry-native identities.
- Deduplicated file-level Docker and Compose partial warnings without dropping affected dependency records or merging evidence across source files.

## Validation

- Read-only exact lookup regression passed in dl-technology-consulting/common-testing for Cargo atty@0.2.14; Dart characters@1.3.0; Docker alpine:3.20.3; Go github.com/gin-gonic/gin@v1.10.0; Maven org.springframework.boot:spring-boot-starter-web@3.2.0; npm @aws-sdk/client-sqs@3.600.0 and axios@1.7.2; NuGet Serilog@3.1.1; Python flask@2.3.0; and Ruby activerecord@7.0.8.
- A real Dependency Health scan of an external multi-stage Docker fixture showed one file-level unresolved-platform warning, all three dependencies preserved as unresolved, and no dependency-level Pull action.
- npm test passed with 679 standalone and 921 extension-host tests (1,600 total); the eight targeted suites passed with 318 tests.
- npm run check passed lint, syntax, build, architecture, polish, and version verification; the extension remains 2.3.0.
- Production and development dependency audits, zero-test guards, and git diff checks passed.
- The reproducible non-publishable development VSIX verified with 164 entries and SHA-256 e2b4aa9f83329ff479df6103619516fe1324cba1b53d427fdafaea78ee1948bb.